### PR TITLE
Introduce explicit type and case class for KLBasis

### DIFF
--- a/src/main/scala/scalismo/kernels/Kernel.scala
+++ b/src/main/scala/scalismo/kernels/Kernel.scala
@@ -19,6 +19,7 @@ import breeze.linalg.{ DenseVector, pinv, diag, DenseMatrix }
 import scalismo.common.{ DiscreteDomain, VectorField, Domain }
 import scalismo.geometry._
 import scalismo.numerics.{ RandomSVD, Sampler }
+import scalismo.statisticalmodel.LowRankGaussianProcess.{ Eigenpair, KLBasis }
 import scalismo.utils.Memoize
 
 abstract class PDKernel[D <: Dim] { self =>
@@ -177,7 +178,7 @@ object Kernel {
 
   def computeNystromApproximation[D <: Dim: NDSpace, DO <: Dim: NDSpace](k: MatrixValuedPDKernel[D, DO],
     numBasisFunctions: Int,
-    sampler: Sampler[D]): IndexedSeq[(Float, VectorField[D, DO])] = {
+    sampler: Sampler[D]): KLBasis[D, DO] = {
 
     // procedure for the nystrom approximation as described in 
     // Gaussian Processes for machine Learning (Rasmussen and Williamson), Chapter 4, Page 99
@@ -205,9 +206,9 @@ object Kernel {
 
     }
 
-    val lambdaISeq = lambda(0 until numParams).map(_.toFloat).toArray.toIndexedSeq
-    val phis = (0 until numParams).map(i => VectorField(k.domain, phi(i)_))
-    lambdaISeq.zip(phis)
+    for (i <- 0 until numParams) yield {
+      Eigenpair(lambda(i).toFloat, VectorField(k.domain, phi(i)_))
+    }
   }
 
 }

--- a/src/main/scala/scalismo/registration/GaussianProcessTransformationSpace.scala
+++ b/src/main/scala/scalismo/registration/GaussianProcessTransformationSpace.scala
@@ -17,6 +17,7 @@ package scalismo.registration
 
 import scalismo.geometry.{ Point, Dim }
 import scalismo.statisticalmodel.LowRankGaussianProcess
+import scalismo.statisticalmodel.LowRankGaussianProcess.Eigenpair
 
 import scala.NotImplementedError
 import TransformationSpace.ParameterVector
@@ -44,7 +45,7 @@ class GaussianProcessTransformationSpace[D <: Dim] private (gp: LowRankGaussianP
         val dim = x.dimensionality
         val J = DenseMatrix.zeros[Float](dim, gp.klBasis.size)
         (0 until gp.rank).map(i => {
-          val (lambda_i, phi_i) = gp.klBasis(i)
+          val Eigenpair(lambda_i, phi_i) = gp.klBasis(i)
           J(::, i) := (phi_i(x) * math.sqrt(lambda_i).toFloat).toBreezeVector
         })
         J

--- a/src/main/scala/scalismo/statisticalmodel/DiscreteLowRankGaussianProcess.scala
+++ b/src/main/scala/scalismo/statisticalmodel/DiscreteLowRankGaussianProcess.scala
@@ -74,7 +74,7 @@ case class DiscreteLowRankGaussianProcess[D <: Dim: NDSpace: CanBound, DO <: Dim
    * Returns the variance and associated basis function that defines the process.
    * The basis is the (discretized) Karhunen Loeve basis (e.g. it is obtained from a Mercer's decomposition of the covariance function
    */
-  def klBasis: DiscreteKLBasis[D, DO] = {
+  def klBasis: KLBasis[D, DO] = {
     for (i <- 0 until rank) yield {
       val eigenValue = variance(i)
       val eigenFunction = DiscreteVectorField.fromDenseVector[D, DO](domain, basisMatrix(::, i).toDenseVector)
@@ -228,7 +228,7 @@ case class DiscreteLowRankGaussianProcess[D <: Dim: NDSpace: CanBound, DO <: Dim
 object DiscreteLowRankGaussianProcess {
 
   case class Eigenpair[D <: Dim, DO <: Dim](eigenvalue: Float, eigenfunction: DiscreteVectorField[D, DO])
-  type DiscreteKLBasis[D <: Dim, DO <: Dim] = Seq[Eigenpair[D, DO]]
+  type KLBasis[D <: Dim, DO <: Dim] = Seq[Eigenpair[D, DO]]
 
   /**
    * Creates a new DiscreteLowRankGaussianProcess by discretizing the given gaussian process at the domain points.
@@ -260,7 +260,7 @@ object DiscreteLowRankGaussianProcess {
   }
 
   def apply[D <: Dim: NDSpace: CanBound, DO <: Dim: NDSpace](mean: DiscreteVectorField[D, DO],
-    klBasis: DiscreteKLBasis[D, DO]): DiscreteLowRankGaussianProcess[D, DO] =
+    klBasis: KLBasis[D, DO]): DiscreteLowRankGaussianProcess[D, DO] =
     {
 
       for (Eigenpair(_, phi) <- klBasis) {

--- a/src/main/scala/scalismo/statisticalmodel/DiscreteLowRankGaussianProcess.scala
+++ b/src/main/scala/scalismo/statisticalmodel/DiscreteLowRankGaussianProcess.scala
@@ -26,6 +26,8 @@ import scalismo.mesh.kdtree.KDTreeMap
 import scalismo.numerics.Sampler
 import scalismo.registration.Transformation
 import scalismo.statisticalmodel.DiscreteLowRankGaussianProcess._
+import scalismo.statisticalmodel.LowRankGaussianProcess.Eigenpair
+import scalismo.statisticalmodel.DiscreteLowRankGaussianProcess.{ Eigenpair => DiscreteEigenpair }
 
 /**
  * Represents a low-rank gaussian process, that is only defined at a finite, discrete set of points.
@@ -72,8 +74,12 @@ case class DiscreteLowRankGaussianProcess[D <: Dim: NDSpace: CanBound, DO <: Dim
    * Returns the variance and associated basis function that defines the process.
    * The basis is the (discretized) Karhunen Loeve basis (e.g. it is obtained from a Mercer's decomposition of the covariance function
    */
-  def klBasis: IndexedSeq[(Float, DiscreteVectorField[D, DO])] = {
-    for (i <- 0 until rank) yield (variance(i), DiscreteVectorField.fromDenseVector[D, DO](domain, basisMatrix(::, i).toDenseVector))
+  def klBasis: DiscreteKLBasis[D, DO] = {
+    for (i <- 0 until rank) yield {
+      val eigenValue = variance(i)
+      val eigenFunction = DiscreteVectorField.fromDenseVector[D, DO](domain, basisMatrix(::, i).toDenseVector)
+      DiscreteEigenpair(eigenValue, eigenFunction)
+    }
   }
 
   /**
@@ -122,13 +128,12 @@ case class DiscreteLowRankGaussianProcess[D <: Dim: NDSpace: CanBound, DO <: Dim
     val newDomain = DiscreteDomain.fromSeq(newPts)
 
     val newMean = DiscreteVectorField(newDomain, pointIds.toIndexedSeq.map(id => mean(id)))
-    val (lambdas, phis) = klBasis.unzip
 
-    val newPhis = for (phi <- phis) yield {
+    val newKLBasis = for (DiscreteEigenpair(lambda, phi) <- klBasis) yield {
       val newValues = pointIds.map(i => phi(i)).toIndexedSeq
-      DiscreteVectorField(newDomain, newValues)
+      DiscreteEigenpair(lambda, DiscreteVectorField(newDomain, newValues))
+
     }
-    val newKLBasis = lambdas zip newPhis
 
     DiscreteLowRankGaussianProcess(newMean, newKLBasis)
   }
@@ -204,7 +209,7 @@ case class DiscreteLowRankGaussianProcess[D <: Dim: NDSpace: CanBound, DO <: Dim
       Vector[DO](basisMatrix(closestPtId * outputDimensionality until (closestPtId + 1) * outputDimensionality, i).toArray)
     }
 
-    val interpolatedKLBasis = (0 until rank) map (i => (variance(i), VectorField(RealSpace[D], phi(i) _)))
+    val interpolatedKLBasis = (0 until rank) map (i => Eigenpair(variance(i), VectorField(RealSpace[D], phi(i) _)))
     new LowRankGaussianProcess(VectorField(RealSpace[D], meanFun), interpolatedKLBasis)
   }
 
@@ -222,6 +227,9 @@ case class DiscreteLowRankGaussianProcess[D <: Dim: NDSpace: CanBound, DO <: Dim
 
 object DiscreteLowRankGaussianProcess {
 
+  case class Eigenpair[D <: Dim, DO <: Dim](eigenvalue: Float, eigenfunction: DiscreteVectorField[D, DO])
+  type DiscreteKLBasis[D <: Dim, DO <: Dim] = Seq[Eigenpair[D, DO]]
+
   /**
    * Creates a new DiscreteLowRankGaussianProcess by discretizing the given gaussian process at the domain points.
    */
@@ -231,7 +239,7 @@ object DiscreteLowRankGaussianProcess {
     val outputDimensionality = implicitly[NDSpace[DO]].dimensionality
 
     // precompute all the at the given points
-    val (gpLambdas, gpPhis) = gp.klBasis.unzip
+
     val m = DenseVector.zeros[Float](points.size * outputDimensionality)
     for (xWithIndex <- points.zipWithIndex.par) {
       val (x, i) = xWithIndex
@@ -239,31 +247,34 @@ object DiscreteLowRankGaussianProcess {
     }
 
     val U = DenseMatrix.zeros[Float](points.size * outputDimensionality, gp.rank)
-    for (xWithIndex <- points.zipWithIndex.par; (phi_j, j) <- gpPhis.zipWithIndex) {
+    val lambdas = DenseVector.zeros[Float](gp.rank)
+    for (xWithIndex <- points.zipWithIndex.par; (eigenPair_j, j) <- gp.klBasis.zipWithIndex) {
+      val LowRankGaussianProcess.Eigenpair(lambda_j, phi_j) = eigenPair_j
       val (x, i) = xWithIndex
       val v = phi_j(x)
       U(i * outputDimensionality until (i + 1) * outputDimensionality, j) := phi_j(x).toBreezeVector
+      lambdas(j) = lambda_j
     }
 
-    val lambdas = new DenseVector[Float](gpLambdas.toArray)
     new DiscreteLowRankGaussianProcess[D, DO](domain, m, lambdas, U)
   }
 
   def apply[D <: Dim: NDSpace: CanBound, DO <: Dim: NDSpace](mean: DiscreteVectorField[D, DO],
-    klBasis: Seq[(Float, DiscreteVectorField[D, DO])]): DiscreteLowRankGaussianProcess[D, DO] =
+    klBasis: DiscreteKLBasis[D, DO]): DiscreteLowRankGaussianProcess[D, DO] =
     {
 
-      val (variances, basis) = klBasis.unzip
-      for (phi <- basis) {
+      for (Eigenpair(_, phi) <- klBasis) {
         require(phi.domain == mean.domain)
       }
 
       val domain = mean.domain
       val meanVec = mean.asBreezeVector
-      val varianceVec = DenseVector(variances.toArray)
+      val varianceVec = DenseVector.zeros[Float](klBasis.size)
       val basisMat = DenseMatrix.zeros[Float](meanVec.length, klBasis.size)
-      for ((phi, i) <- basis.zipWithIndex) yield {
+      for ((eigenPair, i) <- klBasis.zipWithIndex) yield {
+        val Eigenpair(lambda, phi) = eigenPair
         basisMat(::, i) := phi.asBreezeVector
+        varianceVec(i) = lambda
       }
       new DiscreteLowRankGaussianProcess(domain, meanVec, varianceVec, basisMat)
     }

--- a/src/main/scala/scalismo/statisticalmodel/LowRankGaussianProcess.scala
+++ b/src/main/scala/scalismo/statisticalmodel/LowRankGaussianProcess.scala
@@ -24,6 +24,7 @@ import scalismo.geometry.{ Point, SquareMatrix, NDSpace, Dim, Vector }
 import scalismo.kernels.{ MatrixValuedPDKernel, Kernel }
 import scalismo.numerics.Sampler
 import scalismo.registration.RigidTransformation
+import scalismo.statisticalmodel.LowRankGaussianProcess.{ Eigenpair, KLBasis }
 import scalismo.utils.Memoize
 
 /**
@@ -38,7 +39,7 @@ import scalismo.utils.Memoize
  * @tparam DO The dimensionality of the output space
  */
 class LowRankGaussianProcess[D <: Dim: NDSpace: CanBound, DO <: Dim: NDSpace](mean: VectorField[D, DO],
-  val klBasis: IndexedSeq[(Float, VectorField[D, DO])])
+  val klBasis: KLBasis[D, DO])
     extends GaussianProcess[D, DO](mean, LowRankGaussianProcess.covFromKLTBasis(klBasis)) {
 
   /**
@@ -54,7 +55,7 @@ class LowRankGaussianProcess[D <: Dim: NDSpace: CanBound, DO <: Dim: NDSpace](me
     require(klBasis.size == c.size)
     val f: Point[D] => Vector[DO] = x => {
       val deformationsAtX = (0 until klBasis.size).map(i => {
-        val (lambda_i, phi_i) = klBasis(i)
+        val Eigenpair(lambda_i, phi_i) = klBasis(i)
         phi_i(x) * c(i) * math.sqrt(lambda_i).toFloat
       })
       deformationsAtX.foldLeft(mean(x))(_ + _)
@@ -151,6 +152,9 @@ class LowRankGaussianProcess[D <: Dim: NDSpace: CanBound, DO <: Dim: NDSpace](me
  */
 object LowRankGaussianProcess {
 
+  case class Eigenpair[D <: Dim, DO <: Dim](eigenvalue: Float, eigenfunction: VectorField[D, DO])
+  type KLBasis[D <: Dim, DO <: Dim] = Seq[Eigenpair[D, DO]]
+
   /**
    * Perform a low-rank approximation of the Gaussian process using the Nystrom method. The sample points used for the nystrom method
    * are sampled using the given sample.
@@ -165,18 +169,17 @@ object LowRankGaussianProcess {
     new LowRankGaussianProcess[D, DO](gp.mean, kltBasis)
   }
 
-  private def covFromKLTBasis[D <: Dim: NDSpace: CanBound, DO <: Dim: NDSpace](eigenPairs: IndexedSeq[(Float, VectorField[D, DO])]): MatrixValuedPDKernel[D, DO] = {
+  private def covFromKLTBasis[D <: Dim: NDSpace: CanBound, DO <: Dim: NDSpace](klBasis: KLBasis[D, DO]): MatrixValuedPDKernel[D, DO] = {
     val dimOps = implicitly[NDSpace[DO]]
     val cov: MatrixValuedPDKernel[D, DO] = new MatrixValuedPDKernel[D, DO] {
-      override val domain = eigenPairs.headOption
-        .map { case (_, eigenPair) => eigenPair.domain }.getOrElse(RealSpace[D])
+      override val domain = klBasis.headOption
+        .map { case (Eigenpair(lambda, phi)) => phi.domain }.getOrElse(RealSpace[D])
 
       override def k(x: Point[D], y: Point[D]): SquareMatrix[DO] = {
         val ptDim = dimOps.dimensionality
-        val phis = eigenPairs.map(_._2)
 
         var outer = SquareMatrix.zeros[DO]
-        for ((lambda_i, phi_i) <- eigenPairs) {
+        for (Eigenpair(lambda_i, phi_i) <- klBasis) {
           outer = outer + (phi_i(x) outer phi_i(y)) * lambda_i
         }
         outer
@@ -196,13 +199,12 @@ object LowRankGaussianProcess {
     trainingData: IndexedSeq[(Point[D], Vector[DO], NDimensionalNormalDistribution[DO])]): LowRankGaussianProcess[D, DO] = {
     val outputDim = implicitly[NDSpace[DO]].dimensionality
 
-    val (lambdas, phis) = gp.klBasis.unzip
     val (_Minv, _QtL, yVec, mVec) = genericRegressionComputations(gp, trainingData)
     val mean_coeffs = (_Minv * _QtL).map(_.toFloat) * (yVec - mVec)
 
     val mean_p = gp.instance(mean_coeffs)
 
-    val D = breeze.linalg.diag(DenseVector(lambdas.map(math.sqrt(_)).toArray))
+    val D = breeze.linalg.diag(DenseVector(gp.klBasis.map(basisPair => Math.sqrt(basisPair.eigenvalue)).toArray))
     val Sigma = D * _Minv * D
     val SVD(innerUDbl, innerD2, _) = breeze.linalg.svd(Sigma)
     val innerU = innerUDbl.map(_.toFloat)
@@ -212,11 +214,10 @@ object LowRankGaussianProcess {
       val phisAtX = {
         val newPhisAtX = {
           val innerPhisAtx = DenseMatrix.zeros[Float](outputDim, gp.rank)
-          var j = 0;
-          while (j < phis.size) {
-            val phi_j = phis(j)
+
+          for ((eigenPair, j) <- gp.klBasis.zipWithIndex) {
+            val phi_j = eigenPair.eigenfunction
             innerPhisAtx(0 until outputDim, j) := phi_j(x).toBreezeVector
-            j += 1
           }
           innerPhisAtx
         }
@@ -226,12 +227,13 @@ object LowRankGaussianProcess {
       Vector[DO](vec.data)
     }
 
-    val phis_p = for (i <- 0 until phis.size) yield {
+    val klBasis_p = for (i <- 0 until gp.klBasis.size) yield {
       val phipi_memo = Memoize(phip(i), 1000)
-      (VectorField(gp.domain, (x: Point[D]) => phipi_memo(x)))
+      val newEf = (VectorField(gp.domain, (x: Point[D]) => phipi_memo(x)))
+      val newEv = innerD2(i).toFloat
+      Eigenpair(newEv, newEf)
     }
-    val lambdas_p = innerD2.toArray.map(_.toFloat).toIndexedSeq
-    new LowRankGaussianProcess[D, DO](mean_p, lambdas_p.zip(phis_p))
+    new LowRankGaussianProcess[D, DO](mean_p, klBasis_p)
   }
 
   /*
@@ -242,7 +244,6 @@ object LowRankGaussianProcess {
 
     val outputDimensionality = implicitly[NDSpace[DO]].dimensionality
 
-    val (lambdas, phis) = gp.klBasis.unzip
     val outputDim = outputDimensionality
 
     val dim = implicitly[NDSpace[DO]].dimensionality
@@ -254,9 +255,9 @@ object LowRankGaussianProcess {
     val meanValues = xs.map(gp.mean)
     val mVec = flatten(meanValues)
 
-    val Q = DenseMatrix.zeros[Double](trainingData.size * dim, phis.size)
-    for ((x_i, i) <- xs.zipWithIndex; (phi_j, j) <- phis.zipWithIndex) {
-      Q(i * dim until i * dim + dim, j) := phi_j(x_i).toBreezeVector.map(_.toDouble) * math.sqrt(lambdas(j))
+    val Q = DenseMatrix.zeros[Double](trainingData.size * dim, gp.klBasis.size)
+    for ((x_i, i) <- xs.zipWithIndex; (Eigenpair(lambda_j, phi_j), j) <- gp.klBasis.zipWithIndex) {
+      Q(i * dim until i * dim + dim, j) := phi_j(x_i).toBreezeVector.map(_.toDouble) * math.sqrt(lambda_j)
     }
 
     // What we are actually computing here is the following:
@@ -270,7 +271,7 @@ object LowRankGaussianProcess {
       QtL(::, i * dim until (i + 1) * dim) := QtL(::, i * dim until (i + 1) * dim) * breeze.linalg.inv(errDist.cov.toBreezeMatrix)
     }
 
-    val M = QtL * Q + DenseMatrix.eye[Double](phis.size)
+    val M = QtL * Q + DenseMatrix.eye[Double](gp.klBasis.size)
     val Minv = breeze.linalg.pinv(M)
 
     (Minv, QtL, yVec, mVec)
@@ -284,24 +285,22 @@ object LowRankGaussianProcess {
     val invTransform = rigidTransform.inverse
 
     val newDomain = gp.domain.warp(rigidTransform)
-    val (lambdas, phis) = gp.klBasis.unzip
 
     def newMean(pt: Point[D]): Vector[D] = {
       val ptOrigGp = invTransform(pt)
       rigidTransform(ptOrigGp + gp.mean(ptOrigGp)) - rigidTransform(ptOrigGp)
     }
 
-    val newPhis = phis.map(phi => {
+    val newBasis = for (Eigenpair(ev, phi) <- gp.klBasis) yield {
       def newPhi(pt: Point[D]): Vector[D] = {
         val ptOrigGp = invTransform(pt)
         rigidTransform(ptOrigGp + phi(ptOrigGp)) - pt
       }
-      VectorField(newDomain, newPhi _)
-    })
+      val newBasis = VectorField(newDomain, newPhi _)
+      Eigenpair(ev, newBasis)
+    }
 
-    val newEigenpairs = lambdas.zip(newPhis)
-
-    new LowRankGaussianProcess[D, D](VectorField(newDomain, newMean _), newEigenpairs)
+    new LowRankGaussianProcess[D, D](VectorField(newDomain, newMean _), newBasis)
   }
 
 }

--- a/src/main/scala/scalismo/statisticalmodel/StatisticalModel.scala
+++ b/src/main/scala/scalismo/statisticalmodel/StatisticalModel.scala
@@ -23,6 +23,7 @@ import scalismo.mesh.{ Mesh, TriangleMesh }
 import scalismo.geometry._
 
 import scalismo.registration.{ Transformation, RigidTransformation }
+import scalismo.statisticalmodel.DiscreteLowRankGaussianProcess.Eigenpair
 
 /**
  * A StatisticalMeshModel is isomorphic to a [[DiscreteLowRankGaussianProcess]]. The difference is that while the DiscreteLowRankGaussianProcess
@@ -133,7 +134,7 @@ case class StatisticalMeshModel private (val referenceMesh: TriangleMesh, val gp
 
     val newBasisMat = DenseMatrix.zeros[Float](gp.basisMatrix.rows, gp.basisMatrix.cols)
 
-    for (((_, ithKlBasis), i) <- gp.klBasis.zipWithIndex) {
+    for ((Eigenpair(_, ithKlBasis), i) <- gp.klBasis.zipWithIndex) {
       val newIthBasis = for ((pt, basisAtPoint) <- ithKlBasis.pointsWithValues) yield {
         rigidTransform(pt + basisAtPoint) - rigidTransform(pt)
       }

--- a/src/test/scala/scalismo/registration/KernelTransformationTests.scala
+++ b/src/test/scala/scalismo/registration/KernelTransformationTests.scala
@@ -23,6 +23,7 @@ import scalismo.geometry.Point.implicits._
 import scalismo.geometry.Vector.implicits._
 import scalismo.geometry.Index.implicits._
 import scalismo.numerics.{ Integrator, GridSampler, RandomSVD, UniformSampler }
+import scalismo.statisticalmodel.LowRankGaussianProcess.Eigenpair
 import scala.language.implicitConversions
 import org.scalatest.{ Matchers, FunSpec }
 import org.scalatest.matchers.ShouldMatchers
@@ -45,7 +46,7 @@ class KernelTransformationTests extends FunSpec with Matchers {
 
       def approxKernel(x: Point[_1D], y: Point[_1D]) = {
         (0 until eigPairs.size).foldLeft(0.0)((sum, i) => {
-          val (lambda_i, phi_i) = eigPairs(i)
+          val Eigenpair(lambda_i, phi_i) = eigPairs(i)
           sum + lambda_i * phi_i(x)(0) * phi_i(y)(0)
         })
       }
@@ -65,7 +66,7 @@ class KernelTransformationTests extends FunSpec with Matchers {
       val sampler = UniformSampler(domain, numPoints)
       val (points, _) = sampler.sample.unzip
       val eigPairsApprox = Kernel.computeNystromApproximation(scalarKernel, 10, sampler)
-      val approxLambdas = eigPairsApprox.map(_._1)
+      val approxLambdas = eigPairsApprox.map(_.eigenvalue)
 
       val realKernelMatrix = DenseMatrix.zeros[Double](numPoints * kernelDim, numPoints * kernelDim)
 
@@ -91,7 +92,7 @@ class KernelTransformationTests extends FunSpec with Matchers {
       val (pts, _) = sampler.sample.unzip
 
       val eigPairsApprox = Kernel.computeNystromApproximation(ndKernel, 10, sampler)
-      val approxLambdas = eigPairsApprox.map(_._1)
+      val approxLambdas = eigPairsApprox.map(_.eigenvalue)
 
       val realKernelMatrix = DenseMatrix.zeros[Double](pts.size * kernelDim, pts.size * kernelDim)
 
@@ -117,7 +118,7 @@ class KernelTransformationTests extends FunSpec with Matchers {
 
       for (i <- 0 until 20) {
 
-        val (lambda_i, phi_i) = eigPairs(i)
+        val Eigenpair(lambda_i, phi_i) = eigPairs(i)
         def p(x: Point[_1D]) = 1.0 / domain.volume // the eigenfunction is orthogonal with respect to the measure p(x) (from the sampler)
         val phiImg = DifferentiableScalarImage(domain, (x: Point[_1D]) => phi_i(x)(0) * phi_i(x)(0) * p(x), (pt: Point[_1D]) => Vector(0.0))
 

--- a/src/test/scala/scalismo/statisticalmodel/GaussianProcessTests.scala
+++ b/src/test/scala/scalismo/statisticalmodel/GaussianProcessTests.scala
@@ -335,8 +335,8 @@ class GaussianProcessTests extends FunSpec with Matchers {
 
       val meanPosterior = posteriorGP.mean
       val meanPosteriorSpecialized = discretePosteriorGP.mean
-      val phi1Posterior = posteriorGP.klBasis(0)._2
-      val phi1PosteriorSpezialized = discretePosteriorGP.klBasis(0)._2
+      val phi1Posterior = posteriorGP.klBasis(0).eigenfunction
+      val phi1PosteriorSpezialized = discretePosteriorGP.klBasis(0).eigenfunction
 
       // both posterior processes should give the same values at the specialized points
       for ((pt, id) <- f.discretizationPoints.zipWithIndex) {


### PR DESCRIPTION
KLBasis used to be defined as Seq[(Float, VectorField)]. We introduced a type alias
for the seq and a case class for the tuple (Float, VectorField). The changes were made for
DiscreteLowRankGaussianProcess and LowRankGaussianProcess.

Before merging this pull request, we should discuss the terminology, as these things will be all visible to the user and somehow define how the user will think about things. Any comments?