### PR TITLE
Set "default" compile version of scala to 2.10.4

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -11,7 +11,7 @@ import com.banno.license.Licenses._
 object BuildSettings {
   val buildOrganization = "ch.unibas.cs.gravis"
   val buildVersion = "develop-SNAPSHOT"
-  val buildScalaVersion = "2.11.4"
+  val buildScalaVersion = "2.10.4"
   val publishURL = Resolver.file("file", new File("/export/contrib/statismo/repo/public"))
 
   val buildSettings = Defaults.defaultSettings ++ Seq(


### PR DESCRIPTION
This avoids accidentally using 2.11 only features if "sbt compile" (only) is used.
It does not change anything if "sbt +compile" is used.