### PR TITLE
use newest nativelibs, update tests accordingly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,5 @@ scala:
 
 script:
   - jdk_switcher use oraclejdk8
-  - travis_wait sbt ++$TRAVIS_SCALA_VERSION -Djava.awt.headless=true compile test
+  - sbt ++$TRAVIS_SCALA_VERSION -Djava.awt.headless=true compile test
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,5 @@ scala:
 
 script:
   - jdk_switcher use oraclejdk8
-  - sbt ++$TRAVIS_SCALA_VERSION -Djava.awt.headless=true compile test
+  - travis_wait sbt ++$TRAVIS_SCALA_VERSION -Djava.awt.headless=true compile test
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,15 @@ language: scala
 env:
  - SCALISMO_PLATFORM=linux64
 
-cache:
-  directories:
-  - $HOME/.ivy2
-  - $HOME/.sbt
+## Caching seems to cause problems of its own, so we leave it commented for now.
+## We use travis_wait instead (see below in the script: section) to give the build more time. 
+#cache:
+#  directories:
+#  - $HOME/.ivy2
+#  - $HOME/.sbt
 
-before_cache:
-  - rm -f $HOME/.ivy2/.*.lock $HOME/.ivy2/*.lock
+#before_cache:
+#  - rm -f $HOME/.ivy2/.*.lock $HOME/.ivy2/*.lock
 
 scala:
   - 2.10.4
@@ -17,5 +19,5 @@ scala:
 
 script:
   - jdk_switcher use oraclejdk8
-  - sbt ++$TRAVIS_SCALA_VERSION -Djava.awt.headless=true compile test
+  - travis_wait sbt ++$TRAVIS_SCALA_VERSION -Djava.awt.headless=true compile test
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,6 @@ scala:
 
 script:
   - jdk_switcher use oraclejdk8
-  - travis_wait sbt ++$TRAVIS_SCALA_VERSION -Djava.awt.headless=true compile test
+  - travis_wait sbt ++$TRAVIS_SCALA_VERSION update
+  - sbt ++$TRAVIS_SCALA_VERSION -Djava.awt.headless=true compile test
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: scala
 
+env:
+ - SCALISMO_PLATFORM=linux64
+
 cache:
   directories:
   - $HOME/.ivy2

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -25,13 +25,13 @@ object BuildSettings {
 
   // nativelibs implementation to use (e.g., "linux64"). If not explicitly set, use "all"
   // which contains all supported platforms.
-  val ScalismoPlatform = {
+  val scalismoPlatform = {
     val env = System.getenv("SCALISMO_PLATFORM")
     if (env != null) env else "all"
   }
 }
 
-// Shell prompt which show the current project,
+// Shell prompt which shows the current project,
 // git branch and build version
 object ShellPrompt {
   val buildShellPrompt = {
@@ -62,13 +62,13 @@ object Resolvers {
 }
 
 object Dependencies {
-  import BuildSettings.ScalismoPlatform
+  import BuildSettings.scalismoPlatform
   val scalatest = "org.scalatest" %% "scalatest" % "2.2+" % "test"
   val breezeMath = "org.scalanlp" %% "breeze" % "0.11+"
   val breezeNative = "org.scalanlp" %% "breeze-natives" % "0.11+"
   val sprayJson = "io.spray" %% "spray-json" % "1.2.6"
   val scalismoNativeStub = "ch.unibas.cs.gravis" % "scalismo-native-stub" % "2.1.+"
-  val scalismoNativeImpl = "ch.unibas.cs.gravis" % s"scalismo-native-$ScalismoPlatform" % "2.1.+" % "test"
+  val scalismoNativeImpl = "ch.unibas.cs.gravis" % s"scalismo-native-$scalismoPlatform" % "2.1.+" % "test"
   val spire = "org.spire-math" %% "spire" % "0.9.0"
   val slf4jNop = "org.slf4j" % "slf4j-nop" % "1.6.0" // this silences slf4j complaints in registration classes
 }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -22,6 +22,13 @@ object BuildSettings {
     javacOptions ++= Seq("-source", "1.6", "-target", "1.6"),
     scalacOptions ++= Seq("-encoding", "UTF-8", "-Xlint", "-deprecation", "-unchecked", "-feature", "-target:jvm-1.6"),
     shellPrompt := ShellPrompt.buildShellPrompt)
+
+  // nativelibs implementation to use (e.g., "linux64"). If not explicitly set, use "all"
+  // which contains all supported platforms.
+  val ScalismoPlatform = {
+    val env = System.getenv("SCALISMO_PLATFORM")
+    if (env != null) env else "all"
+  }
 }
 
 // Shell prompt which show the current project,
@@ -55,12 +62,13 @@ object Resolvers {
 }
 
 object Dependencies {
+  import BuildSettings.ScalismoPlatform
   val scalatest = "org.scalatest" %% "scalatest" % "2.2+" % "test"
   val breezeMath = "org.scalanlp" %% "breeze" % "0.11+"
   val breezeNative = "org.scalanlp" %% "breeze-natives" % "0.11+"
   val sprayJson = "io.spray" %% "spray-json" % "1.2.6"
   val scalismoNativeStub = "ch.unibas.cs.gravis" % "scalismo-native-stub" % "2.1.+"
-  val scalismoNativeImpl = "ch.unibas.cs.gravis" % "scalismo-native-all" % "2.1.+" % "test"
+  val scalismoNativeImpl = "ch.unibas.cs.gravis" % s"scalismo-native-$ScalismoPlatform" % "2.1.+" % "test"
   val spire = "org.spire-math" %% "spire" % "0.9.0"
   val slf4jNop = "org.slf4j" % "slf4j-nop" % "1.6.0" // this silences slf4j complaints in registration classes
 }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -59,9 +59,10 @@ object Dependencies {
   val breezeMath = "org.scalanlp" %% "breeze" % "0.11+"
   val breezeNative = "org.scalanlp" %% "breeze-natives" % "0.11+"
   val sprayJson = "io.spray" %% "spray-json" % "1.2.6"
-  val scalismoNativeStub = "ch.unibas.cs.gravis" % "scalismo-native-stub" % "2.0.+"
-  val scalismoNativeImpl = "ch.unibas.cs.gravis" % "scalismo-native-all" % "2.0.+" % "test"
+  val scalismoNativeStub = "ch.unibas.cs.gravis" % "scalismo-native-stub" % "2.1.+"
+  val scalismoNativeImpl = "ch.unibas.cs.gravis" % "scalismo-native-all" % "2.1.+" % "test"
   val spire = "org.spire-math" %% "spire" % "0.9.0"
+  val slf4jNop = "org.slf4j" % "slf4j-nop" % "1.6.0" // this silences slf4j complaints in registration classes
 }
 
 object STKBuild extends Build {
@@ -96,5 +97,7 @@ object STKBuild extends Build {
     scalismoNativeStub,
     scalismoNativeImpl,
     sprayJson,
-    spire)
+    spire,
+    slf4jNop
+  )
 }

--- a/src/test/scala/scalismo/ScalismoTestSuite.scala
+++ b/src/test/scala/scalismo/ScalismoTestSuite.scala
@@ -1,0 +1,7 @@
+package scalismo
+
+import org.scalatest.{ Matchers, FunSpec }
+
+class ScalismoTestSuite extends FunSpec with Matchers {
+  scalismo.initialize()
+}

--- a/src/test/scala/scalismo/geometry/GeometryTests.scala
+++ b/src/test/scala/scalismo/geometry/GeometryTests.scala
@@ -15,13 +15,12 @@
  */
 package scalismo.geometry
 
