### PR TITLE
Regression computations using a full gaussian as an error model at each point

### DIFF
--- a/src/main/scala/scalismo/statisticalmodel/DiscreteLowRankGaussianProcess.scala
+++ b/src/main/scala/scalismo/statisticalmodel/DiscreteLowRankGaussianProcess.scala
@@ -110,14 +110,15 @@ case class DiscreteLowRankGaussianProcess[D <: Dim: NDSpace, DO <: Dim: NDSpace]
    * Discrete version of [[LowRankGaussianProcess.project(IndexedSeq[(Point[D], Vector[DO])], Double)]]
    */
   def project(trainingData: IndexedSeq[(Int, Vector[DO])], sigma2: Double = 1e-6): DiscreteVectorField[D, DO] = {
-    val newtd = trainingData.map { case (pt, df) => (pt, df, sigma2) }
+    val cov = NDimensionalNormalDistribution(Vector.zeros[DO], SquareMatrix.eye[DO] * sigma2)
+    val newtd = trainingData.map { case (pt, df) => (pt, df, cov) }
     project(newtd)
   }
 
   /**
    * Discrete version of [[LowRankGaussianProcess.project(IndexedSeq[(Point[D], Vector[DO], Double)])]]
    */
-  def project(trainingData: IndexedSeq[(Int, Vector[DO], Double)]): DiscreteVectorField[D, DO] = {
+  def project(trainingData: IndexedSeq[(Int, Vector[DO], NDimensionalNormalDistribution[DO])]): DiscreteVectorField[D, DO] = {
     val c = coefficients(trainingData)
     instance(c)
   }
@@ -125,7 +126,7 @@ case class DiscreteLowRankGaussianProcess[D <: Dim: NDSpace, DO <: Dim: NDSpace]
   /**
    * Discrete version of [[DiscreteLowRankGaussianProcess.coefficients(IndexedSeq[(Point[D], Vector[DO], Double)])]]
    */
-  def coefficients(trainingData: IndexedSeq[(Int, Vector[DO], Double)]): DenseVector[Float] = {
+  def coefficients(trainingData: IndexedSeq[(Int, Vector[DO], NDimensionalNormalDistribution[DO])]): DenseVector[Float] = {
 
     val (minv, qtL, yVec, mVec) = DiscreteLowRankGaussianProcess.genericRegressionComputations(this, trainingData)
     val mean_coeffs = (minv * qtL).map(_.toFloat) * (yVec - mVec)
@@ -136,7 +137,8 @@ case class DiscreteLowRankGaussianProcess[D <: Dim: NDSpace, DO <: Dim: NDSpace]
    * Discrete version of [[DiscreteLowRankGaussianProcess.coefficients(IndexedSeq[(Point[D], Vector[DO])], Double)]]
    */
   def coefficients(trainingData: IndexedSeq[(Int, Vector[DO])], sigma2: Double): DenseVector[Float] = {
-    val newtd = trainingData.map { case (pt, df) => (pt, df, sigma2) }
+    val cov = NDimensionalNormalDistribution(Vector.zeros[DO], SquareMatrix.eye[DO] * sigma2)
+    val newtd = trainingData.map { case (pt, df) => (pt, df, cov) }
     coefficients(newtd)
   }
 
@@ -154,7 +156,8 @@ case class DiscreteLowRankGaussianProcess[D <: Dim: NDSpace, DO <: Dim: NDSpace]
    *
    */
   def posterior(trainingData: IndexedSeq[(Int, Vector[DO])], sigma2: Double): DiscreteLowRankGaussianProcess[D, DO] = {
-    val newtd = trainingData.map { case (ptId, df) => (ptId, df, sigma2) }
+    val cov = NDimensionalNormalDistribution(Vector.zeros[DO], SquareMatrix.eye[DO] * sigma2)
+    val newtd = trainingData.map { case (ptId, df) => (ptId, df, cov) }
     posterior(newtd)
   }
 
@@ -163,8 +166,8 @@ case class DiscreteLowRankGaussianProcess[D <: Dim: NDSpace, DO <: Dim: NDSpace]
    * data are defined by the pointId. The returned posterior process is defined at the same points.
    *
    */
-  def posterior(trainingData: IndexedSeq[(Int, Vector[DO], Double)]): DiscreteLowRankGaussianProcess[D, DO] = {
-    DiscreteLowRankGaussianProcess.regression(this, trainingData, false)
+  def posterior(trainingData: IndexedSeq[(Int, Vector[DO], NDimensionalNormalDistribution[DO])]): DiscreteLowRankGaussianProcess[D, DO] = {
+    DiscreteLowRankGaussianProcess.regression(this, trainingData)
   }
 
   /**
@@ -289,32 +292,10 @@ object DiscreteLowRankGaussianProcess {
   }
 
   /**
-   * Discrete implementation of [[DiscreteLowRankGaussianProcess.regression]]
+   * Discrete implementation of [[LowRankGaussianProcess.regression]]
    */
   def regression[D <: Dim: NDSpace, DO <: Dim: NDSpace](gp: DiscreteLowRankGaussianProcess[D, DO],
-    trainingData: IndexedSeq[(Int, Vector[DO])],
-    sigma2: Double,
-    meanOnly: Boolean): DiscreteLowRankGaussianProcess[D, DO] = {
-    val tdWithWithPointwiseSigma2 = trainingData.map { case (ptId, v) => (ptId, v, sigma2) }
-    regression(gp, tdWithWithPointwiseSigma2, meanOnly)
-  }
-
-  /**
-   * Discrete implementation of [[DiscreteLowRankGaussianProcess.regression]]
-   */
-  def regression[D <: Dim: NDSpace, DO <: Dim: NDSpace](gp: DiscreteLowRankGaussianProcess[D, DO],
-    trainingData: IndexedSeq[(Int, Vector[DO])],
-    sigma2: Double): DiscreteLowRankGaussianProcess[D, DO] = {
-    val tdWithWithPointwiseSigma2 = trainingData.map { case (ptId, v) => (ptId, v, sigma2) }
-    regression(gp, tdWithWithPointwiseSigma2, false)
-  }
-
-  /**
-   * Discrete implementation of [[DiscreteLowRankGaussianProcess.regression]]
-   */
-  def regression[D <: Dim: NDSpace, DO <: Dim: NDSpace](gp: DiscreteLowRankGaussianProcess[D, DO],
-    trainingData: IndexedSeq[(Int, Vector[DO], Double)],
-    meanOnly: Boolean = false): DiscreteLowRankGaussianProcess[D, DO] = {
+    trainingData: IndexedSeq[(Int, Vector[DO], NDimensionalNormalDistribution[DO])]): DiscreteLowRankGaussianProcess[D, DO] = {
 
     val dim = implicitly[NDSpace[DO]].dimensionality
 
@@ -324,32 +305,25 @@ object DiscreteLowRankGaussianProcess {
     //val mean_p = gp.instance(mean_coeffs)
     val mean_pVector = gp.instanceVector(mean_coeffs)
 
-    if (meanOnly == true) {
-      // create an empty gaussian process (not specialized), which is needed in order to be able to construct
-      // the specialized one
-      val emptyEigenPairs = IndexedSeq[(Float, Point[D] => Vector[DO])]()
-      new DiscreteLowRankGaussianProcess[D, DO](gp.domain, mean_pVector, DenseVector.zeros[Float](0), DenseMatrix.zeros[Float](mean_pVector.size, 0))
-    } else {
-      val D = breeze.linalg.diag(DenseVector(gp.variance.map(math.sqrt(_)).toArray))
-      val Sigma = D * _Minv * D
-      val SVD(innerUDbl, innerD2, _) = breeze.linalg.svd(Sigma)
-      val innerU = innerUDbl.map(_.toFloat)
+    val D = breeze.linalg.diag(DenseVector(gp.variance.map(math.sqrt(_)).toArray))
+    val Sigma = D * _Minv * D
+    val SVD(innerUDbl, innerD2, _) = breeze.linalg.svd(Sigma)
+    val innerU = innerUDbl.map(_.toFloat)
 
-      val lambdas_p = DenseVector[Float](innerD2.toArray.map(_.toFloat))
+    val lambdas_p = DenseVector[Float](innerD2.toArray.map(_.toFloat))
 
-      // we do the follwoing computation
-      // val eigenMatrix_p = gp.eigenMatrix * innerU // IS this correct?
-      // but in parallel
-      val eigenMatrix_p = DenseMatrix.zeros[Float](gp.basisMatrix.rows, innerU.cols)
-      for (rowInd <- (0 until gp.basisMatrix.rows).par) {
+    // we do the follwoing computation
+    // val eigenMatrix_p = gp.eigenMatrix * innerU // IS this correct?
+    // but in parallel
+    val eigenMatrix_p = DenseMatrix.zeros[Float](gp.basisMatrix.rows, innerU.cols)
+    for (rowInd <- (0 until gp.basisMatrix.rows).par) {
 
-        // TODO maybe this strange transposing can be alleviated? It seems breeze does not support
-        // row-vector matrix multiplication
-        eigenMatrix_p(rowInd, ::) := (innerU.t * gp.basisMatrix(rowInd, ::).t).t
-      }
-
-      new DiscreteLowRankGaussianProcess(gp.domain, mean_pVector, lambdas_p, eigenMatrix_p)
+      // TODO maybe this strange transposing can be alleviated? It seems breeze does not support
+      // row-vector matrix multiplication
+      eigenMatrix_p(rowInd, ::) := (innerU.t * gp.basisMatrix(rowInd, ::).t).t
     }
+
+    new DiscreteLowRankGaussianProcess(gp.domain, mean_pVector, lambdas_p, eigenMatrix_p)
   }
 
   /**
@@ -394,9 +368,9 @@ object DiscreteLowRankGaussianProcess {
   }
 
   private def genericRegressionComputations[D <: Dim: NDSpace, DO <: Dim: NDSpace](gp: DiscreteLowRankGaussianProcess[D, DO],
-    trainingData: IndexedSeq[(Int, Vector[DO], Double)]) = {
+    trainingData: IndexedSeq[(Int, Vector[DO], NDimensionalNormalDistribution[DO])]) = {
     val dim = implicitly[NDSpace[DO]].dimensionality
-    val (ptIds, ys, sigma2s) = trainingData.unzip3
+    val (ptIds, ys, errorDistributions) = trainingData.unzip3
 
     def flatten(v: IndexedSeq[Vector[DO]]) = DenseVector(v.flatten(_.data).toArray)
 
@@ -415,16 +389,15 @@ object DiscreteLowRankGaussianProcess {
       Q(i * dim until i * dim + dim, j) := eigenVecAtPoint * math.sqrt(gp.variance(j))
     }
 
-    // compute Q^TL where L is a diagonal matrix that contains the inverse of the sigmas in the diagonal.
-    // As there is only one sigma for each point (but the point has dim components) we need
-    // to correct the index for sigma
+    // What we are actually computing here is the following:
+    // L would be a block diagonal matrix, which contains on the diagonal the blocks that describes the uncertainty
+    // for each point (a d x d) block. We then would compute Q.t * L. For efficiency reasons (L could be large but is sparse)
+    // we avoid ever constructing the matrix L and do the multiplication by hand.
     val QtL = Q.t.copy
-    val sigma2sInv = sigma2s.map { sigma2 =>
-      val divisor = math.max(1e-8, sigma2)
-      1.0 / divisor
-    }
-    for (i <- 0 until QtL.cols) {
-      QtL(::, i) *= sigma2sInv(i / dim)
+    assert(QtL.cols == errorDistributions.size * dim)
+    assert(QtL.rows == gp.rank)
+    for ((errDist, i) <- errorDistributions.zipWithIndex) {
+        QtL(::, i * dim until (i + 1) * dim) := QtL(::, i * dim until (i + 1) * dim) * breeze.linalg.inv(errDist.cov.toBreezeMatrix)
     }
 
     val M = QtL * Q + DenseMatrix.eye[Double](gp.rank)

--- a/src/main/scala/scalismo/statisticalmodel/LowRankGaussianProcess.scala
+++ b/src/main/scala/scalismo/statisticalmodel/LowRankGaussianProcess.scala
@@ -88,17 +88,18 @@ class LowRankGaussianProcess[D <: Dim: NDSpace, DO <: Dim: NDSpace](mean: Vector
    * @param sigma2 variance of a GAussian noise that is assumed on every training point
    */
   def project(trainingData: IndexedSeq[(Point[D], Vector[DO])], sigma2: Double = 1e-6): VectorField[D, DO] = {
-    val newtd = trainingData.map { case (pt, df) => (pt, df, sigma2) }
+    val cov = NDimensionalNormalDistribution(Vector.zeros[DO], SquareMatrix.eye[DO] * sigma2)
+    val newtd = trainingData.map { case (pt, df) => (pt, df, cov) }
     project(newtd)
   }
 
   /**
    * Returns the sample of the gaussian process that best explains the given training data. It is assumed that the training data (values)
-   * are subject to 0 mean Gaussian noise
+   * are subject to 0 mean gaussian noise
    *
    * @param trainingData Point/value pairs where that the sample should approximate, together with the variance of the noise model at each point.
    */
-  def project(trainingData: IndexedSeq[(Point[D], Vector[DO], Double)]): VectorField[D, DO] = {
+  def project(trainingData: IndexedSeq[(Point[D], Vector[DO], NDimensionalNormalDistribution[DO])]): VectorField[D, DO] = {
     val c = coefficients(trainingData)
     instance(c)
   }
@@ -107,7 +108,7 @@ class LowRankGaussianProcess[D <: Dim: NDSpace, DO <: Dim: NDSpace](mean: Vector
    * Returns the sample of the coefficients of the sample that best explains the given training data. It is assumed that the training data (values)
    * are subject to 0 mean Gaussian noise
    */
-  def coefficients(trainingData: IndexedSeq[(Point[D], Vector[DO], Double)]): DenseVector[Float] =
+  def coefficients(trainingData: IndexedSeq[(Point[D], Vector[DO], NDimensionalNormalDistribution[DO])]): DenseVector[Float] =
     {
       val (minv, qtL, yVec, mVec) = LowRankGaussianProcess.genericRegressionComputations(this, trainingData)
       val mean_coeffs = (minv * qtL).map(_.toFloat) * (yVec - mVec)
@@ -119,7 +120,8 @@ class LowRankGaussianProcess[D <: Dim: NDSpace, DO <: Dim: NDSpace](mean: Vector
    * are subject to 0 mean Gaussian noise
    */
   def coefficients(trainingData: IndexedSeq[(Point[D], Vector[DO])], sigma2: Double): DenseVector[Float] = {
-    val newtd = trainingData.map { case (pt, df) => (pt, df, sigma2) }
+    val cov = NDimensionalNormalDistribution(Vector.zeros[DO], SquareMatrix.eye[DO] * sigma2)
+    val newtd = trainingData.map { case (pt, df) => (pt, df, cov) }
     coefficients(newtd)
   }
 
@@ -127,14 +129,15 @@ class LowRankGaussianProcess[D <: Dim: NDSpace, DO <: Dim: NDSpace](mean: Vector
    * The posterior distribution of the gaussian process, with respect to the given trainingData. It is computed using Gaussian process regression.
    */
   def posterior(trainingData: IndexedSeq[(Point[D], Vector[DO])], sigma2: Double): LowRankGaussianProcess[D, DO] = {
-    val newtd = trainingData.map { case (pt, df) => (pt, df, sigma2) }
+    val cov = NDimensionalNormalDistribution(Vector.zeros[DO], SquareMatrix.eye[DO] * sigma2)
+    val newtd = trainingData.map { case (pt, df) => (pt, df, cov) }
     posterior(newtd)
   }
 
   /**
    * The posterior distribution of the gaussian process, with respect to the given trainingData. It is computed using Gaussian process regression.
    */
-  def posterior(trainingData: IndexedSeq[(Point[D], Vector[DO], Double)]): LowRankGaussianProcess[D, DO] = {
+  def posterior(trainingData: IndexedSeq[(Point[D], Vector[DO], NDimensionalNormalDistribution[DO])]): LowRankGaussianProcess[D, DO] = {
     LowRankGaussianProcess.regression(this, trainingData)
   }
 
@@ -189,47 +192,13 @@ object LowRankGaussianProcess {
   }
 
   /**
-   * * Performs a Gaussian process regression, where we assume that all training points (vectors) are subject to the same zero-mean Gaussian noise with variance simga2.
-   *
-   * @param gp  The gaussian process
-   * @param trainingData Point/value pairs where that the sample should approximate
-   * @param sigma2 The variance of the noise model
-   * @param meanOnly Computes only the posterior mean and not the full posterior process. Return a Gaussian process of rank 0.
-   */
-  def regression[D <: Dim: NDSpace, DO <: Dim: NDSpace](gp: LowRankGaussianProcess[D, DO],
-    trainingData: IndexedSeq[(Point[D], Vector[DO])],
-    sigma2: Double,
-    meanOnly: Boolean): LowRankGaussianProcess[D, DO] = {
-
-    val trainingDataWithNoise = trainingData.map { case (x, y) => (x, y, sigma2) }
-    regression(gp, trainingDataWithNoise, meanOnly)
-  }
-
-  /**
-   * * Performs a Gaussian process regression, where we assume that all training points (vectors) are subject to the same zero-mean Gaussian noise with variance simga2.
-   *
-   * @param gp  The gaussian process
-   * @param trainingData Point/value pairs where that the sample should approximate
-   * @param sigma2 The variance of the noise model
-   */
-  def regression[D <: Dim: NDSpace, DO <: Dim: NDSpace](gp: LowRankGaussianProcess[D, DO],
-    trainingData: IndexedSeq[(Point[D], Vector[DO])],
-    sigma2: Double): LowRankGaussianProcess[D, DO] = {
-
-    val trainingDataWithNoise = trainingData.map { case (x, y) => (x, y, sigma2) }
-    regression(gp, trainingDataWithNoise, false)
-  }
-
-  /**
    * * Performs a Gaussian process regression, where we assume that each training point (vector) is subject to  zero-mean noise with given variance.
    *
    * @param gp  The gaussian process
-   * @param trainingData Point/value pairs where that the sample should approximate, together with the variance of the noise model at each point.
-   * @param meanOnly Computes only the posterior mean and not the full posterior process. Return a Gaussian process of rank 0.
+   * @param trainingData Point/value pairs where that the sample should approximate, together with an error model (the uncertainty) at each point.
    */
   def regression[D <: Dim: NDSpace, DO <: Dim: NDSpace](gp: LowRankGaussianProcess[D, DO],
-    trainingData: IndexedSeq[(Point[D], Vector[DO], Double)],
-    meanOnly: Boolean = false): LowRankGaussianProcess[D, DO] = {
+    trainingData: IndexedSeq[(Point[D], Vector[DO], NDimensionalNormalDistribution[DO])]): LowRankGaussianProcess[D, DO] = {
     val outputDim = implicitly[NDSpace[DO]].dimensionality
 
     val (lambdas, phis) = gp.klBasis.unzip
@@ -238,11 +207,6 @@ object LowRankGaussianProcess {
 
     val mean_p = gp.instance(mean_coeffs)
 
-    if (meanOnly == true) {
-      val emptyEigenPairs = IndexedSeq[(Float, VectorField[D, DO])]()
-      new LowRankGaussianProcess(mean_p, emptyEigenPairs)
-
-    } else {
       val D = breeze.linalg.diag(DenseVector(lambdas.map(math.sqrt(_)).toArray))
       val Sigma = D * _Minv * D
       val SVD(innerUDbl, innerD2, _) = breeze.linalg.svd(Sigma)
@@ -274,14 +238,12 @@ object LowRankGaussianProcess {
       val lambdas_p = innerD2.toArray.map(_.toFloat).toIndexedSeq
       new LowRankGaussianProcess[D, DO](mean_p, lambdas_p.zip(phis_p))
     }
-  }
 
   /*
   * Internal computations of the regression.
    */
   private def genericRegressionComputations[D <: Dim: NDSpace, DO <: Dim: NDSpace](gp: LowRankGaussianProcess[D, DO],
-    trainingData: IndexedSeq[(Point[D], Vector[DO], Double)],
-    meanOnly: Boolean = false) = {
+    trainingData: IndexedSeq[(Point[D], Vector[DO], NDimensionalNormalDistribution[DO])]) = {
 
     val outputDimensionality = implicitly[NDSpace[DO]].dimensionality
 
@@ -291,7 +253,7 @@ object LowRankGaussianProcess {
     val dim = implicitly[NDSpace[DO]].dimensionality
     def flatten(v: IndexedSeq[Vector[DO]]) = DenseVector(v.flatten(_.data).toArray)
 
-    val (xs, ys, sigma2s) = trainingData.unzip3
+    val (xs, ys, errorDistributions) = trainingData.unzip3
 
     val yVec = flatten(ys)
     val meanValues = xs.map(gp.mean)
@@ -302,16 +264,15 @@ object LowRankGaussianProcess {
       Q(i * dim until i * dim + dim, j) := phi_j(x_i).toBreezeVector.map(_.toDouble) * math.sqrt(lambdas(j))
     }
 
-    // compute Q^TL where L is a diagonal matrix that contains the inverse of the sigmas in the diagonal.
-    // As there is only one sigma for each point (but the point has dim components) we need
-    // to correct the index for sigma
+    // What we are actually computing here is the following:
+    // L would be a block diagonal matrix, which contains on the diagonal the blocks that describes the uncertainty
+    // for each point (a d x d) block. We then would compute Q.t * L. For efficiency reasons (L could be large but is sparse)
+    // we avoid ever constructing the matrix L and do the multiplication by hand.
     val QtL = Q.t.copy
-    val sigma2sInv = sigma2s.map { sigma2 =>
-      val divisor = math.max(1e-8, sigma2)
-      1.0 / divisor
-    }
-    for (i <- 0 until QtL.cols) {
-      QtL(::, i) *= sigma2sInv(i / dim)
+    assert(QtL.cols == errorDistributions.size * dim)
+    assert(QtL.rows == gp.rank)
+    for ((errDist, i) <- errorDistributions.zipWithIndex) {
+      QtL(::, i * dim until (i + 1) * dim) := QtL(::, i * dim until (i + 1) * dim) * breeze.linalg.inv(errDist.cov.toBreezeMatrix)
     }
 
     val M = QtL * Q + DenseMatrix.eye[Double](phis.size)

--- a/src/main/scala/scalismo/statisticalmodel/StatisticalModel.scala
+++ b/src/main/scala/scalismo/statisticalmodel/StatisticalModel.scala
@@ -17,7 +17,7 @@ package scalismo.statisticalmodel
 
 import breeze.linalg.{ DenseVector, DenseMatrix }
 import scalismo.common.DiscreteVectorField
-import scalismo.geometry.{ Point, _3D }
+import scalismo.geometry.{SquareMatrix, Vector, Point, _3D}
 import scalismo.mesh.TriangleMesh
 import scalismo.registration.{ Transformation, RigidTransformation }
 
@@ -78,7 +78,7 @@ case class StatisticalMeshModel private (val referenceMesh: TriangleMesh, val gp
    * displacement vector. Different uncertainties can be attributed to each point.
    * @see [[DiscreteLowRankGaussianProcess.project]]
    */
-  def project(trainingData: IndexedSeq[(Int, Point[_3D], Double)]) = {
+  def project(trainingData: IndexedSeq[(Int, Point[_3D], NDimensionalNormalDistribution[_3D])]) = {
     val trainingDataWithDisplacements = trainingData.map { case (id, targetPoint, d) => (id, targetPoint - referenceMesh(id), d) }
     warpReference(gp.project(trainingDataWithDisplacements))
   }
@@ -105,8 +105,8 @@ case class StatisticalMeshModel private (val referenceMesh: TriangleMesh, val gp
   /**
    * Similar to [[DiscreteLowRankGaussianProcess.posterior(Int, Point[_3D], Double)]]], but the training data is defined by specifying the target point instead of the displacement vector
    */
-  def posterior(trainingData: IndexedSeq[(Int, Point[_3D], Double)]): StatisticalMeshModel = {
-    val trainingDataWithDisplacements = trainingData.map { case (id, targetPoint, sigma) => (id, targetPoint - referenceMesh(id), sigma) }
+  def posterior(trainingData: IndexedSeq[(Int, Point[_3D], NDimensionalNormalDistribution[_3D])]): StatisticalMeshModel = {
+    val trainingDataWithDisplacements = trainingData.map { case (id, targetPoint, cov) => (id, targetPoint - referenceMesh(id), cov) }
     val posteriorGp = gp.posterior(trainingDataWithDisplacements)
     new StatisticalMeshModel(referenceMesh, posteriorGp)
   }


### PR DESCRIPTION
The regression computations have been changed such that a full error distribution can be
provided for each point. This makes it possible to model unisotropic noise (in each space direction).

Along with this change, the regression interface was streamlined:
- The parameter MeanOnly was removed.
- Regression can only be called with a full specification of the error model for each point.