### PR TITLE
Point/Vector/Index Refactoring with specialized classes

### DIFF
--- a/src/main/scala/scalismo/common/DiscreteField.scala
+++ b/src/main/scala/scalismo/common/DiscreteField.scala
@@ -117,11 +117,11 @@ object DiscreteVectorField {
    * the vector is ordered as (v_11, v_12, ... v_1d, ...v_n1, v_n2, v_nd)
    */
   def fromDenseVector[D <: Dim: NDSpace, DO <: Dim: NDSpace](domain: DiscreteDomain[D],
-    vec: DenseVector[Float]): DiscreteVectorField[D, DO] = {
+    vec: DenseVector[Float])(implicit vectorBuilder: Vector.Create[DO]): DiscreteVectorField[D, DO] = {
     val dim = implicitly[NDSpace[DO]].dimensionality
     val vectors =
       for (v <- vec.toArray.grouped(dim))
-        yield Vector[DO](v)
+        yield Vector.apply[DO](v)
 
     DiscreteVectorField[D, DO](domain, vectors.toIndexedSeq)
   }

--- a/src/main/scala/scalismo/common/DiscreteField.scala
+++ b/src/main/scala/scalismo/common/DiscreteField.scala
@@ -117,7 +117,7 @@ object DiscreteVectorField {
    * the vector is ordered as (v_11, v_12, ... v_1d, ...v_n1, v_n2, v_nd)
    */
   def fromDenseVector[D <: Dim: NDSpace, DO <: Dim: NDSpace](domain: DiscreteDomain[D],
-    vec: DenseVector[Float])(implicit vectorBuilder: Vector.Create[DO]): DiscreteVectorField[D, DO] = {
+    vec: DenseVector[Float]): DiscreteVectorField[D, DO] = {
     val dim = implicitly[NDSpace[DO]].dimensionality
     val vectors =
       for (v <- vec.toArray.grouped(dim))

--- a/src/main/scala/scalismo/geometry/Dim.scala
+++ b/src/main/scala/scalismo/geometry/Dim.scala
@@ -22,19 +22,36 @@ trait _1D extends Dim
 trait _2D extends Dim
 trait _3D extends Dim
 
-trait NDSpace[D <: Dim] {
+trait NDSpace[D <: Dim]
+    extends Vector.Create[D]
+    with Point.Create[D]
+    with Index.Create[D] {
   def dimensionality: Int
 }
 
+object NDSpace {
+  def apply[D <: Dim](implicit ndSpace: NDSpace[D]): NDSpace[D] = ndSpace
+}
+
 object Dim {
-  implicit object OneDSpace extends NDSpace[_1D] {
+  implicit object OneDSpace extends NDSpace[_1D]
+      with Vector.Create1D
+      with Point.Create1D
+      with Index.Create1D {
     override val dimensionality = 1
   }
-  implicit object TwoDSpace extends NDSpace[_2D] {
+
+  implicit object TwoDSpace extends NDSpace[_2D]
+      with Vector.Create2D
+      with Point.Create2D
+      with Index.Create2D {
     override val dimensionality = 2
   }
-  implicit object ThreeDSpace extends NDSpace[_3D] {
+
+  implicit object ThreeDSpace extends NDSpace[_3D]
+      with Vector.Create3D
+      with Point.Create3D
+      with Index.Create3D {
     override val dimensionality = 3
   }
-
 }

--- a/src/main/scala/scalismo/geometry/Index.scala
+++ b/src/main/scala/scalismo/geometry/Index.scala
@@ -28,7 +28,7 @@ sealed abstract class Index[D <: Dim: NDSpace] {
 
   def toArray: Array[Int]
 
-  @deprecated("real data is now private, use toArray")
+  @deprecated("real data is now private, use toArray", "")
   def data = toArray
 
   def toBreezeVector: DenseVector[Int] = DenseVector(toArray)

--- a/src/main/scala/scalismo/geometry/Index.scala
+++ b/src/main/scala/scalismo/geometry/Index.scala
@@ -15,30 +15,123 @@
  */
 package scalismo.geometry
 
+import breeze.linalg.DenseVector
+import spire.algebra.{ Rng, Field }
+
 import scala.language.implicitConversions
 import scala.reflect.ClassTag
 
-class Index[D <: Dim: NDSpace] private (val data: Array[Int]) extends Coordinate[D, Int] with CoordinateOps[D, Int, Index[D]] {
+sealed abstract class Index[D <: Dim: NDSpace] {
+  def apply(a: Int): Int
 
-  override val classTagScalar: ClassTag[Int] = implicitly[ClassTag[Int]]
-  override def createConcreteRepresentation(data: Array[Int]): Index[D] = new Index[D](data)
+  val dimensionality: Int = implicitly[NDSpace[D]].dimensionality
 
-  override def canEqual(other: Any): Boolean = other.isInstanceOf[Index[D]]
+  def toArray: Array[Int]
 
+  @deprecated("real data is now private, use toArray")
+  def data = toArray
+
+  def toBreezeVector: DenseVector[Int] = DenseVector(toArray)
+
+  def mapWithIndex(f: (Int, Int) => Int): Index[D]
+
+  def map(f: Int => Int): Index[D] = mapWithIndex((v, i) => f(v))
+}
+
+/** 1D point */
+case class Index1D(i: Int) extends Index[_1D] {
+  override def apply(a: Int): Int = a match {
+    case 0 => i
+    case _ => throw new IndexOutOfBoundsException("Index1D has only 1 element")
+  }
+
+  override def toArray = Array(i)
+
+  override def mapWithIndex(f: (Int, Int) => Int): Index1D = Index1D(f(i, 0))
+}
+
+/** 2D point */
+case class Index2D(i: Int, j: Int) extends Index[_2D] {
+  override def apply(a: Int): Int = a match {
+    case 0 => i
+    case 1 => j
+    case _ => throw new IndexOutOfBoundsException("Index2D has only 2 elements")
+  }
+
+  override def toArray = Array(i, j)
+
+  override def mapWithIndex(f: (Int, Int) => Int): Index2D = Index2D(f(i, 0), f(j, 1))
+}
+
+/** 3D point */
+case class Index3D(i: Int, j: Int, k: Int) extends Index[_3D] {
+  override def apply(a: Int): Int = a match {
+    case 0 => i
+    case 1 => j
+    case 2 => k
+    case _ => throw new IndexOutOfBoundsException("Index3D has only 3 elements")
+  }
+
+  override def toArray = Array(i, j, k)
+
+  override def mapWithIndex(f: (Int, Int) => Int): Index3D = Index3D(f(i, 0), f(j, 1), f(k, 2))
 }
 
 object Index {
 
-  def apply[D <: Dim: NDSpace](d: Array[Int]) = new Index[D](d)
-  def apply(i: Int): Index[_1D] = new Index[_1D](Array(i))
-  def apply(i: Int, j: Int): Index[_2D] = new Index[_2D](Array(i, j))
-  def apply(i: Int, j: Int, k: Int): Index[_3D] = new Index[_3D](Array(i, j, k))
+  /** creation typeclass */
+  trait Create[D <: Dim] {
+    def createIndex(data: Array[Int]): Index[D]
+  }
+
+  trait Create1D extends Create[_1D] {
+    override def createIndex(d: Array[Int]) = {
+      require(d.length == 1)
+      Index1D(d(0))
+    }
+  }
+
+  trait Create2D extends Create[_2D] {
+    override def createIndex(d: Array[Int]) = {
+      require(d.length == 2)
+      Index2D(d(0), d(1))
+    }
+  }
+
+  trait Create3D extends Create[_3D] {
+    override def createIndex(d: Array[Int]) = {
+      require(d.length == 3)
+      Index3D(d(0), d(1), d(2))
+    }
+  }
+
+  def apply[D <: Dim: NDSpace](d: Array[Int])(implicit builder: Create[D]) = builder.createIndex(d)
+  def apply(x: Int): Index1D = Index1D(x)
+  def apply(x: Int, y: Int): Index2D = Index2D(x, y)
+  def apply(x: Int, y: Int, z: Int): Index3D = Index3D(x, y, z)
+
+  def zeros[D <: Dim: NDSpace](implicit builder: Create[D]) = {
+    Index(Array.fill(NDSpace[D].dimensionality)(0))
+  }
+
+  /** spire Module implementation for Index (no scalar division) */
+  implicit def spireModule[D <: Dim: NDSpace] = new spire.algebra.Module[Index[D], Int] {
+    override implicit def scalar: Rng[Int] = Rng[Int]
+    override def timesl(r: Int, v: Index[D]): Index[D] = v.map(i => i * r)
+    override def negate(x: Index[D]): Index[D] = x.map(i => -i)
+    override def zero: Index[D] = zeros[D]
+    override def plus(x: Index[D], y: Index[D]): Index[D] = x.mapWithIndex((v, i) => v + y(i))
+  }
 
   object implicits {
-    implicit def index1DToInt(v: Index[_1D]) = v(0)
-    implicit def intToindex1De(i: Int): Index[_1D] = Index(i)
-    implicit def tupleOfIntToindex2D(t: (Int, Int)): Index[_2D] = Index(t._1, t._2)
-    implicit def tupleOfIntToindex3D(t: (Int, Int, Int)): Index[_3D] = Index(t._1, t._2, t._3)
+    implicit def point1DToInt(ind: Index[_1D]): Int = ind.i
+    implicit def floatToIndex1D(f: Int): Index1D = Index1D(f)
+    implicit def tupleOfIntToIndex2D(t: (Int, Int)): Index2D = Index2D(t._1, t._2)
+    implicit def tupleOfIntToIndex3D(t: (Int, Int, Int)): Index3D = Index3D(t._1.toInt, t._2.toInt, t._3.toInt)
   }
-}
 
+  implicit def parametricToConcrete1D(p: Index[_1D]): Index1D = p.asInstanceOf[Index1D]
+  implicit def parametricToConcrete2D(p: Index[_2D]): Index2D = p.asInstanceOf[Index2D]
+  implicit def parametricToConcrete3D(p: Index[_3D]): Index3D = p.asInstanceOf[Index3D]
+
+}

--- a/src/main/scala/scalismo/geometry/Index.scala
+++ b/src/main/scala/scalismo/geometry/Index.scala
@@ -124,8 +124,8 @@ object Index {
   }
 
   object implicits {
-    implicit def point1DToInt(ind: Index[_1D]): Int = ind.i
-    implicit def floatToIndex1D(f: Int): Index1D = Index1D(f)
+    implicit def index1DToInt(ind: Index[_1D]): Int = ind.i
+    implicit def intToIndex1D(f: Int): Index1D = Index1D(f)
     implicit def tupleOfIntToIndex2D(t: (Int, Int)): Index2D = Index2D(t._1, t._2)
     implicit def tupleOfIntToIndex3D(t: (Int, Int, Int)): Index3D = Index3D(t._1.toInt, t._2.toInt, t._3.toInt)
   }

--- a/src/main/scala/scalismo/geometry/Point.scala
+++ b/src/main/scala/scalismo/geometry/Point.scala
@@ -38,7 +38,7 @@ sealed abstract class Point[D <: Dim: NDSpace] {
 
   def toArray: Array[Float]
 
-  @deprecated("real data is now private, use toArray")
+  @deprecated("real data is now private, use toArray", "")
   def data = toArray
 
   def toBreezeVector = DenseVector(toArray)

--- a/src/main/scala/scalismo/geometry/Point.scala
+++ b/src/main/scala/scalismo/geometry/Point.scala
@@ -15,63 +15,141 @@
  */
 package scalismo.geometry
 
+import breeze.linalg.DenseVector
+
 import scala.language.implicitConversions
 import scala.reflect.ClassTag
 
 /**
  * An n-dimensional Point
  */
-class Point[D <: Dim: NDSpace] private (private[scalismo] override val data: Array[Float]) extends Coordinate[D, Float] with CoordinateOps[D, Float, Point[D]] {
+sealed abstract class Point[D <: Dim: NDSpace] {
+  def apply(i: Int): Float
 
-  override val classTagScalar: ClassTag[Float] = implicitly[ClassTag[Float]]
-  override def createConcreteRepresentation(data: Array[Float]): Point[D] = new Point(data)
+  val dimensionality: Int = implicitly[NDSpace[D]].dimensionality
 
-  def +(that: Vector[D]): Point[D] = {
-    val newData = new Array[Float](dimensionality)
-    var i = 0
-    while (i < dimensionality) {
-      newData(i) = this.data(i) + that.data(i)
-      i += 1
-    }
-    Point[D](newData)
+  def +(that: Vector[D]): Point[D]
+
+  def -(that: Vector[D]): Point[D]
+
+  def -(that: Point[D]): Vector[D]
+
+  def toVector: Vector[D]
+
+  def toArray: Array[Float]
+
+  @deprecated def data = toArray
+
+  def toBreezeVector: DenseVector[Float] = DenseVector(toArray)
+
+  def mapWithIndex(f: (Float, Int) => Float): Point[D]
+}
+
+/** 1D point */
+case class Point1D (x: Float) extends Point[_1D] {
+  override def apply(i: Int): Float = i match {
+    case 0 => x
+    case _ => throw new IndexOutOfBoundsException("Point1D has only 1 element")
   }
 
-  def -(that: Vector[D]): Point[D] = {
-    val newData = new Array[Float](dimensionality)
-    var i = 0
-    while (i < dimensionality) {
-      newData(i) = this.data(i) - that.data(i)
-      i += 1
-    }
-    Point[D](newData)
+  override def +(that: Vector[_1D]): Point1D = Point(x + that.x)
+
+  override def -(that: Vector[_1D]): Point1D = Point(x-that.x)
+
+  override def -(that: Point[_1D]): Vector1D = Vector(x-that.x)
+
+  override def toVector: Vector[_1D] = Vector(x)
+
+  override def toArray = Array(x)
+
+  override def mapWithIndex(f: (Float, Int) => Float): Point[_1D] = Point(f(x,0))
+}
+
+/** 2D point */
+case class Point2D (x: Float, y: Float) extends Point[_2D] {
+  override def apply(i: Int): Float = i match {
+    case 0 => x
+    case 1 => y
+    case _ => throw new IndexOutOfBoundsException("Point2D has only 2 elements")
   }
 
-  def -(that: Point[D]): Vector[D] = {
-    val newData = new Array[Float](dimensionality)
-    var i = 0
-    while (i < dimensionality) {
-      newData(i) = this.data(i) - that.data(i)
-      i += 1
-    }
-    Vector[D](newData)
+  override def +(that: Vector[_2D]): Point[_2D] = Point(x+that.x, y+that.y)
+
+  override def -(that: Vector[_2D]): Point[_2D] = Point(x-that.x, y-that.y)
+
+  override def -(that: Point[_2D]): Vector[_2D] = Vector(x-that.x, y-that.y)
+
+  override def toVector: Vector[_2D] = Vector(x, y)
+
+  override def toArray = Array(x, y)
+
+  override def mapWithIndex(f: (Float, Int) => Float): Point[_2D] = Point(f(x,0), f(y,1))
+}
+
+/** 3D point */
+case class Point3D (x: Float, y: Float, z: Float) extends Point[_3D] {
+  override def apply(i: Int): Float = i match {
+    case 0 => x
+    case 1 => y
+    case 2 => z
+    case _ => throw new IndexOutOfBoundsException("Point3D has only 3 elements")
   }
 
-  def toVector: Vector[D] = Vector[D](data)
+  override def +(that: Vector[_3D]): Point3D = Point(x+that.x, y+that.y, z+that.z)
 
-  protected override def canEqual(other: Any): Boolean = other.isInstanceOf[Point[D]]
+  override def -(that: Vector[_3D]): Point3D = Point(x-that.x, y-that.y, z-that.z)
+
+  override def -(that: Point[_3D]): Vector3D = Vector(x-that.x, y-that.y, z-that.z)
+
+  override def toVector: Vector[_3D] = Vector(x, y, z)
+
+  override def toArray = Array(x, y, z)
+
+  override def mapWithIndex(f: (Float, Int) => Float): Point[_3D] = Point(f(x,0), f(y,1), f(z,2))
 }
 
 object Point {
 
-  def apply[D <: Dim: NDSpace](d: Array[Float]) = new Point[D](d)
-  def apply(x: Float): Point[_1D] = new Point[_1D](Array(x))
-  def apply(x: Float, y: Float): Point[_2D] = new Point[_2D](Array(x, y))
-  def apply(x: Float, y: Float, z: Float): Point[_3D] = new Point[_3D](Array(x, y, z))
+  /** creation typeclass */
+  trait Create[D] {
+    def create(data: Array[Float]): Point[D]
+  }
+
+  implicit val create1D = new Create[_1D] {
+    override def create(d: Array[Float]) = {
+      require(d.length == 1)
+      Point1D(d(0))
+    }
+  }
+
+  implicit val create2D = new Create[_2D] {
+    override def create(d: Array[Float]) = {
+      require(d.length == 2)
+      Point2D(d(0), d(1))
+    }
+  }
+
+  implicit val create3D = new Create[_3D] {
+    override def create(d: Array[Float]) = {
+      require(d.length == 3)
+      Point3D(d(0), d(1), d(2))
+    }
+  }
+
+  def apply[D <: Dim: NDSpace](d: Array[Float])(implicit builder: Create[D]) = builder.create(d)
+  def apply(x: Float): Point[_1D] = Point1D(x)
+  def apply(x: Float, y: Float): Point[_2D] = Point2D(x, y)
+  def apply(x: Float, y: Float, z: Float): Point[_3D] = Point3D(x, y, z)
 
   object implicits {
-    implicit def point1DToFloat(p: Point[_1D]) = p(0)
+    //implicit def point1DToFloat(p: Point[_1D]): Float = p.x
     implicit def floatToPoint1D(f: Float): Point[_1D] = Point(f)
     implicit def tupleOfFloatToPoint2D(t: (Float, Float)): Point[_2D] = Point(t._1, t._2)
     implicit def tupleOfFloatToPoint3D(t: (Float, Float, Float)): Point[_3D] = Point(t._1.toFloat, t._2.toFloat, t._3.toFloat)
   }
+
+  implicit def parametricToConcrete1D(p: Point[_1D]): Point1D = p.asInstanceOf[Point1D]
+  implicit def parametricToConcrete2D(p: Point[_2D]): Point2D = p.asInstanceOf[Point2D]
+  implicit def parametricToConcrete3D(p: Point[_3D]): Point3D = p.asInstanceOf[Point3D]
+
 }

--- a/src/main/scala/scalismo/geometry/Point.scala
+++ b/src/main/scala/scalismo/geometry/Point.scala
@@ -38,56 +38,59 @@ sealed abstract class Point[D <: Dim: NDSpace] {
 
   def toArray: Array[Float]
 
-  @deprecated def data = toArray
+  @deprecated("real data is now private, use toArray")
+  def data = toArray
 
-  def toBreezeVector: DenseVector[Float] = DenseVector(toArray)
+  def toBreezeVector = DenseVector(toArray)
 
   def mapWithIndex(f: (Float, Int) => Float): Point[D]
+
+  def map(f: Float => Float): Point[D] = mapWithIndex((v, i) => f(v))
 }
 
 /** 1D point */
-case class Point1D (x: Float) extends Point[_1D] {
+case class Point1D(x: Float) extends Point[_1D] {
   override def apply(i: Int): Float = i match {
     case 0 => x
     case _ => throw new IndexOutOfBoundsException("Point1D has only 1 element")
   }
 
-  override def +(that: Vector[_1D]): Point1D = Point(x + that.x)
+  override def +(that: Vector[_1D]): Point1D = Point1D(x + that.x)
 
-  override def -(that: Vector[_1D]): Point1D = Point(x-that.x)
+  override def -(that: Vector[_1D]): Point1D = Point1D(x - that.x)
 
-  override def -(that: Point[_1D]): Vector1D = Vector(x-that.x)
+  override def -(that: Point[_1D]): Vector1D = Vector1D(x - that.x)
 
-  override def toVector: Vector[_1D] = Vector(x)
+  override def toVector: Vector1D = Vector1D(x)
 
   override def toArray = Array(x)
 
-  override def mapWithIndex(f: (Float, Int) => Float): Point[_1D] = Point(f(x,0))
+  override def mapWithIndex(f: (Float, Int) => Float): Point1D = Point1D(f(x, 0))
 }
 
 /** 2D point */
-case class Point2D (x: Float, y: Float) extends Point[_2D] {
+case class Point2D(x: Float, y: Float) extends Point[_2D] {
   override def apply(i: Int): Float = i match {
     case 0 => x
     case 1 => y
     case _ => throw new IndexOutOfBoundsException("Point2D has only 2 elements")
   }
 
-  override def +(that: Vector[_2D]): Point[_2D] = Point(x+that.x, y+that.y)
+  override def +(that: Vector[_2D]): Point2D = Point2D(x + that.x, y + that.y)
 
-  override def -(that: Vector[_2D]): Point[_2D] = Point(x-that.x, y-that.y)
+  override def -(that: Vector[_2D]): Point2D = Point2D(x - that.x, y - that.y)
 
-  override def -(that: Point[_2D]): Vector[_2D] = Vector(x-that.x, y-that.y)
+  override def -(that: Point[_2D]): Vector2D = Vector2D(x - that.x, y - that.y)
 
-  override def toVector: Vector[_2D] = Vector(x, y)
+  override def toVector: Vector2D = Vector2D(x, y)
 
   override def toArray = Array(x, y)
 
-  override def mapWithIndex(f: (Float, Int) => Float): Point[_2D] = Point(f(x,0), f(y,1))
+  override def mapWithIndex(f: (Float, Int) => Float): Point2D = Point2D(f(x, 0), f(y, 1))
 }
 
 /** 3D point */
-case class Point3D (x: Float, y: Float, z: Float) extends Point[_3D] {
+case class Point3D(x: Float, y: Float, z: Float) extends Point[_3D] {
   override def apply(i: Int): Float = i match {
     case 0 => x
     case 1 => y
@@ -95,54 +98,60 @@ case class Point3D (x: Float, y: Float, z: Float) extends Point[_3D] {
     case _ => throw new IndexOutOfBoundsException("Point3D has only 3 elements")
   }
 
-  override def +(that: Vector[_3D]): Point3D = Point(x+that.x, y+that.y, z+that.z)
+  override def +(that: Vector[_3D]): Point3D = Point3D(x + that.x, y + that.y, z + that.z)
 
-  override def -(that: Vector[_3D]): Point3D = Point(x-that.x, y-that.y, z-that.z)
+  override def -(that: Vector[_3D]): Point3D = Point3D(x - that.x, y - that.y, z - that.z)
 
-  override def -(that: Point[_3D]): Vector3D = Vector(x-that.x, y-that.y, z-that.z)
+  override def -(that: Point[_3D]): Vector3D = Vector3D(x - that.x, y - that.y, z - that.z)
 
-  override def toVector: Vector[_3D] = Vector(x, y, z)
+  override def toVector: Vector[_3D] = Vector3D(x, y, z)
 
   override def toArray = Array(x, y, z)
 
-  override def mapWithIndex(f: (Float, Int) => Float): Point[_3D] = Point(f(x,0), f(y,1), f(z,2))
+  override def mapWithIndex(f: (Float, Int) => Float): Point3D = Point3D(f(x, 0), f(y, 1), f(z, 2))
 }
 
 object Point {
 
   /** creation typeclass */
-  trait Create[D] {
-    def create(data: Array[Float]): Point[D]
+  trait Create[D <: Dim] {
+    def createPoint(data: Array[Float]): Point[D]
   }
 
-  implicit val create1D = new Create[_1D] {
-    override def create(d: Array[Float]) = {
+  trait Create1D extends Create[_1D] {
+    override def createPoint(d: Array[Float]) = {
       require(d.length == 1)
       Point1D(d(0))
     }
   }
 
-  implicit val create2D = new Create[_2D] {
-    override def create(d: Array[Float]) = {
+  trait Create2D extends Create[_2D] {
+    override def createPoint(d: Array[Float]) = {
       require(d.length == 2)
       Point2D(d(0), d(1))
     }
   }
 
-  implicit val create3D = new Create[_3D] {
-    override def create(d: Array[Float]) = {
+  trait Create3D extends Create[_3D] {
+    override def createPoint(d: Array[Float]) = {
       require(d.length == 3)
       Point3D(d(0), d(1), d(2))
     }
   }
 
-  def apply[D <: Dim: NDSpace](d: Array[Float])(implicit builder: Create[D]) = builder.create(d)
-  def apply(x: Float): Point[_1D] = Point1D(x)
-  def apply(x: Float, y: Float): Point[_2D] = Point2D(x, y)
-  def apply(x: Float, y: Float, z: Float): Point[_3D] = Point3D(x, y, z)
+  def apply[D <: Dim: NDSpace](d: Array[Float])(implicit builder: Create[D]) = builder.createPoint(d)
+  def apply(x: Float): Point1D = Point1D(x)
+  def apply(x: Float, y: Float): Point2D = Point2D(x, y)
+  def apply(x: Float, y: Float, z: Float): Point3D = Point3D(x, y, z)
+
+  def fromBreezeVector[D <: Dim: NDSpace](breeze: DenseVector[Float])(implicit builder: Create[D]): Point[D] = {
+    val dim = NDSpace[D].dimensionality
+    require(breeze.size == dim, s"Invalid size of breeze vector (${breeze.size} != $dim)")
+    Point.apply[D](breeze.data)
+  }
 
   object implicits {
-    //implicit def point1DToFloat(p: Point[_1D]): Float = p.x
+    implicit def point1DToFloat(p: Point[_1D]): Float = p.x
     implicit def floatToPoint1D(f: Float): Point[_1D] = Point(f)
     implicit def tupleOfFloatToPoint2D(t: (Float, Float)): Point[_2D] = Point(t._1, t._2)
     implicit def tupleOfFloatToPoint3D(t: (Float, Float, Float)): Point[_3D] = Point(t._1.toFloat, t._2.toFloat, t._3.toFloat)

--- a/src/main/scala/scalismo/geometry/SquareMatrix.scala
+++ b/src/main/scala/scalismo/geometry/SquareMatrix.scala
@@ -23,6 +23,7 @@ import breeze.linalg.DenseMatrix
 class SquareMatrix[D <: Dim: NDSpace] private (private[scalismo] val data: Array[Float]) {
 
   val dimensionality: Int = implicitly[NDSpace[D]].dimensionality
+  val ndSpace = NDSpace[D]
 
   def apply(i: Int, j: Int): Float = {
     val d = dimensionality

--- a/src/main/scala/scalismo/geometry/Vector.scala
+++ b/src/main/scala/scalismo/geometry/Vector.scala
@@ -18,72 +18,34 @@ package scalismo.geometry
 import breeze.linalg.DenseVector
 
 import scala.language.implicitConversions
-import scala.reflect.ClassTag
 
 /**
  * An n-dimensional Vector
  */
-class Vector[D <: Dim: NDSpace] private (private[scalismo] override val data: Array[Float]) extends Coordinate[D, Float] with CoordinateOps[D, Float, Vector[D]] {
+sealed abstract class Vector[D <: Dim: NDSpace] {
+  def apply(i: Int): Float
 
-  override val classTagScalar: ClassTag[Float] = implicitly[ClassTag[Float]]
-  override def createConcreteRepresentation(data: Array[Float]): Vector[D] = new Vector(data)
+  val dimensionality: Int = implicitly[NDSpace[D]].dimensionality
 
   def norm: Double = math.sqrt(norm2)
 
-  def norm2: Double = {
-    var norm2 = 0.0
-    var i = 0
-    while (i < dimensionality) {
-      norm2 += data(i) * data(i)
-      i += 1
-    }
-    norm2
-  }
+  def norm2: Double
 
-  def +(that: Vector[D]): Vector[D] = {
-    val newData = new Array[Float](dimensionality)
-    var i = 0
-    while (i < dimensionality) {
-      newData(i) = this.data(i) + that.data(i)
-      i += 1
-    }
-    Vector[D](newData)
-  }
+  def *(s: Float): Vector[D]
 
-  def -(that: Vector[D]): Vector[D] = {
-    val newData = new Array[Float](dimensionality)
-    var i = 0
-    while (i < dimensionality) {
-      newData(i) = this.data(i) - that.data(i)
-      i += 1
-    }
-    Vector[D](newData)
-  }
+  def /(s: Float): Vector[D] = this * (1.0f/s)
 
-  def *(s: Double): Vector[D] = {
-    val newData = new Array[Float](dimensionality)
-    var i = 0
-    val sFloat = s.toFloat
-    while (i < dimensionality) {
-      newData(i) = this.data(i) * sFloat
-      i += 1
-    }
-    Vector[D](newData)
-  }
+  def *(s: Double): Vector[D] = this * s.toFloat
 
-  def toPoint: Point[D] = Point[D](data)
+  def /(s: Double): Vector[D] = this / s.toFloat
 
-  def dot(that: Vector[D]): Float = {
-    val d = dimensionality
+  def +(that: Vector[D]): Vector[D]
 
-    var dotprod = 0f
-    var i = 0
-    while (i < d) {
-      dotprod += this(i) * that(i)
-      i += 1
-    }
-    dotprod
-  }
+  def -(that: Vector[D]): Vector[D]
+
+  def toPoint: Point[D]
+
+  def dot(that: Vector[D]): Float
 
   def outer(that: Vector[D]): SquareMatrix[D] = {
 
@@ -104,36 +66,152 @@ class Vector[D <: Dim: NDSpace] private (private[scalismo] override val data: Ar
     SquareMatrix[D](data)
   }
 
-  protected override def canEqual(other: Any): Boolean = other.isInstanceOf[Vector[D]]
+  def toArray: Array[Float]
+
+  @deprecated def data = toArray
+
+  def toBreezeVector = DenseVector(toArray)
+
+  def mapWithIndex(f: (Float, Int) => Float): Vector[D]
+
+}
+
+/** 1D Vector */
+case class Vector1D (x: Float) extends Vector[_1D] {
+  override def apply(i: Int): Float = i match {
+    case 0 => x
+    case _ => throw new IndexOutOfBoundsException("Vector1D has only 1 element")
+  }
+
+  override def +(that: Vector[_1D]): Vector[_1D] = Vector(x+that.x)
+
+  override def -(that: Vector[_1D]): Vector[_1D] = Vector(x-that.x)
+
+  override def norm2: Double = x*x
+
+  override def dot(that: Vector[_1D]): Float = x*that.x
+
+  override def *(s: Float): Vector[_1D] = Vector(x*s)
+
+  override def toPoint: Point[_1D] = Point(x)
+
+  override def toArray = Array(x)
+
+  override def mapWithIndex(f: (Float, Int) => Float): Vector[_1D] = Vector(f(x,0))
+
+}
+
+/** 2D Vector */
+case class Vector2D (x: Float, y: Float) extends Vector[_2D] {
+  override def apply(i: Int): Float = i match {
+    case 0 => x
+    case 1 => y
+    case _ => throw new IndexOutOfBoundsException("Vector2D has only 2 elements")
+  }
+
+  override def +(that: Vector[_2D]): Vector[_2D] = Vector(x+that.x, y+that.y)
+
+  override def -(that: Vector[_2D]): Vector[_2D] = Vector(x-that.x, y-that.y)
+
+  override def norm2: Double = x*x+y*y
+
+  override def dot(that: Vector[_2D]): Float = x*that.x + y*that.y
+
+  override def *(s: Float): Vector[_2D] = Vector(x*s, y*s)
+
+  override def toPoint: Point[_2D] = Point(x, y)
+
+  override def toArray = Array(x, y)
+
+  override def mapWithIndex(f: (Float, Int) => Float): Vector[_2D] = Vector(f(x,0), f(y,1))
+
+}
+
+/** 3D Vector */
+case class Vector3D (x: Float, y: Float, z: Float) extends Vector[_3D] {
+  override def apply(i: Int): Float = i match {
+    case 0 => x
+    case 1 => y
+    case 2 => z
+    case _ => throw new IndexOutOfBoundsException("Vector3D has only 3 elements")
+  }
+
+  override def +(that: Vector[_3D]): Vector[_3D] = Vector(x + that.x, y+that.y, z+that.z)
+
+  override def -(that: Vector[_3D]): Vector[_3D] = Vector(x - that.x, y-that.y, z-that.z)
+
+  override def norm2: Double = x*x + y*y + z*z
+
+  override def dot(that: Vector[_3D]): Float = x*that.x + y*that.y + z*that.z
+
+  override def *(s: Float): Vector[_3D] = Vector(x*s, y*s, z*s)
+
+  override def toPoint: Point[_3D] = Point(x, y, z)
+
+  override def toArray = Array(x, y, z)
+
+  def crossproduct(v: Vector[_3D]): Vector[_3D] = {
+    Vector(y * v.z - z * v.y, z * v.x - x * v.z, x * v.y - y * v.x)
+  }
+
+  override def mapWithIndex(f: (Float, Int) => Float): Vector[_3D] = Vector(f(x,0), f(y,1), f(z,2))
+
 }
 
 object Vector {
 
-  def apply[D <: Dim: NDSpace](d: Array[Float]) = new Vector[D](d)
-  def apply(x: Float): Vector[_1D] = new Vector[_1D](Array(x))
-  def apply(x: Float, y: Float): Vector[_2D] = new Vector[_2D](Array(x, y))
-  def apply(x: Float, y: Float, z: Float): Vector[_3D] = new Vector[_3D](Array(x, y, z))
+  /** creation typeclass */
+  trait Create[D <: Dim] {
+    def create(data: Array[Float]): Vector[D]
+  }
 
-  def zeros[D <: Dim: NDSpace] = {
+  implicit val create1D = new Create[_1D] {
+    override def create(d: Array[Float]) = {
+      require(d.length == 1, "Creation of Vector failed: provided Array has invalid length")
+      Vector1D(d(0))
+    }
+  }
+
+  implicit val create2D = new Create[_2D] {
+    override def create(d: Array[Float]) = {
+      require(d.length == 2, "Creation of Vector failed: provided Array has invalid length")
+      Vector2D(d(0), d(1))
+    }
+  }
+
+  implicit val create3D = new Create[_3D] {
+    override def create(d: Array[Float]) = {
+      require(d.length == 3, "Creation of Vector failed: provided Array has invalid length")
+      Vector3D(d(0), d(1), d(2))
+    }
+  }
+
+  def apply[D <: Dim: NDSpace](d: Array[Float])(implicit builder: Create[D]) = builder.create(d)
+  def apply(x: Float): Vector[_1D] = Vector1D(x)
+  def apply(x: Float, y: Float): Vector[_2D] = Vector2D(x, y)
+  def apply(x: Float, y: Float, z: Float): Vector[_3D] = Vector3D(x, y, z)
+
+  def zeros[D <: Dim: NDSpace](implicit builder: Create[D]) = {
     val dim = implicitly[NDSpace[D]].dimensionality
-    new Vector[D](Array.fill[Float](dim)(0f))
+    Vector.apply[D](Array.fill[Float](dim)(0f))
   }
-
-  def crossproduct(u: Vector[_3D], v: Vector[_3D]): Vector[_3D] = {
-    Vector(u(1) * v(2) - u(2) * v(1), u(2) * v(0) - u(0) * v(2), u(0) * v(1) - u(1) * v(0))
-  }
-
-  def fromBreezeVector[D <: Dim: NDSpace](breeze: DenseVector[Float]): Vector[D] = {
+  
+  def fromBreezeVector[D <: Dim: NDSpace](breeze: DenseVector[Float])(implicit builder: Create[D]): Vector[D] = {
     val dim = implicitly[NDSpace[D]].dimensionality
     require(breeze.size == dim, s"Invalid size of breeze vector (${breeze.size} != $dim)")
     Vector.apply[D](breeze.data)
   }
 
   object implicits {
-    implicit def vector1DToFloat(v: Vector[_1D]): Float = v(0)
+    implicit def Vector1DToFloat(v: Vector[_1D]): Float = v.x
     implicit def floatToVector1D(f: Float): Vector[_1D] = Vector(f)
     implicit def tupleOfFloatToVector2D(t: (Float, Float)): Vector[_2D] = Vector(t._1, t._2)
-    implicit def tupleOfFloatToVector3D(t: (Float, Float, Float)): Vector[_3D] = Vector(t._1, t._2, t._3)
+    implicit def tupleOfFloatToVector3D(t: (Float, Float, Float)): Vector[_3D] = Vector(t._1.toFloat, t._2.toFloat, t._3.toFloat)
   }
+
+  implicit def parametricToConcrete1D(p: Vector[_1D]): Vector1D = p.asInstanceOf[Vector1D]
+  implicit def parametricToConcrete2D(p: Vector[_2D]): Vector2D = p.asInstanceOf[Vector2D]
+  implicit def parametricToConcrete3D(p: Vector[_3D]): Vector3D = p.asInstanceOf[Vector3D]
+
 }
 

--- a/src/main/scala/scalismo/geometry/Vector.scala
+++ b/src/main/scala/scalismo/geometry/Vector.scala
@@ -69,7 +69,7 @@ sealed abstract class Vector[D <: Dim: NDSpace] {
 
   def toArray: Array[Float]
 
-  @deprecated("real data is now private, use toArray")
+  @deprecated("real data is now private, use toArray", "")
   def data = toArray
 
   def toBreezeVector = DenseVector(toArray)

--- a/src/main/scala/scalismo/geometry/Vector.scala
+++ b/src/main/scala/scalismo/geometry/Vector.scala
@@ -16,6 +16,7 @@
 package scalismo.geometry
 
 import breeze.linalg.DenseVector
+import spire.algebra.Field
 
 import scala.language.implicitConversions
 
@@ -33,7 +34,7 @@ sealed abstract class Vector[D <: Dim: NDSpace] {
 
   def *(s: Float): Vector[D]
 
-  def /(s: Float): Vector[D] = this * (1.0f/s)
+  def /(s: Float): Vector[D] = this * (1.0f / s)
 
   def *(s: Double): Vector[D] = this * s.toFloat
 
@@ -68,67 +69,70 @@ sealed abstract class Vector[D <: Dim: NDSpace] {
 
   def toArray: Array[Float]
 
-  @deprecated def data = toArray
+  @deprecated("real data is now private, use toArray")
+  def data = toArray
 
   def toBreezeVector = DenseVector(toArray)
 
   def mapWithIndex(f: (Float, Int) => Float): Vector[D]
 
+  def map(f: Float => Float): Vector[D] = mapWithIndex((v, i) => f(v))
+
 }
 
 /** 1D Vector */
-case class Vector1D (x: Float) extends Vector[_1D] {
+case class Vector1D(x: Float) extends Vector[_1D] {
   override def apply(i: Int): Float = i match {
     case 0 => x
     case _ => throw new IndexOutOfBoundsException("Vector1D has only 1 element")
   }
 
-  override def +(that: Vector[_1D]): Vector[_1D] = Vector(x+that.x)
+  override def +(that: Vector[_1D]): Vector1D = Vector1D(x + that.x)
 
-  override def -(that: Vector[_1D]): Vector[_1D] = Vector(x-that.x)
+  override def -(that: Vector[_1D]): Vector1D = Vector1D(x - that.x)
 
-  override def norm2: Double = x*x
+  override def norm2: Double = x * x
 
-  override def dot(that: Vector[_1D]): Float = x*that.x
+  override def dot(that: Vector[_1D]): Float = x * that.x
 
-  override def *(s: Float): Vector[_1D] = Vector(x*s)
+  override def *(s: Float): Vector1D = Vector1D(x * s)
 
-  override def toPoint: Point[_1D] = Point(x)
+  override def toPoint: Point1D = Point1D(x)
 
   override def toArray = Array(x)
 
-  override def mapWithIndex(f: (Float, Int) => Float): Vector[_1D] = Vector(f(x,0))
+  override def mapWithIndex(f: (Float, Int) => Float): Vector1D = Vector1D(f(x, 0))
 
 }
 
 /** 2D Vector */
-case class Vector2D (x: Float, y: Float) extends Vector[_2D] {
+case class Vector2D(x: Float, y: Float) extends Vector[_2D] {
   override def apply(i: Int): Float = i match {
     case 0 => x
     case 1 => y
     case _ => throw new IndexOutOfBoundsException("Vector2D has only 2 elements")
   }
 
-  override def +(that: Vector[_2D]): Vector[_2D] = Vector(x+that.x, y+that.y)
+  override def +(that: Vector[_2D]): Vector2D = Vector2D(x + that.x, y + that.y)
 
-  override def -(that: Vector[_2D]): Vector[_2D] = Vector(x-that.x, y-that.y)
+  override def -(that: Vector[_2D]): Vector2D = Vector2D(x - that.x, y - that.y)
 
-  override def norm2: Double = x*x+y*y
+  override def norm2: Double = x * x + y * y
 
-  override def dot(that: Vector[_2D]): Float = x*that.x + y*that.y
+  override def dot(that: Vector[_2D]): Float = x * that.x + y * that.y
 
-  override def *(s: Float): Vector[_2D] = Vector(x*s, y*s)
+  override def *(s: Float): Vector2D = Vector2D(x * s, y * s)
 
-  override def toPoint: Point[_2D] = Point(x, y)
+  override def toPoint: Point2D = Point2D(x, y)
 
   override def toArray = Array(x, y)
 
-  override def mapWithIndex(f: (Float, Int) => Float): Vector[_2D] = Vector(f(x,0), f(y,1))
+  override def mapWithIndex(f: (Float, Int) => Float): Vector2D = Vector2D(f(x, 0), f(y, 1))
 
 }
 
 /** 3D Vector */
-case class Vector3D (x: Float, y: Float, z: Float) extends Vector[_3D] {
+case class Vector3D(x: Float, y: Float, z: Float) extends Vector[_3D] {
   override def apply(i: Int): Float = i match {
     case 0 => x
     case 1 => y
@@ -136,25 +140,25 @@ case class Vector3D (x: Float, y: Float, z: Float) extends Vector[_3D] {
     case _ => throw new IndexOutOfBoundsException("Vector3D has only 3 elements")
   }
 
-  override def +(that: Vector[_3D]): Vector[_3D] = Vector(x + that.x, y+that.y, z+that.z)
+  override def +(that: Vector[_3D]): Vector3D = Vector3D(x + that.x, y + that.y, z + that.z)
 
-  override def -(that: Vector[_3D]): Vector[_3D] = Vector(x - that.x, y-that.y, z-that.z)
+  override def -(that: Vector[_3D]): Vector3D = Vector3D(x - that.x, y - that.y, z - that.z)
 
-  override def norm2: Double = x*x + y*y + z*z
+  override def norm2: Double = x * x + y * y + z * z
 
-  override def dot(that: Vector[_3D]): Float = x*that.x + y*that.y + z*that.z
+  override def dot(that: Vector[_3D]): Float = x * that.x + y * that.y + z * that.z
 
-  override def *(s: Float): Vector[_3D] = Vector(x*s, y*s, z*s)
+  override def *(s: Float): Vector3D = Vector3D(x * s, y * s, z * s)
 
-  override def toPoint: Point[_3D] = Point(x, y, z)
+  override def toPoint: Point3D = Point3D(x, y, z)
 
   override def toArray = Array(x, y, z)
 
-  def crossproduct(v: Vector[_3D]): Vector[_3D] = {
-    Vector(y * v.z - z * v.y, z * v.x - x * v.z, x * v.y - y * v.x)
+  def crossproduct(v: Vector3D): Vector3D = {
+    Vector3D(y * v.z - z * v.y, z * v.x - x * v.z, x * v.y - y * v.x)
   }
 
-  override def mapWithIndex(f: (Float, Int) => Float): Vector[_3D] = Vector(f(x,0), f(y,1), f(z,2))
+  override def mapWithIndex(f: (Float, Int) => Float): Vector3D = Vector3D(f(x, 0), f(y, 1), f(z, 2))
 
 }
 
@@ -162,44 +166,55 @@ object Vector {
 
   /** creation typeclass */
   trait Create[D <: Dim] {
-    def create(data: Array[Float]): Vector[D]
+    def createVector(data: Array[Float]): Vector[D]
   }
 
-  implicit val create1D = new Create[_1D] {
-    override def create(d: Array[Float]) = {
+  trait Create1D extends Create[_1D] {
+    override def createVector(d: Array[Float]) = {
       require(d.length == 1, "Creation of Vector failed: provided Array has invalid length")
       Vector1D(d(0))
     }
   }
 
-  implicit val create2D = new Create[_2D] {
-    override def create(d: Array[Float]) = {
+  trait Create2D extends Create[_2D] {
+    override def createVector(d: Array[Float]) = {
       require(d.length == 2, "Creation of Vector failed: provided Array has invalid length")
       Vector2D(d(0), d(1))
     }
   }
 
-  implicit val create3D = new Create[_3D] {
-    override def create(d: Array[Float]) = {
+  trait Create3D extends Create[_3D] {
+    override def createVector(d: Array[Float]) = {
       require(d.length == 3, "Creation of Vector failed: provided Array has invalid length")
       Vector3D(d(0), d(1), d(2))
     }
   }
 
-  def apply[D <: Dim: NDSpace](d: Array[Float])(implicit builder: Create[D]) = builder.create(d)
-  def apply(x: Float): Vector[_1D] = Vector1D(x)
-  def apply(x: Float, y: Float): Vector[_2D] = Vector2D(x, y)
-  def apply(x: Float, y: Float, z: Float): Vector[_3D] = Vector3D(x, y, z)
+  def apply[D <: Dim: NDSpace](d: Array[Float])(implicit builder: Create[D]) = builder.createVector(d)
+
+  def apply(x: Float): Vector1D = Vector1D(x)
+
+  def apply(x: Float, y: Float): Vector2D = Vector2D(x, y)
+
+  def apply(x: Float, y: Float, z: Float): Vector3D = Vector3D(x, y, z)
 
   def zeros[D <: Dim: NDSpace](implicit builder: Create[D]) = {
-    val dim = implicitly[NDSpace[D]].dimensionality
-    Vector.apply[D](Array.fill[Float](dim)(0f))
+    Vector.apply[D](Array.fill[Float](NDSpace[D].dimensionality)(0f))
   }
-  
+
   def fromBreezeVector[D <: Dim: NDSpace](breeze: DenseVector[Float])(implicit builder: Create[D]): Vector[D] = {
     val dim = implicitly[NDSpace[D]].dimensionality
     require(breeze.size == dim, s"Invalid size of breeze vector (${breeze.size} != $dim)")
     Vector.apply[D](breeze.data)
+  }
+
+  /** spire VectorSpace implementation for Vector */
+  implicit def spireVectorSpace[D <: Dim: NDSpace] = new spire.algebra.VectorSpace[Vector[D], Float] {
+    override implicit def scalar: Field[Float] = Field[Float]
+    override def timesl(r: Float, v: Vector[D]): Vector[D] = v.map(f => f * r)
+    override def negate(x: Vector[D]): Vector[D] = x.map(f => -f)
+    override def zero: Vector[D] = zeros[D]
+    override def plus(x: Vector[D], y: Vector[D]): Vector[D] = x.mapWithIndex((f, i) => f + y(i))
   }
 
   object implicits {

--- a/src/main/scala/scalismo/image/DiscreteImageDomain.scala
+++ b/src/main/scala/scalismo/image/DiscreteImageDomain.scala
@@ -112,7 +112,7 @@ abstract class DiscreteImageDomain[D <: Dim: NDSpace] extends DiscreteDomain[D] 
   }
 
   def indexToPoint(i: Index[D]) = {
-    indexToPhysicalCoordinateTransform(Point[D](i.data.map(_.toFloat)))
+    indexToPhysicalCoordinateTransform(Point[D](i.toArray.map(_.toFloat)))
   }
 
   private def isIndex(continousIndex: Vector[D]): Boolean = {
@@ -161,7 +161,7 @@ object DiscreteImageDomain {
   /** Create a new discreteImageDomain with given image box (i.e. a box that determines the area where the image is defined) and size */
   def apply[D <: Dim](imageBox: BoxDomain[D], spacing: Vector[D])(implicit evDim: NDSpace[D], evCreate: CreateDiscreteImageDomain[D]): DiscreteImageDomain[D] = {
     val sizeFractional = imageBox.extent.mapWithIndex({ case (ithExtent, i) => ithExtent / spacing(i) })
-    val size = Index.apply[D](sizeFractional.data.map(s => Math.ceil(s).toInt))
+    val size = Index.apply[D](sizeFractional.toArray.map(s => Math.ceil(s).toInt))
     evCreate.createImageDomain(imageBox.origin, spacing, size)
   }
 
@@ -222,7 +222,7 @@ case class DiscreteImageDomain2D(size: Index[_2D], indexToPhysicalCoordinateTran
   private val iVecImage = indexToPhysicalCoordinateTransform(Point(1, 0)) - indexToPhysicalCoordinateTransform(Point(0, 0))
   private val jVecImage = indexToPhysicalCoordinateTransform(Point(0, 1)) - indexToPhysicalCoordinateTransform(Point(0, 0))
 
-  override val directions = SquareMatrix[_2D]((iVecImage * (1.0 / iVecImage.norm)).data ++ (jVecImage * (1.0 / jVecImage.norm)).data)
+  override val directions = SquareMatrix[_2D]((iVecImage * (1.0 / iVecImage.norm)).toArray ++ (jVecImage * (1.0 / jVecImage.norm)).toArray)
   override def spacing = Vector(iVecImage.norm.toFloat, jVecImage.norm.toFloat)
 
   def points = for (j <- (0 until size(1)).toIterator; i <- (0 until size(0)).view) yield indexToPhysicalCoordinateTransform(Point(i, j))
@@ -249,9 +249,9 @@ case class DiscreteImageDomain3D(size: Index[_3D], indexToPhysicalCoordinateTran
   private val kVecImage = indexToPhysicalCoordinateTransform(Point(0, 0, 1)) - indexToPhysicalCoordinateTransform(Point(0, 0, 0))
 
   val directions = SquareMatrix[_3D](
-    ((iVecImage * (1.0 / iVecImage.norm)).data
-      ++ (jVecImage * (1.0 / jVecImage.norm)).data
-      ++ (kVecImage * (1.0 / kVecImage.norm)).data)
+    ((iVecImage * (1.0 / iVecImage.norm)).toArray
+      ++ (jVecImage * (1.0 / jVecImage.norm)).toArray
+      ++ (kVecImage * (1.0 / kVecImage.norm)).toArray)
       .map(_.toFloat)
   )
 
@@ -286,8 +286,8 @@ object CreateDiscreteImageDomain {
 
   implicit object CreateDiscreteImageDomain1D extends CreateDiscreteImageDomain[_1D] {
     override def createImageDomain(origin: Point[_1D], spacing: Vector[_1D], size: Index[_1D]): DiscreteImageDomain[_1D] = {
-      val rigidParameters = origin.data ++ Array(0f)
-      val anisotropicScalingParmaters = spacing.data
+      val rigidParameters = origin.toArray ++ Array(0f)
+      val anisotropicScalingParmaters = spacing.toArray
       val anisotropSimTransform = AnisotropicSimilarityTransformationSpace[_1D](Point(0)).transformForParameters(DenseVector(rigidParameters ++ anisotropicScalingParmaters))
       new DiscreteImageDomain1D(size, anisotropSimTransform)
 
@@ -300,8 +300,8 @@ object CreateDiscreteImageDomain {
 
   implicit object CreateDiscreteImageDomain2D extends CreateDiscreteImageDomain[_2D] {
     override def createImageDomain(origin: Point[_2D], spacing: Vector[_2D], size: Index[_2D]): DiscreteImageDomain[_2D] = {
-      val rigidParameters = origin.data ++ Array(0f)
-      val anisotropicScalingParmaters = spacing.data
+      val rigidParameters = origin.toArray ++ Array(0f)
+      val anisotropicScalingParmaters = spacing.toArray
       val anisotropSimTransform = AnisotropicSimilarityTransformationSpace[_2D](Point(0, 0)).transformForParameters(DenseVector(rigidParameters ++ anisotropicScalingParmaters))
       new DiscreteImageDomain2D(size, anisotropSimTransform)
     }
@@ -311,8 +311,8 @@ object CreateDiscreteImageDomain {
 
   implicit object CreateDiscreteImageDomain3D extends CreateDiscreteImageDomain[_3D] {
     override def createImageDomain(origin: Point[_3D], spacing: Vector[_3D], size: Index[_3D]): DiscreteImageDomain[_3D] = {
-      val rigidParameters = origin.data ++ Array(0f, 0f, 0f)
-      val anisotropicScalingParmaters = spacing.data
+      val rigidParameters = origin.toArray ++ Array(0f, 0f, 0f)
+      val anisotropicScalingParmaters = spacing.toArray
       val anisotropSimTransform = AnisotropicSimilarityTransformationSpace[_3D](Point(0, 0, 0)).transformForParameters(DenseVector(rigidParameters ++ anisotropicScalingParmaters))
       new DiscreteImageDomain3D(size, anisotropSimTransform)
     }

--- a/src/main/scala/scalismo/io/ImageIO.scala
+++ b/src/main/scala/scalismo/io/ImageIO.scala
@@ -562,7 +562,7 @@ object ImageIO {
     // (note that here the dimensions of the voxelArray are reversed compared the the
     // vector dims that is stored in the field Dimensions. This is the convention of the itk implementation
     // which we follow)
-    val voxelArrayDim = img.domain.size.data.reverse.map(_.toLong)
+    val voxelArrayDim = img.domain.size.toArray.reverse.map(_.toLong)
 
     val directions = NDArray[Double](
       IndexedSeq[Long](img.domain.size.dimensionality, img.domain.size.dimensionality),
@@ -571,9 +571,9 @@ object ImageIO {
     val maybeError: Try[Unit] = for {
       h5file <- HDF5Utils.createFile(file)
       _ <- h5file.writeNDArray("/ITKImage/0/Directions", directions)
-      _ <- h5file.writeArray("/ITKImage/0/Dimension", img.domain.size.data.map(_.toLong))
-      _ <- h5file.writeArray("/ITKImage/0/Origin", img.domain.origin.data.map(_.toDouble))
-      _ <- h5file.writeArray("/ITKImage/0/Spacing", img.domain.spacing.data.map(_.toDouble))
+      _ <- h5file.writeArray("/ITKImage/0/Dimension", img.domain.size.toArray.map(_.toLong))
+      _ <- h5file.writeArray("/ITKImage/0/Origin", img.domain.origin.toArray.map(_.toDouble))
+      _ <- h5file.writeArray("/ITKImage/0/Spacing", img.domain.spacing.toArray.map(_.toDouble))
       _ <- h5file.writeNDArray("/ITKImage/0/VoxelData", NDArray(voxelArrayDim, img.values.toArray))
       _ <- h5file.createGroup("/ITKImage/0/MetaData")
       _ <- h5file.writeString("/ITKVersion", "4.2.0") // we don't need it - ever

--- a/src/main/scala/scalismo/io/LandmarkIO.scala
+++ b/src/main/scala/scalismo/io/LandmarkIO.scala
@@ -49,14 +49,14 @@ object LandmarkIO {
   private implicit def m2u[D <: Dim: NDSpace](m: NDimensionalNormalDistribution[D]): Uncertainty = {
     val (pcs, variances) = m.principalComponents.unzip
     val stdDevs: List[Float] = variances.map(Math.sqrt(_).toFloat).toList
-    val pcList: List[List[Float]] = pcs.map(v => v.data.toList).toList
+    val pcList: List[List[Float]] = pcs.map(v => v.toArray.toList).toList
     Uncertainty(stdDevs, pcList)
   }
 
   private case class LandmarkJsonFormat[D <: Dim: NDSpace]() extends JsonFormat[ExtLandmark[D]] {
     def write(l: ExtLandmark[D]) = {
       val fixedMap = Map("id" -> JsString(l.lm.id),
-        "coordinates" -> arrayFormat[Float].write(l.lm.point.data))
+        "coordinates" -> arrayFormat[Float].write(l.lm.point.toArray))
       val descriptionMap = l.lm.description.map { d => Map("description" -> JsString(d)) }.getOrElse(Map())
       val uncertaintyMap = l.lm.uncertainty.map { u => Map("uncertainty" -> uncertaintyProtocol.write(u)) }.getOrElse(Map())
       val extensionsMap = l.exts.map(e => Map("extensions" -> JsObject(e))).getOrElse(Map())

--- a/src/main/scala/scalismo/io/MeshIO.scala
+++ b/src/main/scala/scalismo/io/MeshIO.scala
@@ -201,7 +201,7 @@ object MeshIO {
   }
 
   private def pointSeqToNDArray[T](points: IndexedSeq[Point[_3D]]): NDArray[Double] =
-    NDArray(IndexedSeq(points.size, 3), points.flatten(pt => pt.data.map(_.toDouble)).toArray)
+    NDArray(IndexedSeq(points.size, 3), points.flatten(pt => pt.toArray.map(_.toDouble)).toArray)
 
   private def cellSeqToNDArray[T](cells: IndexedSeq[TriangleCell]): NDArray[Int] =
     NDArray(IndexedSeq(cells.size, 3), cells.flatten(cell => cell.pointIds).toArray)

--- a/src/main/scala/scalismo/io/StatismoIO.scala
+++ b/src/main/scala/scalismo/io/StatismoIO.scala
@@ -175,7 +175,7 @@ object StatismoIO {
 
   def writeStatismoMeshModel(model: StatisticalMeshModel, file: File, modelPath: String = "/", statismoVersion: StatismoVersion = v090): Try[Unit] = {
 
-    val discretizedMean = model.mean.points.toIndexedSeq.flatten(_.data)
+    val discretizedMean = model.mean.points.toIndexedSeq.flatten(_.toArray)
     val variance = model.gp.variance
 
     val pcaBasis = model.gp.basisMatrix.copy
@@ -221,7 +221,7 @@ object StatismoIO {
   private def writeRepresenterStatismov090(h5file: HDF5File, group: Group, model: StatisticalMeshModel, modelPath: String): Try[Unit] = {
 
     val cellArray = model.referenceMesh.cells.map(_.ptId1) ++ model.referenceMesh.cells.map(_.ptId2) ++ model.referenceMesh.cells.map(_.ptId3)
-    val pts = model.referenceMesh.points.toIndexedSeq.par.map(p => (p.data(0).toDouble, p.data(1).toDouble, p.data(2).toDouble))
+    val pts = model.referenceMesh.points.toIndexedSeq.par.map(p => (p.toArray(0).toDouble, p.toArray(1).toDouble, p.toArray(2).toDouble))
     val pointArray = pts.map(_._1.toFloat) ++ pts.map(_._2.toFloat) ++ pts.map(_._3.toFloat)
 
     for {

--- a/src/main/scala/scalismo/mesh/TriangleMesh.scala
+++ b/src/main/scala/scalismo/mesh/TriangleMesh.scala
@@ -74,7 +74,7 @@ case class TriangleMesh private[scalismo] (private val meshPoints: IndexedSeq[Po
 
     val u = pt2 - pt1
     val v = pt3 - pt1
-    Vector.crossproduct(u, v)
+    u.crossproduct(v)
   }
 
   /**

--- a/src/main/scala/scalismo/registration/LandmarkRegistration.scala
+++ b/src/main/scala/scalismo/registration/LandmarkRegistration.scala
@@ -127,8 +127,8 @@ object LandmarkRegistration {
     val Y = DenseMatrix.zeros[Double](n, dimensionality)
 
     for (((x, y), i) <- landmarks.zipWithIndex) {
-      X(i, ::) := DenseVector(x.data.map(_.toDouble)).t
-      Y(i, ::) := DenseVector(y.data.map(_.toDouble)).t
+      X(i, ::) := DenseVector(x.toArray.map(_.toDouble)).t
+      Y(i, ::) := DenseVector(y.toArray.map(_.toDouble)).t
     }
 
     val mu_x = mean(X.t, Axis._1)

--- a/src/main/scala/scalismo/registration/TransformationSpace.scala
+++ b/src/main/scala/scalismo/registration/TransformationSpace.scala
@@ -626,7 +626,7 @@ case class AnisotropicScalingTransformation[D <: Dim: NDSpace](s: geometry.Vecto
   def takeDerivative(x: Point[D]): SquareMatrix[D] = SquareMatrix[D](breeze.linalg.diag(s.toBreezeVector).data)
 
   override def inverse: AnisotropicScalingTransformation[D] = {
-    val sinv = s.data.map(v => if (v == 0) 0 else 1.0 / v) map (_.toFloat)
+    val sinv = s.toArray.map(v => if (v == 0) 0 else 1.0 / v) map (_.toFloat)
     new AnisotropicScalingTransformation[D](Vector[D](sinv))
   }
 }
@@ -650,7 +650,7 @@ case class AnisotropicScalingSpace[D <: Dim: NDSpace]() extends TransformationSp
   }
 
   override def takeDerivativeWRTParameters(p: ParameterVector) = {
-    x: Point[D] => new DenseMatrix(parametersDimensionality, 1, x.data)
+    x: Point[D] => new DenseMatrix(parametersDimensionality, 1, x.toArray)
   }
 }
 /**

--- a/src/main/scala/scalismo/registration/TransformationSpace.scala
+++ b/src/main/scala/scalismo/registration/TransformationSpace.scala
@@ -620,7 +620,7 @@ private class RigidTransformationTransThenRot[D <: Dim: NDSpace](rotationTransfo
  */
 case class AnisotropicScalingTransformation[D <: Dim: NDSpace](s: geometry.Vector[D]) extends ParametricTransformation[D] with CanInvert[D] with CanDifferentiate[D] {
   override val domain = RealSpace[D]
-  override val f = (x: Point[D]) => Point((x.toBreezeVector :* s.toBreezeVector).data)
+  override val f = (x: Point[D]) => Point((x.toVector.toBreezeVector :* s.toBreezeVector).data)
 
   val parameters = s.toBreezeVector
   def takeDerivative(x: Point[D]): SquareMatrix[D] = SquareMatrix[D](breeze.linalg.diag(s.toBreezeVector).data)

--- a/src/main/scala/scalismo/statisticalmodel/DiscreteLowRankGaussianProcess.scala
+++ b/src/main/scala/scalismo/statisticalmodel/DiscreteLowRankGaussianProcess.scala
@@ -360,7 +360,7 @@ object DiscreteLowRankGaussianProcess {
     val dim = implicitly[NDSpace[DO]].dimensionality
     val (ptIds, ys, errorDistributions) = trainingData.unzip3
 
-    def flatten(v: IndexedSeq[Vector[DO]]) = DenseVector(v.flatten(_.data).toArray)
+    def flatten(v: IndexedSeq[Vector[DO]]) = DenseVector(v.flatten(_.toArray).toArray)
 
     val yVec = flatten(ys)
     val meanValues = ptIds.map { ptId =>

--- a/src/main/scala/scalismo/statisticalmodel/GaussianProcess.scala
+++ b/src/main/scala/scalismo/statisticalmodel/GaussianProcess.scala
@@ -111,7 +111,7 @@ object GaussianProcess {
 
     val outputDim = implicitly[NDSpace[DO]].dimensionality
 
-    def flatten(v: IndexedSeq[Vector[DO]]) = DenseVector(v.flatten(_.data).toArray)
+    def flatten(v: IndexedSeq[Vector[DO]]) = DenseVector(v.flatten(_.toArray).toArray)
 
     val (xs, ys, errorDists) = trainingData.unzip3
 

--- a/src/main/scala/scalismo/statisticalmodel/LowRankGaussianProcess.scala
+++ b/src/main/scala/scalismo/statisticalmodel/LowRankGaussianProcess.scala
@@ -244,7 +244,7 @@ object LowRankGaussianProcess {
     val outputDim = outputDimensionality
 
     val dim = implicitly[NDSpace[DO]].dimensionality
-    def flatten(v: IndexedSeq[Vector[DO]]) = DenseVector(v.flatten(_.data).toArray)
+    def flatten(v: IndexedSeq[Vector[DO]]) = DenseVector(v.flatten(_.toArray).toArray)
 
     val (xs, ys, errorDistributions) = trainingData.unzip3
 

--- a/src/main/scala/scalismo/statisticalmodel/MultivariateNormalDistribution.scala
+++ b/src/main/scala/scalismo/statisticalmodel/MultivariateNormalDistribution.scala
@@ -157,7 +157,7 @@ object NDimensionalNormalDistribution {
         for (i <- 0 until dim) data(i * dim + i) = principalComponents(i)._2
         SquareMatrix[D](data)
       }
-      val u = SquareMatrix[D](principalComponents.map(_._1.data).flatten.toArray)
+      val u = SquareMatrix[D](principalComponents.map(_._1.toArray).flatten.toArray)
       u * d2 * u.t
     }
     NDimensionalNormalDistribution(mean, cov)

--- a/src/main/scala/scalismo/statisticalmodel/StatisticalModel.scala
+++ b/src/main/scala/scalismo/statisticalmodel/StatisticalModel.scala
@@ -143,7 +143,7 @@ case class StatisticalMeshModel private (val referenceMesh: TriangleMesh, val gp
       val newMeanVecs = for ((pt, meanAtPoint) <- gp.mean.pointsWithValues) yield {
         rigidTransform(pt + meanAtPoint) - rigidTransform(pt)
       }
-      val data = newMeanVecs.map(_.data).flatten.toArray
+      val data = newMeanVecs.map(_.toArray).flatten.toArray
       DenseVector(data)
     }
 
@@ -153,7 +153,7 @@ case class StatisticalMeshModel private (val referenceMesh: TriangleMesh, val gp
       val newIthBasis = for ((pt, basisAtPoint) <- ithKlBasis.pointsWithValues) yield {
         rigidTransform(pt + basisAtPoint) - rigidTransform(pt)
       }
-      val data = newIthBasis.map(_.data).flatten.toArray
+      val data = newIthBasis.map(_.toArray).flatten.toArray
       newBasisMat(::, i) := DenseVector(data)
     }
     val newGp = new DiscreteLowRankGaussianProcess[_3D, _3D](gp.domain.transform(rigidTransform), newMean, gp.variance, newBasisMat)
@@ -169,7 +169,7 @@ case class StatisticalMeshModel private (val referenceMesh: TriangleMesh, val gp
 
     val newRef = referenceMesh.transform(t)
     val newMean = gp.mean.pointsWithValues.map { case (refPt, meanVec) => (refPt - t(refPt)) + meanVec }
-    val newMeanVec = DenseVector(newMean.map(_.data).flatten.toArray)
+    val newMeanVec = DenseVector(newMean.map(_.toArray).flatten.toArray)
     val newGp = new DiscreteLowRankGaussianProcess[_3D, _3D](newRef, newMeanVec, gp.variance, gp.basisMatrix)
     new StatisticalMeshModel(newRef, newGp)
   }

--- a/src/main/scala/scalismo/utils/Conversions.scala
+++ b/src/main/scala/scalismo/utils/Conversions.scala
@@ -252,7 +252,7 @@ object MeshConversion {
     }
 
     // set points
-    val pointDataArray = mesh.points.toIndexedSeq.toArray.map(_.data).flatten
+    val pointDataArray = mesh.points.toIndexedSeq.toArray.map(_.toArray).flatten
     val pointDataArrayVTK = VtkHelpers.scalarArrayToVtkDataArray(Scalar.FloatIsScalar.createArray(pointDataArray), 3)
     val pointsVTK = new vtkPoints
     pointsVTK.SetData(pointDataArrayVTK)

--- a/src/test/scala/scalismo/geometry/GeometryTests.scala
+++ b/src/test/scala/scalismo/geometry/GeometryTests.scala
@@ -22,12 +22,189 @@ import scala.language.implicitConversions
 
 class GeometryTests extends ScalismoTestSuite {
 
-  implicit def doubleToFloat(d: Double) = d.toFloat
+  implicit def doubleToFloat(d: Double): Float = d.toFloat
 
   val p = Point(0.1, 3.0, 1.1)
   val pGeneric: Point[_3D] = p
   val v = Vector(0.1, 3.0, 1.1)
   val vGeneric: Vector[_3D] = v
+
+  def checkPoint[D <: Dim: NDSpace]() = {
+    def randomPoint(): Point[D] = Point[D](Array.fill(NDSpace[D].dimensionality)(scala.util.Random.nextFloat()))
+    val pt = randomPoint()
+
+    describe(s"A random nD Point $pt (n=${NDSpace[D].dimensionality})") {
+      it("equals a Point with identical values") {
+        pt should equal(pt.map(v => v))
+      }
+
+      it("fulfills p + (p2 - p) - (p2 - p) == p") {
+        val p2 = randomPoint()
+        pt + (p2 - pt) - (p2 - pt) should equal(pt)
+      }
+
+      it("converts to an Array and back") {
+        Point[D](pt.toArray) should equal(pt)
+      }
+
+      it("converts to a Vector and back") {
+        pt.toVector.toPoint should be(pt)
+      }
+
+      it("converts to an Array of proper length") {
+        pt.toArray should have length NDSpace[D].dimensionality
+      }
+
+      it("converts to a Breeze vector and back") {
+        Point.fromBreezeVector[D](pt.toBreezeVector) should equal(pt)
+      }
+
+      it("can map a constant value p.map(f) == 0 (f: x => 0.0f)") {
+        val z = Point[D](Array.fill(NDSpace[D].dimensionality)(0f))
+        def f(x: Float): Float = 0.0f
+        pt.map(f) should equal(z)
+      }
+
+      it("can map a function p.map(f).map(g) == 0 (f: x => 2.0+x, g: x => x-2.0)") {
+        val z = Point[D](Array.fill(NDSpace[D].dimensionality)(0f))
+        val f = (x: Float) => 2.0f + x
+        val g = (x: Float) => x - 2.0f
+        (pt.map(f).map(g) - pt).norm should be < 1e-4
+      }
+
+      it("can map a function using its index: p.mapWithIndex(f) == 0 (f: (v,i) => v - p(i))") {
+        val z = Point[D](Array.fill(NDSpace[D].dimensionality)(0f))
+        pt.mapWithIndex((v, i) => v - pt(i)) should equal(z)
+      }
+    }
+  }
+
+  // test all dimensions for Point
+  checkPoint[_1D]()
+  checkPoint[_2D]()
+  checkPoint[_3D]()
+
+  def checkVector[D <: Dim: NDSpace]() = {
+    def randomVector(): Vector[D] = Vector[D](Array.fill(NDSpace[D].dimensionality)(scala.util.Random.nextFloat()))
+    val v = randomVector()
+
+    describe(s"A random nD Vector $v (n=${NDSpace[D].dimensionality})") {
+
+      it("equals a Vector with identical values") {
+        v should equal(v.map(f => f))
+      }
+
+      it("fulfills v*(-1) + v*(1) == 0") {
+        v * (-1) + v * 1 should equal(Vector.zeros[D])
+      }
+
+      it("fulfills v - v == 0") {
+        v - v should equal(Vector.zeros[D])
+      }
+
+      it("converts to an Array and back") {
+        Vector[D](v.toArray) should equal(v)
+      }
+
+      it("converts to an Array of proper length") {
+        v.toArray should have length NDSpace[D].dimensionality
+      }
+
+      it("converts to a Breeze vector and back") {
+        Vector.fromBreezeVector[D](v.toBreezeVector) should equal(v)
+      }
+
+      it("can map a constant value v.map(f) == 0 (f: x => 0.0f)") {
+        val z = Vector[D](Array.fill(NDSpace[D].dimensionality)(0f))
+        def f(x: Float): Float = 0.0f
+        v.map(f) should equal(z)
+      }
+
+      it("can map a function v.map(f).map(g) == 0 (f: x => 2.0+x, g: x => x-2.0)") {
+        val z = Vector[D](Array.fill(NDSpace[D].dimensionality)(0f))
+        val f = (x: Float) => 2.0f + x
+        val g = (x: Float) => x - 2.0f
+        (v.map(f).map(g) - v).norm should be < 1e-4
+      }
+
+      it("can map a function using its index: v.mapWithIndex(f) == 0 (f: (x,i) => x - v(i))") {
+        val z = Vector[D](Array.fill(NDSpace[D].dimensionality)(0f))
+        v.mapWithIndex((x, i) => x - v(i)) should equal(z)
+      }
+
+      it("converts to a Vector and back") {
+        v.toPoint.toVector should be(v)
+      }
+
+      it("has the proper relation between norm and norm2") {
+        math.sqrt(v.norm2) should be(v.norm +- 1e-5)
+      }
+
+      it("probably has a positive norm") {
+        v.norm should be > 0.0
+      }
+
+      it("provides a zero norm for zero vectors") {
+        Vector.zeros[D].norm should be(0.0 +- 1e-10)
+      }
+
+      val f = math.max(1e-10, scala.util.Random.nextFloat())
+      it(s"fulfills norm((v*f)/f - v) ~ 0 (f=$f)") {
+        ((v * f) / f - v).norm should be(0.0 +- 1e-4)
+      }
+    }
+  }
+
+  // test all dimensions for Vector
+  checkVector[_1D]()
+  checkVector[_2D]()
+  checkVector[_3D]()
+
+  def checkIndex[D <: Dim: NDSpace]() = {
+    def randomIndex(): Index[D] = Index[D](Array.fill(NDSpace[D].dimensionality)(scala.util.Random.nextInt()))
+    val ind = randomIndex()
+
+    describe(s"A random nD Index $ind (n=${NDSpace[D].dimensionality})") {
+      it("equals a Index with identical values") {
+        ind should equal(ind.map(v => v))
+      }
+
+      it("converts to an Array and back") {
+        Index[D](ind.toArray) should equal(ind)
+      }
+
+      it("converts to an Array of proper length") {
+        ind.toArray should have length NDSpace[D].dimensionality
+      }
+
+      it("converts to a Breeze vector and back") {
+        Index[D](ind.toBreezeVector.data) should equal(ind)
+      }
+
+      it("can map a constant value p.map(f) == 0 (f: x => 0)") {
+        val z = Index[D](Array.fill(NDSpace[D].dimensionality)(0))
+        def f(x: Int): Int = 0
+        ind.map(f) should equal(z)
+      }
+
+      it("can map a function p.map(f).map(g) == 0 (f: x => 2 + x, g: x => x - 2)") {
+        val z = Index[D](Array.fill(NDSpace[D].dimensionality)(0))
+        val f = (x: Int) => 2 + x
+        val g = (x: Int) => x - 2
+        ind.map(f).map(g) should equal(ind)
+      }
+
+      it("can map a function using its index: p.mapWithIndex(f) == 0 (f: (v,i) => v - p(i))") {
+        val z = Index[D](Array.fill(NDSpace[D].dimensionality)(0))
+        ind.mapWithIndex((v, i) => v - ind(i)) should equal(z)
+      }
+    }
+  }
+
+  // test all dimensions for Index
+  checkIndex[_1D]()
+  checkIndex[_2D]()
+  checkIndex[_3D]()
 
   describe("A 3D Point") {
     it("equals a Point[ThreeD]") {
@@ -95,7 +272,7 @@ class GeometryTests extends ScalismoTestSuite {
       val v1 = Vector(4.0, -3.0, -1.0)
       val v2 = Vector(3.0, 2.0, 5.0)
       val crossPdBreeze = breeze.linalg.cross(v1.toBreezeVector, v2.toBreezeVector)
-      Vector.crossproduct(v1, v2) should be(Vector(crossPdBreeze(0), crossPdBreeze(1), crossPdBreeze(2)))
+      v1.crossproduct(v2) should be(Vector(crossPdBreeze(0), crossPdBreeze(1), crossPdBreeze(2)))
     }
 
     it("can be mapped with a function f: (Float) => Float") {

--- a/src/test/scala/scalismo/geometry/GeometryTests.scala
+++ b/src/test/scala/scalismo/geometry/GeometryTests.scala
@@ -136,16 +136,51 @@ class GeometryTests extends ScalismoTestSuite {
         v.toPoint.toVector should be(v)
       }
 
+      it("inner product probably (1 example) fulfills dot(v,v) >= 0") {
+        v.dot(v) should be >= 0f
+      }
+
+      it("inner product probably (1 example) fulfills dot(a*v,w) == a*dot(v,w)") {
+        val a = scala.util.Random.nextFloat()
+        val w = randomVector()
+        (v * a).dot(w) - a * v.dot(w) should be < 1.0e-4.toFloat
+      }
+
+      it("inner product probably (1 example) fulfills dot(v+a,w) == dot(v,w)+dot(a,w)") {
+        val w = randomVector()
+        val a = randomVector()
+        (v + a).dot(w) - (v.dot(w) + a.dot(w)) should be < 1.0e-4.toFloat
+      }
+
+      it("inner product is probably (1 example) symmetric") {
+        val w = randomVector()
+        v.dot(w) - w.dot(v) should be < 1.0e-4.toFloat
+      }
+
       it("has the proper relation between norm and norm2") {
         math.sqrt(v.norm2) should be(v.norm +- 1e-5)
       }
 
-      it("probably has a positive norm") {
+      it("probably (1 example) has a positive norm") {
         v.norm should be > 0.0
       }
 
       it("provides a zero norm for zero vectors") {
         Vector.zeros[D].norm should be(0.0 +- 1e-10)
+      }
+
+      it("has norm which probably (1 example) fulfills the triangle equality") {
+        val w = randomVector()
+        (v + w).norm should be <= (v.norm + w.norm + 1e-6)
+      }
+
+      it("has norm which probably (1 example) fulfills (a*v).norm == |a|*v.norm(v)") {
+        val a = scala.util.Random.nextFloat()
+        (v * a).norm - math.abs(a) * v.norm should be <= 1e-6
+      }
+
+      it("has a norm which is derived from the inner product: dot(v,v)==v.norm2") {
+        v.norm2 should be(v.dot(v))
       }
 
       val f = math.max(1e-10, scala.util.Random.nextFloat())


### PR DESCRIPTION
A refactoring of the basic types `Point`/`Vector`/`Index` based on specific implementations for each dimensionality.

## Motivation:

* `Coordinate` hierarchy boxes
* slow beyond boxing due to the Array overhead, also in specific contexts (fixed dimensionality)
* access through `apply(i: Int)` led to unreadable code

## Features

* no more boxing, no generic Arrays
* specific types `Vector1D`, `Vector2D` and `Vector3D` with named members: usage e.g. `vec.x`
* all specific access and creation operations are faster (25% for rendering)
* preserves all generic operations in the form of `map` and `mapWithIndex`
* implicit conversions between general types and specific implementations: `Index[_3D]` and `Index3D`
* includes many new tests (in `GeometryTests`)

## Downsides

* generic apply access `apply(i: Int)` operations with a slight overhead due to indirect member access
* some duplicated code

## Technical Details

* storage backend with named members, no more Arrays
* generic creation needs a typeclass
* no "naked" data views anymore, any access as Array yields a copy (`point.data` is marked *deprecated* and linked to `toArray`, replaced by `point.toArray`)

### Create Typeclasses

Each of the classes provides a `Create[D]` typeclass to allow for generic construction. These would quickly clutter all generic code since they are needed to construct from Arrays, a very widespread operation. To hide these typeclasses, they have have been mixed into the `NDSpace[D]` object which is already present everywhere. So, no change is necessary to continue using old code like `Vector[D](array)`