### PR TITLE
add memoize function for transformations

### DIFF
--- a/src/main/scala/scalismo/common/Field.scala
+++ b/src/main/scala/scalismo/common/Field.scala
@@ -52,7 +52,7 @@ object Field {
 trait Field[D <: Dim, A] extends Function1[Point[D], A] { self =>
 
   /** a function that defines the image values. It must be defined on the full domain */
-  protected val f: Point[D] => A
+  protected[scalismo] val f: Point[D] => A
 
   /** The domain on which the image is defined */
   def domain: Domain[D]

--- a/src/main/scala/scalismo/registration/TransformationSpace.scala
+++ b/src/main/scala/scalismo/registration/TransformationSpace.scala
@@ -22,6 +22,7 @@ import java.util.Arrays
 import scalismo.geometry
 import scalismo.geometry._
 import scalismo.common._
+import scalismo.utils.Memoize
 
 import scala.annotation._
 
@@ -32,6 +33,20 @@ import scala.annotation._
  */
 trait Transformation[D <: Dim] extends Field[D, Point[D]] {}
 /** Trait for parametric D-dimensional transformation */
+
+object Transformation {
+
+  /**
+   * Returns a new transformation that memoizes (caches) the values that have already been
+   * computed. The size of the cache used is given by the argument cacheSizeHint.
+   */
+  def memoize[D <: Dim](t: Transformation[D], cacheSizeHint: Int) = new Transformation[D] {
+    override protected[scalismo] val f: (Point[D]) => Point[D] = Memoize(t.f, cacheSizeHint)
+    override def domain: Domain[D] = t.domain
+  }
+
+}
+
 trait ParametricTransformation[D <: Dim] extends Transformation[D] {
   /** the parameters defining the transform*/
   val parameters: TransformationSpace.ParameterVector

--- a/src/test/scala/scalismo/registration/TransformationTests.scala
+++ b/src/test/scala/scalismo/registration/TransformationTests.scala
@@ -32,6 +32,17 @@ class TransformationTests extends ScalismoTestSuite {
 
   implicit def doubleToFloat(d: Double) = d.toFloat
 
+  describe("A Transformation") {
+    it("can be memoized and yields the same results") {
+      val transform = RotationSpace[_2D](Point(0f, 0f)).transformForParameters(DenseVector(0.1f))
+      val transformMemoized = Transformation.memoize(transform, 100)
+      for (x <- 0 until 10; y <- -5 until 5) {
+        val p = Point(x, y)
+        transform(p) should equal(transformMemoized(p))
+      }
+    }
+  }
+
   describe("A scaling in 2D") {
     val ss = ScalingSpace[_2D]
     val params = DenseVector[Float](3.0)


### PR DESCRIPTION
Whenever we need to warp several meshes/images with the same transform, it saves a lot of computations if we are able to memoize the transformation. The standard memoize function in utils does not work, as it does not preserve the type