-import org.scalatest.{ Matchers, FunSpec }
-import org.scalatest.matchers.ShouldMatchers
-import breeze.linalg.DenseMatrix
-import breeze.linalg.DenseVector
+import breeze.linalg.{ DenseMatrix, DenseVector }
+import scalismo.ScalismoTestSuite
+
 import scala.language.implicitConversions
 
-class GeometryTests extends FunSpec with Matchers {
+class GeometryTests extends ScalismoTestSuite {
 
   implicit def doubleToFloat(d: Double) = d.toFloat
 

--- a/src/test/scala/scalismo/image/ImageTests.scala
+++ b/src/test/scala/scalismo/image/ImageTests.scala
@@ -15,23 +15,24 @@
  */
 package scalismo.image
 
-import org.scalatest.{ Matchers, FunSpec }
-import org.scalatest.matchers.ShouldMatchers
-import breeze.linalg.DenseVector
-import scalismo.common.{ Scalar, ScalarArray, BoxDomain }
-import scalismo.io.ImageIO
-import scalismo.registration.TranslationSpace
-import scala.language.implicitConversions
 import java.io.File
-import scalismo.geometry._
+
+import breeze.linalg.DenseVector
+import scalismo.ScalismoTestSuite
+import scalismo.common.{ BoxDomain, Scalar, ScalarArray }
+import scalismo.geometry.Index.implicits._
 import scalismo.geometry.Point.implicits._
 import scalismo.geometry.Vector.implicits._
-import scalismo.geometry.Index.implicits._
+import scalismo.geometry._
+import scalismo.io.ImageIO
+import scalismo.registration.TranslationSpace
 
+import scala.language.implicitConversions
 import scala.reflect.ClassTag
 
-class ImageTests extends FunSpec with Matchers {
+class ImageTests extends ScalismoTestSuite {
   implicit def doubleToFloat(d: Double) = d.toFloat
+
   implicit def arrayToScalarArray[A: Scalar: ClassTag](a: Array[A]) = ScalarArray(a)
 
   describe("A discrete 1D image") {
@@ -112,7 +113,7 @@ class ImageTests extends FunSpec with Matchers {
   }
 }
 
-class DomainTest extends FunSpec with Matchers {
+class DomainTest extends ScalismoTestSuite {
   describe("a domain") {
     it("correctly reports the number of points") {
       val domain = DiscreteImageDomain[_2D]((0.0f, 0.0f), (1.0f, 2.0f), (42, 49))

--- a/src/test/scala/scalismo/image/InterpolationTest.scala
+++ b/src/test/scala/scalismo/image/InterpolationTest.scala
@@ -15,23 +15,23 @@
  */
 package scalismo.image
 
+import java.io.File
+
+import org.scalatest.PrivateMethodTester
+import scalismo.ScalismoTestSuite
+import scalismo.common.ScalarArray.implicits._
+import scalismo.geometry.Index.implicits._
+import scalismo.geometry.Point.implicits._
+import scalismo.geometry.Vector.implicits._
+import scalismo.geometry._
 import scalismo.io.ImageIO
 
 import scala.language.implicitConversions
-import scalismo.geometry._
-import scalismo.geometry.Point.implicits._
-import scalismo.geometry.Vector.implicits._
-import scalismo.geometry.Index.implicits._
 
-import org.scalatest.{ Matchers, FunSpec, PrivateMethodTester }
-import org.scalatest.matchers.ShouldMatchers
-import java.io.File
-import scalismo.common.ScalarArray.implicits._
-
-class InterpolationTest extends FunSpec with Matchers with PrivateMethodTester {
+class InterpolationTest extends ScalismoTestSuite with PrivateMethodTester {
 
   implicit def doubleToFloat(d: Double) = d.toFloat
-  scalismo.initialize()
+
   describe("A 1D Interpolation with 0rd order bspline") {
 
     it("interpolates the values for origin 2.3 and spacing 1.5") {

--- a/src/test/scala/scalismo/image/ResampleTests.scala
+++ b/src/test/scala/scalismo/image/ResampleTests.scala
@@ -15,14 +15,12 @@
  */
 package scalismo.image
 
-import org.scalatest.{ Matchers, FunSpec }
-import org.scalatest.matchers.ShouldMatchers
 import java.io.File
 
+import scalismo.ScalismoTestSuite
 import scalismo.io.ImageIO
 
-class ResampleTests extends FunSpec with Matchers {
-  scalismo.initialize()
+class ResampleTests extends ScalismoTestSuite {
 
   describe("Resampling a 2D image") {
 

--- a/src/test/scala/scalismo/io/ActiveShapeModelIOTests.scala
+++ b/src/test/scala/scalismo/io/ActiveShapeModelIOTests.scala
@@ -15,24 +15,19 @@
  */
 package scalismo.io
 
-import org.scalatest.{ Matchers, FunSpec }
-import org.scalatest.matchers.ShouldMatchers
 import java.io.File
+
 import breeze.linalg.{ DenseMatrix, DenseVector }
+import scalismo.ScalismoTestSuite
 import scalismo.common.SpatiallyIndexedDiscreteDomain
-import scalismo.image.ScalarImage
 import scalismo.numerics.FixedPointsUniformMeshSampler3D
-import scalismo.statisticalmodel.{ ASMProfileDistributions, MultivariateNormalDistribution, ActiveShapeModel }
 import scalismo.statisticalmodel.ActiveShapeModel.NormalDirectionFeatureExtractor
-import scala.util.{ Try, Success }
-import ncsa.hdf.`object`.Group
+import scalismo.statisticalmodel.{ ASMProfileDistributions, ActiveShapeModel, MultivariateNormalDistribution }
 
 /**
  * Created by Luethi on 09.03.14.
  */
-class ActiveShapeModelIOTests extends FunSpec with Matchers {
-
-  scalismo.initialize()
+class ActiveShapeModelIOTests extends ScalismoTestSuite {
 
   private def createTmpH5File(): File = {
     val f = File.createTempFile("hdf5file", ".h5")

--- a/src/test/scala/scalismo/io/HDF5UtilsTests.scala
+++ b/src/test/scala/scalismo/io/HDF5UtilsTests.scala
@@ -15,16 +15,14 @@
  */
 package scalismo.io
 
-import org.scalatest.{ Matchers, FunSpec }
-import org.scalatest.matchers.ShouldMatchers
 import java.io.File
+
+import scalismo.ScalismoTestSuite
 
 /**
  * Created by luethi on 2/19/14.
  */
-class HDF5UtilsTests extends FunSpec with Matchers {
-
-  scalismo.initialize()
+class HDF5UtilsTests extends ScalismoTestSuite {
 
   def createTmpH5File(): File = {
     val f = File.createTempFile("hdf5file", ".h5")

--- a/src/test/scala/scalismo/io/ImageIOTests.scala
+++ b/src/test/scala/scalismo/io/ImageIOTests.scala
@@ -19,20 +19,18 @@ import java.io.File
 
 import breeze.linalg.{ DenseMatrix, DenseVector }
 import niftijio.NiftiVolume
-import org.scalatest.{ FunSpec, Matchers }
+import scalismo.ScalismoTestSuite
 import scalismo.common.{ Scalar, ScalarArray }
 import scalismo.geometry._
 import scalismo.image.{ DiscreteImageDomain, DiscreteScalarImage }
-import scalismo.utils.{ Benchmark, CanConvertToVtk }
+import scalismo.utils.CanConvertToVtk
 import spire.math.{ UByte, UInt, ULong, UShort }
 
 import scala.reflect.ClassTag
 import scala.reflect.runtime.universe.{ TypeTag, typeOf }
 import scala.util.{ Failure, Success, Try }
 
-class ImageIOTests extends FunSpec with Matchers {
-
-  scalismo.initialize()
+class ImageIOTests extends ScalismoTestSuite {
 
   def equalImages(img1: DiscreteScalarImage[_3D, _], img2: DiscreteScalarImage[_3D, _]): Boolean = {
 

--- a/src/test/scala/scalismo/io/LandmarkIOTests.scala
+++ b/src/test/scala/scalismo/io/LandmarkIOTests.scala
@@ -17,15 +17,14 @@ package scalismo.io
 
 import java.io.{ ByteArrayOutputStream, File, InputStream }
 
-import org.scalatest.{ Matchers, FunSpec }
-import org.scalatest.matchers.ShouldMatchers
+import scalismo.ScalismoTestSuite
 import scalismo.geometry._
 import scalismo.statisticalmodel.NDimensionalNormalDistribution
 
 import scala.io.Source
 import scala.language.implicitConversions
 
-class LandmarkIOTests extends FunSpec with Matchers {
+class LandmarkIOTests extends ScalismoTestSuite {
 
   implicit def doubleToFloat(d: Double): Float = d.toFloat
 

--- a/src/test/scala/scalismo/io/MeshIOTests.scala
+++ b/src/test/scala/scalismo/io/MeshIOTests.scala
@@ -15,17 +15,13 @@
  */
 package scalismo.io
 
-import scala.language.implicitConversions
-import org.scalatest.{ Matchers, FunSpec, FailureMessages }
-import org.scalatest.matchers.ShouldMatchers
 import java.io.File
-import scala.util.Failure
-import scala.util.Success
-import org.scalatest.exceptions.TestFailedException
 
-class MeshIOTests extends FunSpec with Matchers {
+import scalismo.ScalismoTestSuite
 
-  scalismo.initialize()
+import scala.language.implicitConversions
+
+class MeshIOTests extends ScalismoTestSuite {
 
   describe("MeshIO") {
 

--- a/src/test/scala/scalismo/io/StatismoIOTest.scala
+++ b/src/test/scala/scalismo/io/StatismoIOTest.scala
@@ -15,16 +15,13 @@
  */
 package scalismo.io
 
-import org.scalatest.{ Matchers, FunSpec }
-import org.scalatest.matchers.ShouldMatchers
 import java.io.File
+
+import scalismo.ScalismoTestSuite
 import scalismo.io.StatismoIO.writeStatismoMeshModel
-import breeze.linalg.DenseVector
 import scalismo.statisticalmodel.StatisticalMeshModel
 
-class StatismoIOTest extends FunSpec with Matchers {
-
-  scalismo.initialize()
+class StatismoIOTest extends ScalismoTestSuite {
 
   describe("a Statismo Mesh Model") {
 

--- a/src/test/scala/scalismo/kernels/KernelTests.scala
+++ b/src/test/scala/scalismo/kernels/KernelTests.scala
@@ -15,18 +15,15 @@
  */
 package scalismo.kernels
 
-import org.scalatest.{ Matchers, FunSpec }
-import org.scalatest.matchers.ShouldMatchers
-import scalismo.common.{ RealSpace, VectorField, BoxDomain }
-import scalismo.geometry.{ _3D, _1D, Point, Vector }
-import Point.implicits._
-import scalismo.geometry
+import scalismo.common.{ BoxDomain, RealSpace, VectorField }
+import scalismo.geometry.Point.implicits._
+import scalismo.geometry.{ Point, Vector, _1D, _3D }
 import scalismo.numerics.UniformSampler
 import scalismo.registration.Transformation
 import scalismo.statisticalmodel.{ GaussianProcess, LowRankGaussianProcess }
+import scalismo.{ ScalismoTestSuite, geometry }
 
-class KernelTests extends FunSpec with Matchers {
-  scalismo.initialize()
+class KernelTests extends ScalismoTestSuite {
 
   describe("a Kernel") {
     it("yields correct multiple when  multiplied by a scalar") {

--- a/src/test/scala/scalismo/mesh/MeshMetricsTests.scala
+++ b/src/test/scala/scalismo/mesh/MeshMetricsTests.scala
@@ -17,15 +17,11 @@ package scalismo.mesh
 
 import java.io.File
 
-import org.scalatest.{ Matchers, FunSpec }
-import org.scalatest.matchers.ShouldMatchers
-import org.scalatest.matchers.ShouldMatchers
-import scalismo.geometry.{ _3D, Point, Vector }
+import scalismo.ScalismoTestSuite
+import scalismo.geometry.{ Point, Vector, _3D }
 import scalismo.io.MeshIO
 
-class MeshMetricsTests extends FunSpec with Matchers {
-
-  scalismo.initialize()
+class MeshMetricsTests extends ScalismoTestSuite {
 
   val path = getClass().getResource("/facemesh.stl").getPath
   val mesh = MeshIO.readMesh(new File(path)).get

--- a/src/test/scala/scalismo/mesh/MeshTests.scala
+++ b/src/test/scala/scalismo/mesh/MeshTests.scala
@@ -15,22 +15,20 @@
  */
 package scalismo.mesh
 
-import scalismo.geometry.{ _3D, Point }
+import java.io.File
+
+import breeze.linalg.DenseVector
+import scalismo.ScalismoTestSuite
+import scalismo.geometry.Point.implicits._
+import scalismo.geometry.{ Point, _3D }
 import scalismo.io.MeshIO
-import scalismo.registration.{ ScalingSpace, RotationSpace }
+import scalismo.registration.{ RotationSpace, ScalingSpace }
 
 import scala.language.implicitConversions
-import scalismo.geometry.Point.implicits._
-import java.io.File
-import org.scalatest.{ Matchers, FunSpec }
-import org.scalatest.matchers.ShouldMatchers
-import breeze.linalg.DenseVector
 
-class MeshTests extends FunSpec with Matchers {
+class MeshTests extends ScalismoTestSuite {
 
   implicit def doubleToFloat(d: Double) = d.toFloat
-
-  scalismo.initialize()
 
   describe("a mesh") {
     val path = getClass.getResource("/facemesh.stl").getPath

--- a/src/test/scala/scalismo/numerics/IntegrationTest.scala
+++ b/src/test/scala/scalismo/numerics/IntegrationTest.scala
@@ -15,18 +15,15 @@
  */
 package scalismo.numerics
 
+import scalismo.ScalismoTestSuite
 import scalismo.common.BoxDomain
-import scalismo.geometry._
-import scalismo.image.{ DifferentiableScalarImage, ScalarImage, DiscreteImageDomain }
 import scalismo.geometry.Point.implicits._
-import scalismo.geometry.Index.implicits._
-import scalismo.geometry.Vector.implicits._
+import scalismo.geometry._
+import scalismo.image.{ DifferentiableScalarImage, DiscreteImageDomain, ScalarImage }
 
 import scala.language.implicitConversions
-import org.scalatest.{ Matchers, FunSpec }
-import org.scalatest.matchers.ShouldMatchers
 
-class IntegrationTest extends FunSpec with Matchers {
+class IntegrationTest extends ScalismoTestSuite {
 
   implicit def doubleToFloat(d: Double) = d.toFloat
 

--- a/src/test/scala/scalismo/numerics/OptimizerTests.scala
+++ b/src/test/scala/scalismo/numerics/OptimizerTests.scala
@@ -15,13 +15,10 @@
  */
 package scalismo.numerics
 
-import org.scalatest.{ Matchers, FunSpec }
-import org.scalatest.matchers.ShouldMatchers
 import breeze.linalg.DenseVector
-import scala.collection.mutable.Subscriber
-import scala.collection.mutable.Publisher
+import scalismo.ScalismoTestSuite
 
-class OptimizerTests extends FunSpec with Matchers {
+class OptimizerTests extends ScalismoTestSuite {
 
   describe("The GradientDescentOptimizer") {
 

--- a/src/test/scala/scalismo/numerics/RandomSVDTest.scala
+++ b/src/test/scala/scalismo/numerics/RandomSVDTest.scala
@@ -17,13 +17,11 @@ package scalismo.numerics
 
 import breeze.linalg.DenseMatrix
 import breeze.linalg.svd.SVD
-import org.scalatest.{ Matchers, FunSpec }
-import org.scalatest.matchers.ShouldMatchers
+import scalismo.ScalismoTestSuite
 import scalismo.geometry.{ Point, _1D }
-import scalismo.kernels.{ GaussianKernel, UncorrelatedKernel, Kernel }
-import scalismo.utils.Benchmark
+import scalismo.kernels.{ GaussianKernel, Kernel, UncorrelatedKernel }
 
-class RandomSVDTest extends FunSpec with Matchers {
+class RandomSVDTest extends ScalismoTestSuite {
 
   describe("The random svd") {
 

--- a/src/test/scala/scalismo/numerics/SamplerTests.scala
+++ b/src/test/scala/scalismo/numerics/SamplerTests.scala
@@ -17,8 +17,7 @@ package scalismo.numerics
 
 import java.io.File
 
-import org.scalatest.{ Matchers, FunSpec }
-import org.scalatest.matchers.ShouldMatchers
+import scalismo.ScalismoTestSuite
 import scalismo.geometry._
 import scalismo.io.MeshIO
 import scalismo.mesh.TriangleMesh
@@ -26,8 +25,7 @@ import scalismo.utils.Memoize
 
 import scala.util.Random
 
-class SamplerTests extends FunSpec with Matchers {
-  scalismo.initialize()
+class SamplerTests extends ScalismoTestSuite {
 
   val facepath = getClass.getResource("/facemesh.stl").getPath
   val facemesh = MeshIO.readMesh(new File(facepath)).get

--- a/src/test/scala/scalismo/registration/KernelTransformationTests.scala
+++ b/src/test/scala/scalismo/registration/KernelTransformationTests.scala
@@ -15,20 +15,18 @@
  */
 package scalismo.registration
 
-import scalismo.common.BoxDomain
-import scalismo.image.{ DifferentiableScalarImage, DiscreteImageDomain }
-import scalismo.kernels.{ Kernel, GaussianKernel, UncorrelatedKernel }
-import scalismo.geometry._
-import scalismo.geometry.Point.implicits._
-import scalismo.geometry.Vector.implicits._
-import scalismo.geometry.Index.implicits._
-import scalismo.numerics.{ Integrator, GridSampler, RandomSVD, UniformSampler }
-import scala.language.implicitConversions
-import org.scalatest.{ Matchers, FunSpec }
-import org.scalatest.matchers.ShouldMatchers
 import breeze.linalg.DenseMatrix
+import scalismo.ScalismoTestSuite
+import scalismo.common.BoxDomain
+import scalismo.geometry.Point.implicits._
+import scalismo.geometry._
+import scalismo.image.{ DifferentiableScalarImage, DiscreteImageDomain }
+import scalismo.kernels.{ GaussianKernel, Kernel, UncorrelatedKernel }
+import scalismo.numerics.{ GridSampler, Integrator, RandomSVD, UniformSampler }
 
-class KernelTransformationTests extends FunSpec with Matchers {
+import scala.language.implicitConversions
+
+class KernelTransformationTests extends ScalismoTestSuite {
 
   implicit def doubleToFloat(d: Double) = d.toFloat
 

--- a/src/test/scala/scalismo/registration/MetricTests.scala
+++ b/src/test/scala/scalismo/registration/MetricTests.scala
@@ -15,15 +15,14 @@
  */
 package scalismo.registration
 
-import org.scalatest.{ Matchers, FunSpec }
-import org.scalatest.matchers.ShouldMatchers
+import scalismo.ScalismoTestSuite
 import scalismo.common.BoxDomain
-import scalismo.image.DifferentiableScalarImage
-import scalismo.geometry._
 import scalismo.geometry.Point.implicits._
-import scalismo.numerics.{ UniformSampler, Integrator }
+import scalismo.geometry._
+import scalismo.image.DifferentiableScalarImage
+import scalismo.numerics.UniformSampler
 
-class MetricTests extends FunSpec with Matchers {
+class MetricTests extends ScalismoTestSuite {
 
   describe("A mean squares metric (1D)") {
     it("returns 0 if provided twice the same image") {

--- a/src/test/scala/scalismo/registration/RegistrationTests.scala
+++ b/src/test/scala/scalismo/registration/RegistrationTests.scala
@@ -15,23 +15,20 @@
  */
 package scalismo.registration
 
-import scalismo.image.DiscreteScalarImage
+import java.io.File
+
+import breeze.linalg.DenseVector
+import scalismo.ScalismoTestSuite
+import scalismo.geometry._
 import scalismo.io.{ ImageIO, MeshIO }
-import scalismo.numerics.{ GradientDescentOptimizer, LBFGSOptimizer, UniformSampler, Integrator }
+import scalismo.numerics.{ GradientDescentOptimizer, LBFGSOptimizer, UniformSampler }
 
 import scala.language.implicitConversions
-import org.scalatest.{ Matchers, FunSpec }
-import java.io.File
-import scalismo.geometry._
-import breeze.linalg.DenseVector
-import org.scalatest.matchers.ShouldMatchers
-import breeze.linalg.DenseMatrix
 
-class RegistrationTests extends FunSpec with Matchers {
+class RegistrationTests extends ScalismoTestSuite {
 
   implicit def doubleToFloat(d: Double) = d.toFloat
 
-  scalismo.initialize()
   describe("A 2D rigid landmark based registration") {
     it("can retrieve correct parameters") {
       val points: IndexedSeq[Point[_2D]] = IndexedSeq(Point(0.0, 0.0), Point(1.0, 4.0), Point(2.0, 0.0))

--- a/src/test/scala/scalismo/registration/TransformationTests.scala
+++ b/src/test/scala/scalismo/registration/TransformationTests.scala
@@ -15,23 +15,22 @@
  */
 package scalismo.registration
 
-import scalismo.image.{ DifferentiableScalarImage, DiscreteImageDomain }
-import scalismo.io.{ MeshIO, ImageIO }
-import scalismo.geometry.Point.implicits._
-import scalismo.geometry.Index.implicits._
-import scalismo.geometry.Vector.implicits._
-import scala.language.implicitConversions
-import org.scalatest.{ Matchers, FunSpec }
-import org.scalatest.matchers.ShouldMatchers
 import java.io.File
-import breeze.linalg.DenseVector
-import scalismo.geometry._
 
-class TransformationTests extends FunSpec with Matchers {
+import breeze.linalg.DenseVector
+import scalismo.ScalismoTestSuite
+import scalismo.geometry.Index.implicits._
+import scalismo.geometry.Point.implicits._
+import scalismo.geometry.Vector.implicits._
+import scalismo.geometry._
+import scalismo.image.{ DifferentiableScalarImage, DiscreteImageDomain }
+import scalismo.io.{ ImageIO, MeshIO }
+
+import scala.language.implicitConversions
+
+class TransformationTests extends ScalismoTestSuite {
 
   implicit def doubleToFloat(d: Double) = d.toFloat
-
-  scalismo.initialize()
 
   describe("A scaling in 2D") {
     val ss = ScalingSpace[_2D]

--- a/src/test/scala/scalismo/statisticalmodel/GaussianProcessTests.scala
+++ b/src/test/scala/scalismo/statisticalmodel/GaussianProcessTests.scala
@@ -15,24 +15,18 @@
  */
 package scalismo.statisticalmodel
 
-import scalismo.common.{ DiscreteDomain, RealSpace, VectorField, BoxDomain }
-import scalismo.image.DiscreteImageDomain
-import scalismo.geometry._
-import scalismo.geometry.Point.implicits._
-import scalismo.geometry.Vector.implicits._
-import scalismo.geometry.Index.implicits._
-import scalismo.io.StatismoIO
-
-import scalismo.kernels.{ MatrixValuedPDKernel, GaussianKernel, UncorrelatedKernel }
-import scalismo.numerics.{ FixedPointsUniformMeshSampler3D, GridSampler, UniformSampler }
-import scalismo.registration.Transformation
-import scala.language.implicitConversions
-import org.scalatest.{ Matchers, FunSpec }
-import org.scalatest.matchers.ShouldMatchers
 import breeze.linalg.DenseVector
-import java.io.File
+import scalismo.ScalismoTestSuite
+import scalismo.common.{ BoxDomain, DiscreteDomain, RealSpace, VectorField }
+import scalismo.geometry.Point.implicits._
+import scalismo.geometry._
+import scalismo.image.DiscreteImageDomain
+import scalismo.kernels.{ GaussianKernel, MatrixValuedPDKernel, UncorrelatedKernel }
+import scalismo.numerics.{ GridSampler, UniformSampler }
 
-class GaussianProcessTests extends FunSpec with Matchers {
+import scala.language.implicitConversions
+
+class GaussianProcessTests extends ScalismoTestSuite {
   implicit def doubleToFloat(d: Double) = d.toFloat
 
   describe("samples from a gaussian process") {
@@ -245,6 +239,7 @@ class GaussianProcessTests extends FunSpec with Matchers {
         }
 
         override val domain = RealSpace[_3D]
+
         override def k(x: Point[_3D], y: Point[_3D]) = {
           SquareMatrix[_3D](f(x, y).data)
         }

--- a/src/test/scala/scalismo/statisticalmodel/MultivariateNormalDistributionTests.scala
+++ b/src/test/scala/scalismo/statisticalmodel/MultivariateNormalDistributionTests.scala
@@ -15,13 +15,11 @@
  */
 package scalismo.statisticalmodel
 
-import org.scalatest.matchers.ShouldMatchers
-import org.scalatest.{ Matchers, FunSpec }
-import breeze.linalg.DenseVector
-import breeze.linalg.DenseMatrix
+import breeze.linalg.{ DenseMatrix, DenseVector }
+import scalismo.ScalismoTestSuite
 import scalismo.geometry._
 
-class MultivariateNormalDistributionTests extends FunSpec with Matchers {
+class MultivariateNormalDistributionTests extends ScalismoTestSuite {
   describe("A 1D Multivariate normal") {
     it("should give the same pdf values as breeze Gaussian with the same parameters") {
       val mvn = new MultivariateNormalDistribution(DenseVector(2f), DenseMatrix(3f))

--- a/src/test/scala/scalismo/statisticalmodel/StatisticalModelTests.scala
+++ b/src/test/scala/scalismo/statisticalmodel/StatisticalModelTests.scala
@@ -15,23 +15,18 @@
  */
 package scalismo.statisticalmodel
 
+import java.io.File
+
+import breeze.linalg.DenseVector
+import scalismo.ScalismoTestSuite
 import scalismo.geometry._
 import scalismo.io.StatismoIO
 import scalismo.registration.{ RigidTransformation, RigidTransformationSpace }
 
 import scala.language.implicitConversions
-import breeze.linalg.{ DenseVector, DenseMatrix }
-import java.io.File
-import org.scalatest.{ Matchers, FunSpec }
-import org.scalatest.matchers.ShouldMatchers
-import breeze.stats.distributions.RandBasis
-import org.apache.commons.math3.random.MersenneTwister
-import scalismo.io.MeshIO
-class StatisticalModelTests extends FunSpec with Matchers {
+class StatisticalModelTests extends ScalismoTestSuite {
 
   implicit def doubleToFloat(d: Double) = d.toFloat
-
-  scalismo.initialize()
 
   describe("A statistical model") {
 
@@ -65,7 +60,7 @@ class StatisticalModelTests extends FunSpec with Matchers {
     }
 
     it("can change the mean shape and still yield the same shape space") {
-      scalismo.initialize()
+
       val path = getClass().getResource("/facemodel.h5").getPath
       val model = StatismoIO.readStatismoMeshModel(new File(path)).get
 

--- a/src/test/scala/scalismo/statisticalmodel/dataset/DataCollectionTests.scala
+++ b/src/test/scala/scalismo/statisticalmodel/dataset/DataCollectionTests.scala
@@ -15,21 +15,18 @@
  */
 package scalismo.statisticalmodel.dataset
 
-import org.scalatest.matchers.ShouldMatchers
-import org.scalatest.{ Matchers, FunSpec }
 import java.io.File
-import org.scalatest.matchers.ShouldMatchers
-import breeze.linalg.DenseVector
+
+import scalismo.ScalismoTestSuite
 import scalismo.common.VectorField
+import scalismo.geometry._
 import scalismo.io.MeshIO
 import scalismo.kernels.{ GaussianKernel, UncorrelatedKernel }
 import scalismo.mesh.MeshMetrics
 import scalismo.registration.{ LandmarkRegistration, TranslationTransform }
-import scalismo.geometry._
 import scalismo.statisticalmodel.GaussianProcess
 
-class DataCollectionTests extends FunSpec with Matchers {
-  scalismo.initialize()
+class DataCollectionTests extends ScalismoTestSuite {
 
   describe("A datacollection") {
 
@@ -81,7 +78,6 @@ class DataCollectionTests extends FunSpec with Matchers {
   }
 
   object Fixture {
-    scalismo.initialize()
 
     val nonAlignedFaces = new File(getClass.getResource("/nonAlignedFaces").getPath).listFiles.sortBy(_.getName).map { f => MeshIO.readMesh(f).get }.toIndexedSeq
     val ref = nonAlignedFaces.head

--- a/src/test/scala/scalismo/utils/ConversionTests.scala
+++ b/src/test/scala/scalismo/utils/ConversionTests.scala
@@ -16,15 +16,13 @@
 
 package scalismo.utils
 
+import scalismo.ScalismoTestSuite
 import scalismo.geometry._2D
 import scalismo.io.{ ImageIO, MeshIO }
 
 import scala.language.implicitConversions
-import org.scalatest.{ Matchers, FunSpec }
-import org.scalatest.matchers.ShouldMatchers
 
-class ConversionTests extends FunSpec with Matchers {
-  scalismo.initialize()
+class ConversionTests extends ScalismoTestSuite {
 
   describe("a Mesh ") {
 

--- a/src/test/scala/scalismo/utils/MemoizationTests.scala
+++ b/src/test/scala/scalismo/utils/MemoizationTests.scala
@@ -15,11 +15,11 @@
  */
 package scalismo.utils
 
-import scala.language.implicitConversions
-import org.scalatest.{ Matchers, FunSpec }
-import org.scalatest.matchers.ShouldMatchers
+import scalismo.ScalismoTestSuite
 
-class MemoizationTests extends FunSpec with Matchers {
+import scala.language.implicitConversions
+
+class MemoizationTests extends ScalismoTestSuite {
   describe("a Function ") {
 
     def testFun(x: Double) = {


### PR DESCRIPTION
- Introduced common test suite superclass which calls scalismo.initialize()
- Bumped nativelibs dependency to newest version
- Cosmetic fix to suppress slf4j output
- A couple of adjustments to the travis configuration