### PR TITLE
DiscreteImageDomain: fixed equality bug, only compared direction

### DIFF
--- a/src/main/scala/scalismo/image/DiscreteImageDomain.scala
+++ b/src/main/scala/scalismo/image/DiscreteImageDomain.scala
@@ -132,8 +132,8 @@ abstract class DiscreteImageDomain[D <: Dim: NDSpace] extends DiscreteDomain[D] 
         c.canEqual(this) &&
           origin == c.origin &&
           spacing == c.spacing &&
-          size == c.size
-        directions == c.directions
+          size == c.size &&
+          directions == c.directions
       }
       case other => false
     }


### PR DESCRIPTION
DiscreteImageDomain.equals did only compare directions due to missing "&&"