### PR TITLE
update to sbt version 0.13.7

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.0
+sbt.version=0.13.7


### PR DESCRIPTION
Since typesafe [migrated their repos](https://www.typesafe.com/blog/incident-report-for-repo-typesafe-com-and-repo-scala-sbt-org)  using ```sbt 0.13.0``` leads to an obscure compilation error. Upgrading to a more recent sbt version resolves the problem.  