### PR TITLE
renaming of typeclasses to make intent more clear

### DIFF
--- a/src/main/scala/scalismo/common/DiscreteDomain.scala
+++ b/src/main/scala/scalismo/common/DiscreteDomain.scala
@@ -15,7 +15,7 @@
  */
 package scalismo.common
 
-import scalismo.common.DiscreteDomain.CanBound
+import scalismo.common.DiscreteDomain.NDDomainOps
 import scalismo.geometry._
 import scalismo.mesh.kdtree.KDTreeMap
 
@@ -43,8 +43,8 @@ trait DiscreteDomain[D <: Dim] extends Equals { self =>
    * The bounding box is always oriented along the dimensions of the space (i.e. this method does not return rotated boxes)
    */
 
-  def boundingBox(implicit canBound: CanBound[D]): BoxDomain[D] = {
-    canBound.boundingBox(this)
+  def boundingBox(implicit domainOps: NDDomainOps[D]): BoxDomain[D] = {
+    domainOps.boundingBox(this)
   }
 
   override def equals(that: Any) = {
@@ -88,11 +88,11 @@ object DiscreteDomain {
     }
   }
 
-  trait CanBound[D <: Dim] {
+  trait NDDomainOps[D <: Dim] {
     def boundingBox(domain: DiscreteDomain[D]): BoxDomain[D]
   }
 
-  implicit object CanBound1D extends CanBound[_1D] {
+  implicit object DomainOps1D extends NDDomainOps[_1D] {
     def boundingBox(domain: DiscreteDomain[_1D]): BoxDomain[_1D] = {
       val minx = domain.points.map(_(0)).min
       val maxx = domain.points.map(_(0)).max
@@ -100,7 +100,7 @@ object DiscreteDomain {
     }
   }
 
-  implicit object CanBound2D extends CanBound[_2D] {
+  implicit object DomainOps2D extends NDDomainOps[_2D] {
     def boundingBox(domain: DiscreteDomain[_2D]): BoxDomain[_2D] = {
       val minx = domain.points.map(_(0)).min
       val miny = domain.points.map(_(1)).min
@@ -110,7 +110,7 @@ object DiscreteDomain {
     }
   }
 
-  implicit object CanBound3D extends CanBound[_3D] {
+  implicit object DomainOps3D extends NDDomainOps[_3D] {
     def boundingBox(domain: DiscreteDomain[_3D]): BoxDomain[_3D] = {
       val minx = domain.points.map(_(0)).min
       val miny = domain.points.map(_(1)).min

--- a/src/main/scala/scalismo/common/DiscreteField.scala
+++ b/src/main/scala/scalismo/common/DiscreteField.scala
@@ -47,7 +47,7 @@ trait DiscreteField[D <: Dim, A] extends PartialFunction[Int, A] { self =>
  *
  */
 
-class DiscreteScalarField[D <: Dim: NDSpace: CanBound, A: Scalar: ClassTag](val domain: DiscreteDomain[D], private[scalismo] val data: ScalarArray[A]) extends DiscreteField[D, A] {
+class DiscreteScalarField[D <: Dim: NDSpace: NDDomainOps, A: Scalar: ClassTag](val domain: DiscreteDomain[D], private[scalismo] val data: ScalarArray[A]) extends DiscreteField[D, A] {
 
   /** map the function f over the values, but ensures that the result is scalar valued as well */
   def map[B: Scalar: ClassTag](f: A => B): DiscreteScalarField[D, B] = {
@@ -83,7 +83,7 @@ class DiscreteScalarField[D <: Dim: NDSpace: CanBound, A: Scalar: ClassTag](val 
 /**
  *
  */
-class DiscreteVectorField[D <: Dim: NDSpace: CanBound, DO <: Dim] private (val domain: DiscreteDomain[D], private[scalismo] val data: IndexedSeq[Vector[DO]]) extends DiscreteField[D, Vector[DO]] {
+class DiscreteVectorField[D <: Dim: NDSpace: NDDomainOps, DO <: Dim] private (val domain: DiscreteDomain[D], private[scalismo] val data: IndexedSeq[Vector[DO]]) extends DiscreteField[D, Vector[DO]] {
 
   override def values = data.iterator
   override def apply(ptId: Int) = data(ptId)
@@ -101,7 +101,7 @@ class DiscreteVectorField[D <: Dim: NDSpace: CanBound, DO <: Dim] private (val d
 
 object DiscreteVectorField {
 
-  def apply[D <: Dim: NDSpace: CanBound, DO <: Dim](domain: DiscreteDomain[D], data: IndexedSeq[Vector[DO]]) = {
+  def apply[D <: Dim: NDSpace: NDDomainOps, DO <: Dim](domain: DiscreteDomain[D], data: IndexedSeq[Vector[DO]]) = {
     new DiscreteVectorField(domain, data)
   }
 }

--- a/src/main/scala/scalismo/image/DiscreteImageDomain.scala
+++ b/src/main/scala/scalismo/image/DiscreteImageDomain.scala
@@ -130,12 +130,12 @@ abstract class DiscreteImageDomain[D <: Dim: NDSpace] extends DiscreteDomain[D] 
 object DiscreteImageDomain {
 
   /** Typeclass for creating domains of arbitrary dimensionality */
-  sealed trait CanCreate[D <: Dim] {
+  sealed trait NDCreateImageDomain[D <: Dim] {
     def createImageDomain(origin: Point[D], spacing: Vector[D], size: Index[D]): DiscreteImageDomain[D]
     def createWithTransform(size: Index[D], transform: AnisotropicSimilarityTransformation[D]): DiscreteImageDomain[D]
   }
 
-  implicit object canCreateImageDomain2D extends CanCreate[_2D] {
+  implicit object _2DCreateImageDomainImageDomain$ extends NDCreateImageDomain[_2D] {
     override def createImageDomain(origin: Point[_2D], spacing: Vector[_2D], size: Index[_2D]): DiscreteImageDomain[_2D] = {
       val rigidParameters = origin.data ++ Array(0f)
       val anisotropicScalingParmaters = spacing.data
@@ -145,7 +145,7 @@ object DiscreteImageDomain {
     override def createWithTransform(size: Index[_2D], transform: AnisotropicSimilarityTransformation[_2D]): DiscreteImageDomain[_2D] = new DiscreteImageDomain2D(size, transform)
   }
 
-  implicit object canCreateImageDomain3D extends CanCreate[_3D] {
+  implicit object _3DCreateImageDomainImageDomain$ extends NDCreateImageDomain[_3D] {
     override def createImageDomain(origin: Point[_3D], spacing: Vector[_3D], size: Index[_3D]): DiscreteImageDomain[_3D] = {
       val rigidParameters = origin.data ++ Array(0f, 0f, 0f)
       val anisotropicScalingParmaters = spacing.data
@@ -155,7 +155,7 @@ object DiscreteImageDomain {
     override def createWithTransform(size: Index[_3D], transform: AnisotropicSimilarityTransformation[_3D]): DiscreteImageDomain[_3D] = new DiscreteImageDomain3D(size, transform)
   }
 
-  implicit object canCreateImageDomain1D extends CanCreate[_1D] {
+  implicit object _1DNDCreateImageDomainImageDomain$ extends NDCreateImageDomain[_1D] {
     override def createImageDomain(origin: Point[_1D], spacing: Vector[_1D], size: Index[_1D]): DiscreteImageDomain[_1D] = new DiscreteImageDomain1D(origin, spacing, size)
     override def createWithTransform(size: Index[_1D], transform: AnisotropicSimilarityTransformation[_1D]): DiscreteImageDomain[_1D] = {
       val origin = transform(Point(0))
@@ -165,7 +165,7 @@ object DiscreteImageDomain {
   }
 
   /** Create a new discreteImageDomain with given origin, spacing and size*/
-  def apply[D <: Dim](origin: Point[D], spacing: Vector[D], size: Index[D])(implicit evDim: NDSpace[D], evCreate: CanCreate[D]) = {
+  def apply[D <: Dim](origin: Point[D], spacing: Vector[D], size: Index[D])(implicit evDim: NDSpace[D], evCreate: NDCreateImageDomain[D]) = {
     evCreate.createImageDomain(origin, spacing, size)
   }
 
@@ -173,7 +173,7 @@ object DiscreteImageDomain {
    * Create a discreteImageDomain where the points are defined as tranformations of the indeces (from (0,0,0) to (size - 1, size - 1 , size -1)
    * This makes it possible to define image regions which are not aligned to the coordinate axis.
    */
-  private[scalismo] def apply[D <: Dim](size: Index[D], transform: AnisotropicSimilarityTransformation[D])(implicit evDim: NDSpace[D], evCreateRot: CanCreate[D]) = {
+  private[scalismo] def apply[D <: Dim](size: Index[D], transform: AnisotropicSimilarityTransformation[D])(implicit evDim: NDSpace[D], evCreateRot: NDCreateImageDomain[D]) = {
     evCreateRot.createWithTransform(size, transform)
   }
 

--- a/src/main/scala/scalismo/image/Image.scala
+++ b/src/main/scala/scalismo/image/Image.scala
@@ -15,7 +15,7 @@
  */
 package scalismo.image
 
-import scalismo.common.DiscreteDomain.CanBound
+import scalismo.common.DiscreteDomain.NDDomainOps
 import scalismo.image.filter.Filter
 import scalismo.common._
 import scalismo.geometry._
@@ -24,12 +24,12 @@ import scalismo.registration.{ CanDifferentiate, Transformation }
 import scala.language.implicitConversions
 import scala.reflect.ClassTag
 import scalismo.numerics.GridSampler
-import DiscreteImageDomain.CanCreate
+import DiscreteImageDomain.NDCreateImageDomain
 
 /**
  * An image whose values are scalar.
  */
-class ScalarImage[D <: Dim: NDSpace: CanBound: CanInterpolate] protected (override val domain: Domain[D], override val f: Point[D] => Float) extends ScalarField[D, Float](domain, f) {
+class ScalarImage[D <: Dim: NDSpace: NDDomainOps: NDImageOps] protected (override val domain: Domain[D], override val f: Point[D] => Float) extends ScalarField[D, Float](domain, f) {
 
   /** adds two images. The domain of the new image is the intersection of both */
   def +(that: ScalarImage[D]): ScalarImage[D] = {
@@ -79,7 +79,7 @@ class ScalarImage[D <: Dim: NDSpace: CanBound: CanInterpolate] protected (overri
    * @param  numberOfPointsPerDim Number of points to be used to approximate the filter. Depending on the
    * support size of the filter and the Frequency of the image, increasing this value can help avoid artifacts (at the cost of heavier computation)
    */
-  def convolve(filter: Filter[D], numberOfPointsPerDim: Int)(implicit c: CanCreate[D]): ScalarImage[D] = {
+  def convolve(filter: Filter[D], numberOfPointsPerDim: Int)(implicit c: NDCreateImageDomain[D]): ScalarImage[D] = {
 
     val dim = implicitly[NDSpace[D]].dimensionality
     val supportSpacing = filter.support.extent * (1f / numberOfPointsPerDim.toFloat)
@@ -132,14 +132,14 @@ object ScalarImage {
    * @param domain The domain over which the image is defined
    * @param f A function which yields for each point of the domain its value
    */
-  def apply[D <: Dim: NDSpace: CanBound: CanInterpolate](domain: Domain[D], f: Point[D] => Float) = new ScalarImage[D](domain, f)
+  def apply[D <: Dim: NDSpace: NDDomainOps: NDImageOps](domain: Domain[D], f: Point[D] => Float) = new ScalarImage[D](domain, f)
 
 }
 
 /**
  * A scalar image that is once differentiable
  */
-class DifferentiableScalarImage[D <: Dim: NDSpace: CanBound: CanInterpolate](_domain: Domain[D], _f: Point[D] => Float, val df: Point[D] => Vector[D]) extends ScalarImage[D](_domain, _f) {
+class DifferentiableScalarImage[D <: Dim: NDSpace: NDDomainOps: NDImageOps](_domain: Domain[D], _f: Point[D] => Float, val df: Point[D] => Vector[D]) extends ScalarImage[D](_domain, _f) {
 
   def differentiate: VectorField[D, D] = VectorField(domain, df)
 
@@ -178,7 +178,7 @@ class DifferentiableScalarImage[D <: Dim: NDSpace: CanBound: CanInterpolate](_do
     new DifferentiableScalarImage(newDomain, f, df)
   }
 
-  override def convolve(filter: Filter[D], numberOfPointsPerDim: Int)(implicit c: CanCreate[D]): DifferentiableScalarImage[D] = {
+  override def convolve(filter: Filter[D], numberOfPointsPerDim: Int)(implicit c: NDCreateImageDomain[D]): DifferentiableScalarImage[D] = {
 
     val convolvedImage = super.convolve(filter, numberOfPointsPerDim)
 
@@ -216,7 +216,7 @@ object DifferentiableScalarImage {
    * @param f a function that yiels for each point of the domain its intensities
    * @param df the derivative of the function f
    */
-  def apply[D <: Dim: NDSpace: CanBound: CanInterpolate](domain: Domain[D], f: Point[D] => Float, df: Point[D] => Vector[D]) = new DifferentiableScalarImage[D](domain, f, df)
+  def apply[D <: Dim: NDSpace: NDDomainOps: NDImageOps](domain: Domain[D], f: Point[D] => Float, df: Point[D] => Vector[D]) = new DifferentiableScalarImage[D](domain, f, df)
 
 }
 

--- a/src/main/scala/scalismo/image/filter/DiscreteImageFilter.scala
+++ b/src/main/scala/scalismo/image/filter/DiscreteImageFilter.scala
@@ -16,10 +16,10 @@
 package scalismo.image.filter
 
 import scalismo.common.{ ScalarArray, Scalar }
-import scalismo.common.DiscreteDomain.CanBound
-import scalismo.image.{ CanInterpolate, DiscreteScalarImage }
+import scalismo.common.DiscreteDomain.NDDomainOps
+import scalismo.image.{ NDImageOps, DiscreteScalarImage }
 import scalismo.geometry._
-import scalismo.utils.{ CanConvertToVtk, ImageConversion }
+import scalismo.utils.{NDImageToVtkOps, ImageConversion}
 import vtk.{ vtkImageCast, vtkImageEuclideanDistance }
 
 import scala.reflect.ClassTag
@@ -31,7 +31,7 @@ object DiscreteImageFilter {
    * Computes a (signed) distance transform of the image.
    * @note The value that is returned is not the euclidean distance unless the image has unit spacing. Even worse, the distance might depend on the spacing of the image.
    */
-  def distanceTransform[D <: Dim: NDSpace: CanConvertToVtk: CanInterpolate: CanBound, A: Scalar: ClassTag: TypeTag](img: DiscreteScalarImage[D, A]): DiscreteScalarImage[D, Float] = {
+  def distanceTransform[D <: Dim: NDSpace: NDImageToVtkOps: NDImageOps: NDDomainOps, A: Scalar: ClassTag: TypeTag](img: DiscreteScalarImage[D, A]): DiscreteScalarImage[D, Float] = {
 
     val scalar = implicitly[Scalar[A]]
 

--- a/src/main/scala/scalismo/io/ImageIO.scala
+++ b/src/main/scala/scalismo/io/ImageIO.scala
@@ -23,7 +23,7 @@ import scalismo.common.{ RealSpace, Scalar, ScalarArray }
 import scalismo.geometry._
 import scalismo.image.{ DiscreteImageDomain, DiscreteScalarImage }
 import scalismo.registration.{ AnisotropicScalingSpace, AnisotropicSimilarityTransformationSpace, LandmarkRegistration, Transformation }
-import scalismo.utils.{ CanConvertToVtk, ImageConversion, VtkHelpers }
+import scalismo.utils.{NDImageToVtkOps, ImageConversion, VtkHelpers}
 import spire.math.{ UByte, UInt, ULong, UShort }
 import vtk._
 
@@ -513,7 +513,7 @@ object ImageIO {
     }
   }
 
-  def writeVTK[D <: Dim: NDSpace: CanConvertToVtk, S: Scalar: TypeTag: ClassTag](img: DiscreteScalarImage[D, S], file: File): Try[Unit] = {
+  def writeVTK[D <: Dim: NDSpace: NDImageToVtkOps, S: Scalar: TypeTag: ClassTag](img: DiscreteScalarImage[D, S], file: File): Try[Unit] = {
 
     val imgVtk = ImageConversion.imageToVtkStructuredPoints(img)
 

--- a/src/main/scala/scalismo/kernels/StandardKernels.scala
+++ b/src/main/scala/scalismo/kernels/StandardKernels.scala
@@ -77,23 +77,23 @@ abstract case class BSplineKernel[D <: Dim](order: Int, scale: Int) extends PDKe
 
 object BSplineKernel {
 
-  def apply[D <: Dim: CanCreate](order: Int, scale: Int): BSplineKernel[D] = {
-    implicitly[CanCreate[D]].create(order, scale)
+  def apply[D <: Dim: NDCreateBSplineKernel](order: Int, scale: Int): BSplineKernel[D] = {
+    implicitly[NDCreateBSplineKernel[D]].create(order, scale)
   }
 
-  trait CanCreate[D <: Dim] {
+  trait NDCreateBSplineKernel[D <: Dim] {
     def create(order: Int, j: Int): BSplineKernel[D]
   }
 
-  implicit object CanCreateBSplineKernel1D extends CanCreate[_1D] {
+  implicit object _1DCreateBSplineKernelBSplineKernel extends NDCreateBSplineKernel[_1D] {
     def create(order: Int, j: Int): BSplineKernel[_1D] = new BSplineKernel1D(order, j)
   }
 
-  implicit object CanCreateBSplineKernel2D extends CanCreate[_2D] {
+  implicit object _2DCreateBSplineKernelBSplineKernel extends NDCreateBSplineKernel[_2D] {
     def create(order: Int, j: Int): BSplineKernel[_2D] = new BSplineKernel2D(order, j)
   }
 
-  implicit object CanCreateBSplineKernel3D extends CanCreate[_3D] {
+  implicit object _3DCreateBSplineKernelBSplineKernel extends NDCreateBSplineKernel[_3D] {
     def create(order: Int, j: Int): BSplineKernel[_3D] = new BSplineKernel3D(order, j)
   }
 

--- a/src/main/scala/scalismo/statisticalmodel/DiscreteLowRankGaussianProcess.scala
+++ b/src/main/scala/scalismo/statisticalmodel/DiscreteLowRankGaussianProcess.scala
@@ -18,7 +18,7 @@ package scalismo.statisticalmodel
 import breeze.linalg.svd.SVD
 import breeze.linalg.{ *, DenseMatrix, DenseVector }
 import breeze.stats.distributions.Gaussian
-import scalismo.common.DiscreteDomain.CanBound
+import scalismo.common.DiscreteDomain.NDDomainOps
 import scalismo.common.{ RealSpace, VectorField, DiscreteVectorField, DiscreteDomain }
 import scalismo.geometry._
 import scalismo.kernels.MatrixValuedPDKernel
@@ -39,7 +39,7 @@ import scalismo.registration.Transformation
  * @see [[scalismo.common.DiscreteVectorField]]
  * @see [[DiscreteLowRankGaussianProcess]]
  */
-case class DiscreteLowRankGaussianProcess[D <: Dim: NDSpace: CanBound, DO <: Dim: NDSpace] private[scalismo] (val domain: DiscreteDomain[D],
+case class DiscreteLowRankGaussianProcess[D <: Dim: NDSpace: NDDomainOps, DO <: Dim: NDSpace] private[scalismo] (val domain: DiscreteDomain[D],
     val meanVector: DenseVector[Float],
     val variance: DenseVector[Float],
     val basisMatrix: DenseMatrix[Float]) { self =>
@@ -267,7 +267,7 @@ object DiscreteLowRankGaussianProcess {
   /**
    * Creates a new DiscreteLowRankGaussianProcess by discretizing the given gaussian process at the domain points.
    */
-  def apply[D <: Dim: NDSpace: CanBound, DO <: Dim: NDSpace](domain: DiscreteDomain[D], gp: LowRankGaussianProcess[D, DO]): DiscreteLowRankGaussianProcess[D, DO] = {
+  def apply[D <: Dim: NDSpace: NDDomainOps, DO <: Dim: NDSpace](domain: DiscreteDomain[D], gp: LowRankGaussianProcess[D, DO]): DiscreteLowRankGaussianProcess[D, DO] = {
     val points = domain.points.toSeq
 
     val outputDimensionality = implicitly[NDSpace[DO]].dimensionality
@@ -294,7 +294,7 @@ object DiscreteLowRankGaussianProcess {
   /**
    * Discrete implementation of [[LowRankGaussianProcess.regression]]
    */
-  def regression[D <: Dim: NDSpace: CanBound, DO <: Dim: NDSpace](gp: DiscreteLowRankGaussianProcess[D, DO],
+  def regression[D <: Dim: NDSpace: NDDomainOps, DO <: Dim: NDSpace](gp: DiscreteLowRankGaussianProcess[D, DO],
     trainingData: IndexedSeq[(Int, Vector[DO], NDimensionalNormalDistribution[DO])]): DiscreteLowRankGaussianProcess[D, DO] = {
 
     val dim = implicitly[NDSpace[DO]].dimensionality
@@ -330,7 +330,7 @@ object DiscreteLowRankGaussianProcess {
    * Creates a new DiscreteLowRankGaussianProcess, where the mean and covariance matrix are estimated from the given transformations.
    *
    */
-  def createDiscreteLowRankGPFromTransformations[D <: Dim: NDSpace: CanBound](domain: DiscreteDomain[D], transformations: Seq[Transformation[D]]): DiscreteLowRankGaussianProcess[D, D] = {
+  def createDiscreteLowRankGPFromTransformations[D <: Dim: NDSpace: NDDomainOps](domain: DiscreteDomain[D], transformations: Seq[Transformation[D]]): DiscreteLowRankGaussianProcess[D, D] = {
     val dim = implicitly[NDSpace[D]].dimensionality
 
     val n = transformations.size
@@ -367,7 +367,7 @@ object DiscreteLowRankGaussianProcess {
 
   }
 
-  private def genericRegressionComputations[D <: Dim: NDSpace: CanBound, DO <: Dim: NDSpace](gp: DiscreteLowRankGaussianProcess[D, DO],
+  private def genericRegressionComputations[D <: Dim: NDSpace: NDDomainOps, DO <: Dim: NDSpace](gp: DiscreteLowRankGaussianProcess[D, DO],
     trainingData: IndexedSeq[(Int, Vector[DO], NDimensionalNormalDistribution[DO])]) = {
     val dim = implicitly[NDSpace[DO]].dimensionality
     val (ptIds, ys, errorDistributions) = trainingData.unzip3

--- a/src/main/scala/scalismo/statisticalmodel/GaussianProcess.scala
+++ b/src/main/scala/scalismo/statisticalmodel/GaussianProcess.scala
@@ -17,7 +17,7 @@ package scalismo.statisticalmodel
 
 import breeze.linalg.svd.SVD
 import breeze.linalg.{ *, DenseVector, DenseMatrix }
-import scalismo.common.DiscreteDomain.CanBound
+import scalismo.common.DiscreteDomain.NDDomainOps
 import scalismo.common._
 import scalismo.geometry._
 import scalismo.kernels._
@@ -32,7 +32,7 @@ import scalismo.utils.Memoize
  * @tparam D The dimensionality of the input space
  * @tparam DO The dimensionality of the output space
  */
-class GaussianProcess[D <: Dim: NDSpace: CanBound, DO <: Dim: NDSpace] protected (val mean: VectorField[D, DO],
+class GaussianProcess[D <: Dim: NDSpace: NDDomainOps, DO <: Dim: NDSpace] protected (val mean: VectorField[D, DO],
     val cov: MatrixValuedPDKernel[D, DO]) {
 
   protected[this] val dimOps: NDSpace[DO] = implicitly[NDSpace[DO]]
@@ -101,7 +101,7 @@ object GaussianProcess {
   /**
    * Creates a new Gaussian process with given mean and covariance, which is defined on the given domain.
    */
-  def apply[D <: Dim: NDSpace: CanBound, DO <: Dim: NDSpace](mean: VectorField[D, DO], cov: MatrixValuedPDKernel[D, DO]) = {
+  def apply[D <: Dim: NDSpace: NDDomainOps, DO <: Dim: NDSpace](mean: VectorField[D, DO], cov: MatrixValuedPDKernel[D, DO]) = {
     new GaussianProcess[D, DO](mean, cov)
   }
 
@@ -111,7 +111,7 @@ object GaussianProcess {
    * @param gp  The gaussian process
    * @param trainingData Point/value pairs where that the sample should approximate, together with an error model (the uncertainty) at each point.
    */
-  def regression[D <: Dim: NDSpace: CanBound, DO <: Dim: NDSpace](gp: GaussianProcess[D, DO],
+  def regression[D <: Dim: NDSpace: NDDomainOps, DO <: Dim: NDSpace](gp: GaussianProcess[D, DO],
     trainingData: IndexedSeq[(Point[D], Vector[DO], NDimensionalNormalDistribution[DO])]): GaussianProcess[D, DO] = {
 
     val outputDim = implicitly[NDSpace[DO]].dimensionality

--- a/src/main/scala/scalismo/statisticalmodel/LowRankGaussianProcess.scala
+++ b/src/main/scala/scalismo/statisticalmodel/LowRankGaussianProcess.scala
@@ -18,7 +18,7 @@ package scalismo.statisticalmodel
 import breeze.linalg.svd.SVD
 import breeze.linalg.{ *, Axis, DenseVector, DenseMatrix }
 import breeze.stats.distributions.Gaussian
-import scalismo.common.DiscreteDomain.CanBound
+import scalismo.common.DiscreteDomain.NDDomainOps
 import scalismo.common._
 import scalismo.geometry.{ Point, SquareMatrix, NDSpace, Dim, Vector }
 import scalismo.kernels.{ MatrixValuedPDKernel, Kernel }
@@ -37,7 +37,7 @@ import scalismo.utils.Memoize
  * @tparam D The dimensionality of the input space
  * @tparam DO The dimensionality of the output space
  */
-class LowRankGaussianProcess[D <: Dim: NDSpace: CanBound, DO <: Dim: NDSpace](mean: VectorField[D, DO],
+class LowRankGaussianProcess[D <: Dim: NDSpace: NDDomainOps, DO <: Dim: NDSpace](mean: VectorField[D, DO],
   val klBasis: IndexedSeq[(Float, VectorField[D, DO])])
     extends GaussianProcess[D, DO](mean, LowRankGaussianProcess.covFromKLTBasis(klBasis)) {
 
@@ -158,14 +158,14 @@ object LowRankGaussianProcess {
    * @param sampler determines which points will be used as samples for the nystrom approximation.
    * @param numBasisFunctions The number of basis functions to approximate.
    */
-  def approximateGP[D <: Dim: NDSpace: CanBound, DO <: Dim: NDSpace](gp: GaussianProcess[D, DO],
+  def approximateGP[D <: Dim: NDSpace: NDDomainOps, DO <: Dim: NDSpace](gp: GaussianProcess[D, DO],
     sampler: Sampler[D],
     numBasisFunctions: Int) = {
     val kltBasis = Kernel.computeNystromApproximation(gp.cov, numBasisFunctions, sampler)
     new LowRankGaussianProcess[D, DO](gp.mean, kltBasis)
   }
 
-  private def covFromKLTBasis[D <: Dim: NDSpace: CanBound, DO <: Dim: NDSpace](eigenPairs: IndexedSeq[(Float, VectorField[D, DO])]): MatrixValuedPDKernel[D, DO] = {
+  private def covFromKLTBasis[D <: Dim: NDSpace: NDDomainOps, DO <: Dim: NDSpace](eigenPairs: IndexedSeq[(Float, VectorField[D, DO])]): MatrixValuedPDKernel[D, DO] = {
     val dimOps = implicitly[NDSpace[DO]]
     val cov: MatrixValuedPDKernel[D, DO] = new MatrixValuedPDKernel[D, DO] {
       override val domain = eigenPairs.headOption
@@ -192,7 +192,7 @@ object LowRankGaussianProcess {
    * @param gp  The gaussian process
    * @param trainingData Point/value pairs where that the sample should approximate, together with an error model (the uncertainty) at each point.
    */
-  def regression[D <: Dim: NDSpace: CanBound, DO <: Dim: NDSpace](gp: LowRankGaussianProcess[D, DO],
+  def regression[D <: Dim: NDSpace: NDDomainOps, DO <: Dim: NDSpace](gp: LowRankGaussianProcess[D, DO],
     trainingData: IndexedSeq[(Point[D], Vector[DO], NDimensionalNormalDistribution[DO])]): LowRankGaussianProcess[D, DO] = {
     val outputDim = implicitly[NDSpace[DO]].dimensionality
 
@@ -280,7 +280,7 @@ object LowRankGaussianProcess {
    * perform a rigid transformation of the gaussian process, i.e. it is later defined on the transformed domain and its
    * vectors are transformed along the domain.
    */
-  def transform[D <: Dim: NDSpace: CanBound](gp: LowRankGaussianProcess[D, D], rigidTransform: RigidTransformation[D]): LowRankGaussianProcess[D, D] = {
+  def transform[D <: Dim: NDSpace: NDDomainOps](gp: LowRankGaussianProcess[D, D], rigidTransform: RigidTransformation[D]): LowRankGaussianProcess[D, D] = {
     val invTransform = rigidTransform.inverse
 
     val newDomain = gp.domain.warp(rigidTransform)

--- a/src/main/scala/scalismo/utils/Conversions.scala
+++ b/src/main/scala/scalismo/utils/Conversions.scala
@@ -244,7 +244,7 @@ object MeshConversion {
   }
 }
 
-trait CanConvertToVtk[D <: Dim] {
+trait NDImageToVtkOps[D <: Dim] {
   def toVtk[Pixel: Scalar: ClassTag: TypeTag](img: DiscreteScalarImage[D, Pixel]): vtkStructuredPoints = {
     val sp = new vtkStructuredPoints()
     sp.SetNumberOfScalarComponents(1, new vtkInformation())
@@ -282,9 +282,9 @@ trait CanConvertToVtk[D <: Dim] {
   }
 }
 
-object CanConvertToVtk {
+object NDImageToVtkOps {
 
-  implicit object _2DCanConvertToVtk$ extends CanConvertToVtk[_2D] {
+  implicit object _2DNDImageToVtkOps extends NDImageToVtkOps[_2D] {
 
     override def setDomainInfo(domain: DiscreteImageDomain[_2D], sp: vtkStructuredPoints): Unit = {
       sp.SetDimensions(domain.size(0), domain.size(1), 1)
@@ -321,7 +321,7 @@ object CanConvertToVtk {
     }
   }
 
-  implicit object _3DCanConvertToVtk$ extends CanConvertToVtk[_3D] {
+  implicit object _3DNDImageToVtkOps extends NDImageToVtkOps[_3D] {
     override def setDomainInfo(domain: DiscreteImageDomain[_3D], sp: vtkStructuredPoints): Unit = {
       sp.SetDimensions(domain.size(0), domain.size(1), domain.size(2))
       sp.SetOrigin(domain.origin(0), domain.origin(1), domain.origin(2))
@@ -360,11 +360,11 @@ object CanConvertToVtk {
 
 object ImageConversion {
 
-  def imageToVtkStructuredPoints[D <: Dim: CanConvertToVtk, Pixel: Scalar: ClassTag: TypeTag](img: DiscreteScalarImage[D, Pixel]): vtkStructuredPoints = {
-    implicitly[CanConvertToVtk[D]].toVtk(img)
+  def imageToVtkStructuredPoints[D <: Dim: NDImageToVtkOps, Pixel: Scalar: ClassTag: TypeTag](img: DiscreteScalarImage[D, Pixel]): vtkStructuredPoints = {
+    implicitly[NDImageToVtkOps[D]].toVtk(img)
   }
 
-  def vtkStructuredPointsToScalarImage[D <: Dim: CanConvertToVtk, Pixel: Scalar: TypeTag: ClassTag](sp: vtkImageData): Try[DiscreteScalarImage[D, Pixel]] = {
-    implicitly[CanConvertToVtk[D]].fromVtk(sp)
+  def vtkStructuredPointsToScalarImage[D <: Dim: NDImageToVtkOps, Pixel: Scalar: TypeTag: ClassTag](sp: vtkImageData): Try[DiscreteScalarImage[D, Pixel]] = {
+    implicitly[NDImageToVtkOps[D]].fromVtk(sp)
   }
 }

--- a/src/test/scala/scalismo/io/ImageIOTests.scala
+++ b/src/test/scala/scalismo/io/ImageIOTests.scala
@@ -23,7 +23,7 @@ import org.scalatest.{ FunSpec, Matchers }
 import scalismo.common.{ Scalar, ScalarArray }
 import scalismo.geometry._
 import scalismo.image.{ DiscreteImageDomain, DiscreteScalarImage }
-import scalismo.utils.{ Benchmark, CanConvertToVtk }
+import scalismo.utils.{NDImageToVtkOps, Benchmark, NDImageToVtkOps$}
 import spire.math.{ UByte, UInt, ULong, UShort }
 
 import scala.reflect.ClassTag
@@ -64,7 +64,7 @@ class ImageIOTests extends FunSpec with Matchers {
     }
   }
 
-  private class DataReadWrite[D <: Dim: NDSpace: CanConvertToVtk] {
+  private class DataReadWrite[D <: Dim: NDSpace: NDImageToVtkOps] {
 
     val dim = implicitly[NDSpace[D]].dimensionality
 
@@ -269,7 +269,7 @@ class ImageIOTests extends FunSpec with Matchers {
   describe("ImageIO") {
     it("is type safe") {
 
-      case class ImageWithType[D <: Dim: NDSpace: CanConvertToVtk, T: Scalar: TypeTag: ClassTag](img: DiscreteScalarImage[D, T], typeName: String) {
+      case class ImageWithType[D <: Dim: NDSpace: NDImageToVtkOps, T: Scalar: TypeTag: ClassTag](img: DiscreteScalarImage[D, T], typeName: String) {
         def writeVtk(file: File) = ImageIO.writeVTK(img, file)
         def writeNii(file: File) = {
           if (implicitly[NDSpace[D]].dimensionality == 3) ImageIO.writeNifti(img.asInstanceOf[DiscreteScalarImage[_3D, T]], file)
@@ -277,7 +277,7 @@ class ImageIOTests extends FunSpec with Matchers {
         }
       }
 
-      def convertTo[D <: Dim: NDSpace: CanConvertToVtk, OUT: Scalar: TypeTag: ClassTag](in: DiscreteScalarImage[D, Int]): ImageWithType[D, OUT] = {
+      def convertTo[D <: Dim: NDSpace: NDImageToVtkOps, OUT: Scalar: TypeTag: ClassTag](in: DiscreteScalarImage[D, Int]): ImageWithType[D, OUT] = {
         val img = in.map(implicitly[Scalar[OUT]].fromInt)
         ImageWithType(img, ImageIO.ScalarType.fromType[OUT].toString)
       }
@@ -288,7 +288,7 @@ class ImageIOTests extends FunSpec with Matchers {
       val dom3 = DiscreteImageDomain(Point(0, 0, 0), Vector(1, 1, 1), Index(2, 2, 2))
       val img3 = DiscreteScalarImage(dom3, ScalarArray(data))
 
-      def imageSeq[D <: Dim: NDSpace: CanConvertToVtk](img: DiscreteScalarImage[D, Int]) = Seq(
+      def imageSeq[D <: Dim: NDSpace: NDImageToVtkOps](img: DiscreteScalarImage[D, Int]) = Seq(
         convertTo[D, Byte](img),
         convertTo[D, Short](img),
         convertTo[D, Int](img),


### PR DESCRIPTION
Proposal for a scheme to organize and name dimensionality related type classes, in order to make their purpose more clear. 
Mainly intended as a basis for discussions.