### PR TITLE
Introduce explicit type PointId (instead of Int) in DiscreteDomain.

### DIFF
--- a/src/main/scala/scalismo/common/DiscreteDomain.scala
+++ b/src/main/scala/scalismo/common/DiscreteDomain.scala
@@ -16,30 +16,35 @@
 package scalismo.common
 
 import scalismo.geometry._
-import scalismo.image.{ DiscreteImageDomain, DiscreteScalarImage }
-import scalismo.mesh.kdtree.KDTreeMap
 
-import scala.reflect.ClassTag
+final case class PointId(id: Int) extends AnyVal
 
 trait Cell {
-  def pointIds: IndexedSeq[Int]
+  def pointIds: IndexedSeq[PointId]
 }
 
 trait PointGenerator[D <: Dim] extends Function0[Point[D]]
 
-trait DiscreteDomain[D <: Dim] extends Equals { self =>
+trait DiscreteDomain[D <: Dim] extends Equals {
+  self =>
 
   def numberOfPoints: Int
+
   def points: Iterator[Point[D]]
-  def pointIds: Iterator[Int] = Iterator.range(0, numberOfPoints)
+
+  def pointIds: Iterator[PointId] = Iterator.range(0, numberOfPoints).map(id => PointId(id))
+
   def isDefinedAt(pt: Point[D]): Boolean
-  def pointId(pt: Point[D]): Option[Int]
-  def pointsWithId: Iterator[(Point[D], Int)] = points.zipWithIndex
 
-  def point(id: Int): Point[D]
+  def pointId(pt: Point[D]): Option[PointId]
 
-  def findClosestPoint(pt: Point[D]): (Point[D], Int)
-  def findNClosestPoints(pt: Point[D], n: Int): Seq[(Point[D], Int)]
+  def pointsWithId: Iterator[(Point[D], PointId)] = points.zipWithIndex.map { case (pt, id) => (pt, PointId(id)) }
+
+  def point(id: PointId): Point[D]
+
+  def findClosestPoint(pt: Point[D]): (Point[D], PointId)
+
+  def findNClosestPoints(pt: Point[D], n: Int): Seq[(Point[D], PointId)]
 
   def transform(t: Point[D] => Point[D]): DiscreteDomain[D]
 
@@ -58,6 +63,7 @@ trait DiscreteDomain[D <: Dim] extends Equals { self =>
   }
 
   override def canEqual(that: Any) = that.isInstanceOf[DiscreteDomain[D]]
+
   override def hashCode() = points.hashCode()
 
 }

--- a/src/main/scala/scalismo/common/DiscreteField.scala
+++ b/src/main/scala/scalismo/common/DiscreteField.scala
@@ -24,11 +24,12 @@ import scalismo.geometry.Point
 /**
  * Defines a discrete set of values, where each associated to a point of the domain.
  */
-trait DiscreteField[D <: Dim, A] extends PartialFunction[Int, A] { self =>
+trait DiscreteField[D <: Dim, A] extends PartialFunction[PointId, A] { self =>
 
   def domain: DiscreteDomain[D]
 
   def values: Iterator[A]
+  def valuesWithIds = values zip domain.pointIds
   def pointsWithValues = domain.points zip values
   def pointsWithIds = domain.points.zipWithIndex
 
@@ -55,8 +56,8 @@ class DiscreteScalarField[D <: Dim: NDSpace, A: Scalar: ClassTag](val domain: Di
   }
 
   override def values = data.iterator
-  override def apply(ptId: Int) = data(ptId)
-  override def isDefinedAt(ptId: Int) = data.isDefinedAt(ptId)
+  override def apply(ptId: PointId) = data(ptId.id)
+  override def isDefinedAt(ptId: PointId) = data.isDefinedAt(ptId.id)
 
   override def equals(other: Any): Boolean =
     other match {
@@ -91,8 +92,8 @@ object DiscreteScalarField {
 class DiscreteVectorField[D <: Dim: NDSpace, DO <: Dim: NDSpace](val domain: DiscreteDomain[D], private[scalismo] val data: IndexedSeq[Vector[DO]]) extends DiscreteField[D, Vector[DO]] {
 
   override def values = data.iterator
-  override def apply(ptId: Int) = data(ptId)
-  override def isDefinedAt(ptId: Int) = data.isDefinedAt(ptId)
+  override def apply(ptId: PointId) = data(ptId.id)
+  override def isDefinedAt(ptId: PointId) = data.isDefinedAt(ptId.id)
 
   def interpolateNearestNeighbor(): VectorField[D, DO] = {
     VectorField(RealSpace[D], (p: Point[D]) => apply(domain.findClosestPoint(p)._2))
@@ -105,7 +106,7 @@ class DiscreteVectorField[D <: Dim: NDSpace, DO <: Dim: NDSpace](val domain: Dis
     val d = implicitly[NDSpace[DO]].dimensionality
     val v = DenseVector.zeros[Float](domain.numberOfPoints * d)
     for ((pt, i) <- domain.pointsWithId) {
-      v(i * d until (i + 1) * d) := data(i).toBreezeVector
+      v(i.id * d until (i.id + 1) * d) := data(i.id).toBreezeVector
     }
     v
   }

--- a/src/main/scala/scalismo/image/DiscreteImageDomain.scala
+++ b/src/main/scala/scalismo/image/DiscreteImageDomain.scala
@@ -51,13 +51,13 @@ abstract class DiscreteImageDomain[D <: Dim: NDSpace] extends DiscreteDomain[D] 
 
   override def numberOfPoints = (0 until size.dimensionality).foldLeft(1)((res, d) => res * size(d))
 
-  override def point(id: Int): Point[D] = indexToPoint(index(id))
+  override def point(id: PointId): Point[D] = indexToPoint(index(id))
 
   /** converts a grid index into a id that identifies a point */
-  def pointId(idx: Index[D]): Int
+  def pointId(idx: Index[D]): PointId
 
   /** The index for the given point id */
-  def index(pointId: Int): Index[D]
+  def index(pointId: PointId): Index[D]
 
   /** the point corresponding to the given index */
   //def indexToPoint(i: Index[D]): Point[D]
@@ -83,20 +83,20 @@ abstract class DiscreteImageDomain[D <: Dim: NDSpace] extends DiscreteDomain[D] 
   }
 
   /** returns the point id in case it is defined, None otherwise. */
-  override def pointId(pt: Point[D]): Option[Int] = {
+  override def pointId(pt: Point[D]): Option[PointId] = {
     val cidx = pointToContinuousIndex(pt)
     val ptId = pointId(continuousIndextoIndex(cidx))
     if (isIndex(cidx)) Some(ptId) else None
   }
 
-  override def findClosestPoint(pt: Point[D]): (Point[D], Int) = {
+  override def findClosestPoint(pt: Point[D]): (Point[D], PointId) = {
     val cidx = pointToContinuousIndex(pt)
     val idxClosestPoint = continuousIndextoIndex(cidx)
     val ptIdClosestPoint = pointId(idxClosestPoint)
     (indexToPoint(idxClosestPoint), ptIdClosestPoint)
   }
 
-  override def findNClosestPoints(pt: Point[D], n: Int): Seq[(Point[D], Int)] = ???
+  override def findNClosestPoints(pt: Point[D], n: Int): Seq[(Point[D], PointId)] = ???
 
   private def continuousIndextoIndex(cidx: Vector[D]): Index[D] = {
     var d = 0;
@@ -215,8 +215,8 @@ case class DiscreteImageDomain1D(size: Index[_1D], indexToPhysicalCoordinateTran
 
   //override def indexToPhysicalCoordinateTransform = transform
 
-  override def index(linearIdx: Int) = Index(linearIdx)
-  override def pointId(idx: Index[_1D]) = idx(0)
+  override def index(linearIdx: PointId) = Index(linearIdx.id)
+  override def pointId(idx: Index[_1D]) = PointId(idx(0))
 
   override val directions = SquareMatrix(1.0f)
 
@@ -245,8 +245,8 @@ case class DiscreteImageDomain2D(size: Index[_2D], indexToPhysicalCoordinateTran
 
   def points = for (j <- (0 until size(1)).toIterator; i <- (0 until size(0)).view) yield indexToPhysicalCoordinateTransform(Point(i, j))
 
-  override def index(ptId: Int) = (Index(ptId % size(0), ptId / size(0)))
-  override def pointId(idx: Index[_2D]) = idx(0) + idx(1) * size(0)
+  override def index(ptId: PointId) = (Index(ptId.id % size(0), ptId.id / size(0)))
+  override def pointId(idx: Index[_2D]) = PointId(idx(0) + idx(1) * size(0))
 
   override def transform(t: Point[_2D] => Point[_2D]): UnstructuredPointsDomain[_2D] = {
     new UnstructuredPointsDomain2D(points.map(t).toIndexedSeq)
@@ -304,14 +304,14 @@ case class DiscreteImageDomain3D(size: Index[_3D], indexToPhysicalCoordinateTran
 
   override def indexToPoint(i: Index[_3D]) = indexToPhysicalCoordinateTransform(Point(i(0), i(1), i(2)))
 
-  override def index(pointId: Int) =
+  override def index(pointId: PointId) =
     Index(
-      pointId % (size(0) * size(1)) % size(0),
-      pointId % (size(0) * size(1)) / size(0),
-      pointId / (size(0) * size(1)))
+      pointId.id % (size(0) * size(1)) % size(0),
+      pointId.id % (size(0) * size(1)) / size(0),
+      pointId.id / (size(0) * size(1)))
 
-  override def pointId(idx: Index[_3D]): Int = {
-    idx(0) + idx(1) * size(0) + idx(2) * size(0) * size(1)
+  override def pointId(idx: Index[_3D]): PointId = {
+    PointId(idx(0) + idx(1) * size(0) + idx(2) * size(0) * size(1))
   }
 
   override def transform(t: Point[_3D] => Point[_3D]): UnstructuredPointsDomain[_3D] = {

--- a/src/main/scala/scalismo/image/DiscreteScalarImage.scala
+++ b/src/main/scala/scalismo/image/DiscreteScalarImage.scala
@@ -188,8 +188,8 @@ private class DiscreteScalarImage2D[A: Scalar: ClassTag](domain: DiscreteImageDo
         var k = k1
         while (k <= k1 + K - 1) {
           val kBC = DiscreteScalarImage.applyMirrorBoundaryCondition(k, domain.size(0))
-          val idx = domain.pointId(Index(kBC, lBC))
-          result = result + ck(idx) * splineBasis(xUnit - k, yUnit - l)
+          val pointId = domain.pointId(Index(kBC, lBC))
+          result = result + ck(pointId.id) * splineBasis(xUnit - k, yUnit - l)
           k = k + 1
         }
         l = l + 1
@@ -230,7 +230,7 @@ private class DiscreteScalarImage2D[A: Scalar: ClassTag](domain: DiscreteImageDo
       val c = rowValues.map(numeric.toFloat).toArray
       BSplineCoefficients.getSplineInterpolationCoefficients(degree, c)
 
-      val idxInCoeffs = img.domain.pointId(Index(0, y))
+      val idxInCoeffs = img.domain.pointId(Index(0, y)).id
       coeffs(idxInCoeffs until idxInCoeffs + img.domain.size(0)) := DenseVector(c)
       y = y + 1
     }
@@ -269,8 +269,8 @@ private class DiscreteScalarImage3D[A: Scalar: ClassTag](domain: DiscreteImageDo
           k = k1
           while (k <= k1 + K - 1) {
             val kBC = DiscreteScalarImage.applyMirrorBoundaryCondition(k, domain.size(0))
-            val idx = domain.pointId(Index(kBC, lBC, mBC))
-            result = result + ck(idx) * splineBasis(xUnit - k, yUnit - l, zUnit - m)
+            val pointId = domain.pointId(Index(kBC, lBC, mBC))
+            result = result + ck(pointId.id) * splineBasis(xUnit - k, yUnit - l, zUnit - m)
             k = k + 1
           }
           l = l + 1
@@ -313,7 +313,7 @@ private class DiscreteScalarImage3D[A: Scalar: ClassTag](domain: DiscreteImageDo
         // the c is an input-output argument here
         val c = rowValues.map(numeric.toFloat).toArray
         BSplineCoefficients.getSplineInterpolationCoefficients(degree, c)
-        val idxInCoeffs = img.domain.pointId(Index(0, y, z))
+        val idxInCoeffs = img.domain.pointId(Index(0, y, z)).id
         coeffs(idxInCoeffs until idxInCoeffs + img.domain.size(0)) := DenseVector(c)
         y = y + 1
       }

--- a/src/main/scala/scalismo/io/MeshIO.scala
+++ b/src/main/scala/scalismo/io/MeshIO.scala
@@ -16,7 +16,7 @@
 package scalismo.io
 
 import java.io.File
-import scalismo.common.Scalar
+import scalismo.common.{ PointId, Scalar }
 import scalismo.utils.MeshConversion
 import scalismo.mesh.{ TriangleCell, ScalarMeshField, TriangleMesh }
 import scalismo.geometry._
@@ -197,13 +197,13 @@ object MeshIO {
 
   private def NDArrayToCellSeq(ndarray: NDArray[Int]): IndexedSeq[TriangleCell] = {
     // take block of 3, map them to 3dPoints and convert the resulting array to an indexed seq 
-    ndarray.data.grouped(3).map(grp => TriangleCell(grp(0), grp(1), grp(2))).toIndexedSeq
+    ndarray.data.grouped(3).map(grp => TriangleCell(PointId(grp(0)), PointId(grp(1)), PointId(grp(2)))).toIndexedSeq
   }
 
   private def pointSeqToNDArray[T](points: IndexedSeq[Point[_3D]]): NDArray[Double] =
     NDArray(IndexedSeq(points.size, 3), points.flatten(pt => pt.toArray.map(_.toDouble)).toArray)
 
   private def cellSeqToNDArray[T](cells: IndexedSeq[TriangleCell]): NDArray[Int] =
-    NDArray(IndexedSeq(cells.size, 3), cells.flatten(cell => cell.pointIds).toArray)
+    NDArray(IndexedSeq(cells.size, 3), cells.flatten(cell => cell.pointIds.map(_.id)).toArray)
 }
 

--- a/src/main/scala/scalismo/io/StatismoIO.scala
+++ b/src/main/scala/scalismo/io/StatismoIO.scala
@@ -17,6 +17,7 @@ package scalismo.io
 
 import java.io.File
 
+import scalismo.common.PointId
 import scalismo.geometry.{ _3D, Point }
 import scalismo.io.StatismoIO.StatismoModelType.StatismoModelType
 import scalismo.mesh.{ TriangleCell, TriangleMesh }
@@ -220,7 +221,7 @@ object StatismoIO {
 
   private def writeRepresenterStatismov090(h5file: HDF5File, group: Group, model: StatisticalMeshModel, modelPath: String): Try[Unit] = {
 
-    val cellArray = model.referenceMesh.cells.map(_.ptId1) ++ model.referenceMesh.cells.map(_.ptId2) ++ model.referenceMesh.cells.map(_.ptId3)
+    val cellArray = model.referenceMesh.cells.map(_.ptId1.id) ++ model.referenceMesh.cells.map(_.ptId2.id) ++ model.referenceMesh.cells.map(_.ptId3.id)
     val pts = model.referenceMesh.points.toIndexedSeq.par.map(p => (p.toArray(0).toDouble, p.toArray(1).toDouble, p.toArray(2).toDouble))
     val pointArray = pts.map(_._1.toFloat) ++ pts.map(_._2.toFloat) ++ pts.map(_._3.toFloat)
 
@@ -299,7 +300,7 @@ object StatismoIO {
         else
           Success(cellArray))
       cellMat = ndArrayToMatrix(cellArray)
-      cells = for (i <- 0 until cellMat.cols) yield TriangleCell(cellMat(0, i), cellMat(1, i), cellMat(2, i))
+      cells = for (i <- 0 until cellMat.cols) yield TriangleCell(PointId(cellMat(0, i)), PointId(cellMat(1, i)), PointId(cellMat(2, i)))
       cellArray <- h5file.readNDArray[Int](s"$modelPath/representer/cells")
     } yield TriangleMesh(points, cells)
   }

--- a/src/main/scala/scalismo/kernels/DiscreteKernel.scala
+++ b/src/main/scala/scalismo/kernels/DiscreteKernel.scala
@@ -17,7 +17,7 @@
 package scalismo.kernels
 
 import breeze.linalg.DenseMatrix
-import scalismo.common.DiscreteDomain
+import scalismo.common.{ PointId, DiscreteDomain }
 import scalismo.geometry.{ NDSpace, Dim, SquareMatrix }
 
 /**
@@ -26,16 +26,16 @@ import scalismo.geometry.{ NDSpace, Dim, SquareMatrix }
  *  is a matrix. Furthermore, the class has the knowledge about its domain (the point on which it is defined).
  */
 class DiscreteMatrixValuedPDKernel[D <: Dim: NDSpace, DO <: Dim: NDSpace] private[scalismo] (val domain: DiscreteDomain[D],
-    val k: (Int, Int) => SquareMatrix[DO]) {
+    val k: (PointId, PointId) => SquareMatrix[DO]) {
   self =>
 
   def outputDim = implicitly[NDSpace[DO]].dimensionality
 
-  def apply(i: Int, j: Int): SquareMatrix[DO] = {
-    if (i < domain.numberOfPoints && j < domain.numberOfPoints)
+  def apply(i: PointId, j: PointId): SquareMatrix[DO] = {
+    if (i.id < domain.numberOfPoints && j.id < domain.numberOfPoints)
       k(i, j)
     else {
-      if (i >= domain.numberOfPoints) {
+      if (i.id >= domain.numberOfPoints) {
         throw new IllegalArgumentException((s"$i is not a valid index"))
       } else {
         throw new IllegalArgumentException((s"$j is not a valid index"))
@@ -55,7 +55,7 @@ class DiscreteMatrixValuedPDKernel[D <: Dim: NDSpace, DO <: Dim: NDSpace] privat
     val xiWithIndex = xs.zipWithIndex.par
     val xjWithIndex = xs.zipWithIndex
     for { i <- 0 until xs.size; j <- 0 to i } {
-      val kxixj = k(i, j)
+      val kxixj = k(PointId(i), PointId(j))
       var di = 0;
       while (di < d) {
         var dj = 0;
@@ -73,7 +73,7 @@ class DiscreteMatrixValuedPDKernel[D <: Dim: NDSpace, DO <: Dim: NDSpace] privat
 }
 
 object DiscreteMatrixValuedPDKernel {
-  def apply[D <: Dim: NDSpace, DO <: Dim: NDSpace](domain: DiscreteDomain[D], k: (Int, Int) => SquareMatrix[DO]) = {
+  def apply[D <: Dim: NDSpace, DO <: Dim: NDSpace](domain: DiscreteDomain[D], k: (PointId, PointId) => SquareMatrix[DO]) = {
     new DiscreteMatrixValuedPDKernel(domain, k)
   }
 }

--- a/src/main/scala/scalismo/kernels/Kernel.scala
+++ b/src/main/scala/scalismo/kernels/Kernel.scala
@@ -16,7 +16,7 @@
 package scalismo.kernels
 
 import breeze.linalg.{ DenseVector, pinv, diag, DenseMatrix }
-import scalismo.common.{ UnstructuredPointsDomain, DiscreteDomain, VectorField, Domain }
+import scalismo.common._
 import scalismo.geometry._
 import scalismo.numerics.{ RandomSVD, Sampler }
 import scalismo.statisticalmodel.LowRankGaussianProcess.{ Eigenpair, KLBasis }
@@ -109,7 +109,7 @@ abstract class MatrixValuedPDKernel[D <: Dim: NDSpace, DO <: Dim: NDSpace] { sel
    */
   def discretize(domain: DiscreteDomain[D]): DiscreteMatrixValuedPDKernel[D, DO] = {
 
-    def k(i: Int, j: Int): SquareMatrix[DO] = {
+    def k(i: PointId, j: PointId): SquareMatrix[DO] = {
       self.k(domain.point(i), domain.point(j))
     }
     DiscreteMatrixValuedPDKernel[D, DO](domain, k)

--- a/src/main/scala/scalismo/mesh/Mesh.scala
+++ b/src/main/scala/scalismo/mesh/Mesh.scala
@@ -15,7 +15,7 @@
  */
 package scalismo.mesh
 
-import scalismo.common.RealSpace
+import scalismo.common.{ PointId, RealSpace }
 import scalismo.geometry._
 import scalismo.image.{ DifferentiableScalarImage, ScalarImage }
 
@@ -71,13 +71,13 @@ object Mesh {
 
     val remainingPointTriplet = mesh.cells.par.map {
       cell =>
-        val points = cell.pointIds.map(pts)
+        val points = cell.pointIds.map(pointId => pts(pointId.id))
         (points, points.map(p => remainingPoints.get(p).isDefined).reduce(_ && _))
     }.filter(_._2).map(_._1)
 
     val points = remainingPointTriplet.flatten.distinct
     val pt2Id = points.zipWithIndex.toMap
-    val cells = remainingPointTriplet.map { case vec => TriangleCell(pt2Id(vec(0)), pt2Id(vec(1)), pt2Id(vec(2))) }
+    val cells = remainingPointTriplet.map { case vec => TriangleCell(PointId(pt2Id(vec(0))), PointId(pt2Id(vec(1))), PointId(pt2Id(vec(2)))) }
 
     TriangleMesh(points.toIndexedSeq, cells.toIndexedSeq)
   }

--- a/src/main/scala/scalismo/registration/TransformationSpace.scala
+++ b/src/main/scala/scalismo/registration/TransformationSpace.scala
@@ -18,7 +18,6 @@ package scalismo.registration
 import TransformationSpace.ParameterVector
 import breeze.linalg.DenseVector
 import breeze.linalg.DenseMatrix
-import java.util.Arrays
 import scalismo.geometry
 import scalismo.geometry._
 import scalismo.common._
@@ -122,8 +121,6 @@ class ProductTransformationSpace[D <: Dim, OT <: ParametricTransformation[D] wit
   /**Returns a transform belonging to the product space. Parameters should be a concatenation of the outer and inner space parameters*/
   override def transformForParameters(p: ParameterVector) = {
     val (outerParams, innerParams) = splitProductParameterVector(p)
-    val v = outer.transformForParameters(outerParams)
-
     new ProductTransformation(outer.transformForParameters(outerParams), inner.transformForParameters(innerParams))
   }
 
@@ -390,7 +387,7 @@ private case class RotationTransform3D(rotMatrix: SquareMatrix[_3D], centre: Poi
   override val f = (pt: Point[_3D]) => {
     val ptCentered = pt - centre
     val rotCentered = rotMatrix * ptCentered
-    centre + Vector(rotCentered(0).toFloat, rotCentered(1).toFloat, rotCentered(2).toFloat)
+    centre + Vector(rotCentered(0), rotCentered(1), rotCentered(2))
   }
 
   override val domain = RealSpace[_3D]
@@ -410,7 +407,7 @@ private case class RotationTransform2D(rotMatrix: SquareMatrix[_2D], centre: Poi
   override val f = (pt: Point[_2D]) => {
     val ptCentered = pt - centre
     val rotCentered = rotMatrix * ptCentered
-    centre + Vector(rotCentered(0).toFloat, rotCentered(1).toFloat)
+    centre + Vector(rotCentered(0), rotCentered(1))
   }
   override def domain = RealSpace[_2D]
 
@@ -434,7 +431,7 @@ private[scalismo] case class RotationTransform1D() extends RotationTransform[_1D
 
   val parameters = DenseVector.zeros[Float](0)
 
-  def takeDerivative(x: Point[_1D]): SquareMatrix[_1D] = ???
+  def takeDerivative(x: Point[_1D]): SquareMatrix[_1D] = throw new UnsupportedOperationException
 
   override def inverse: RotationTransform1D = {
     RotationTransform1D()
@@ -693,7 +690,7 @@ case class AnisotropicSimilarityTransformationSpace[D <: Dim: NDSpace: CreateRot
    *  constructors or factory methods.
    *
    *  The order of operations in the rigid transformation is first rotation, then translation.
-   *  @param : p parameter vector for the transform. This must be a concatenation of the rigid transform parameters first, then scaling parameters
+   *  @param p parameter vector for the transform. This must be a concatenation of the rigid transform parameters first, then scaling parameters
    *
    */
   override def transformForParameters(p: ParameterVector): AnisotropicSimilarityTransformation[D] = {

--- a/src/main/scala/scalismo/statisticalmodel/DiscreteGaussianProcess.scala
+++ b/src/main/scala/scalismo/statisticalmodel/DiscreteGaussianProcess.scala
@@ -59,7 +59,7 @@ class DiscreteGaussianProcess[D <: Dim: NDSpace, DO <: Dim: NDSpace] private[sca
   /**
    * The marginal distribution at a given (single) point, specified by the pointId.
    */
-  def marginal(pointId: Int) = {
+  def marginal(pointId: PointId) = {
     NDimensionalNormalDistribution(mean(pointId), cov(pointId, pointId))
   }
 
@@ -67,15 +67,15 @@ class DiscreteGaussianProcess[D <: Dim: NDSpace, DO <: Dim: NDSpace] private[sca
    * The marginal distribution for the points specified by the given point ids.
    * Note that this is again a DiscreteGaussianProcess.
    */
-  def marginal(pointIds: Seq[Int])(implicit domainCreator: CreateUnstructuredPointsDomain[D]): DiscreteGaussianProcess[D, DO] = {
+  def marginal(pointIds: Seq[PointId])(implicit domainCreator: CreateUnstructuredPointsDomain[D]): DiscreteGaussianProcess[D, DO] = {
     val domainPts = domain.points.toIndexedSeq
 
-    val newPts = pointIds.map(id => domainPts(id)).toIndexedSeq
+    val newPts = pointIds.map(pointId => domainPts(pointId.id)).toIndexedSeq
     val newDomain = domainCreator.create(newPts)
 
     val newMean = DiscreteVectorField(newDomain, pointIds.toIndexedSeq.map(id => mean(id)))
-    val newCov = (i: Int, j: Int) => {
-      cov(pointIds(i), pointIds(j))
+    val newCov = (i: PointId, j: PointId) => {
+      cov(pointIds(i.id), pointIds(j.id))
     }
     val newDiscreteCov = DiscreteMatrixValuedPDKernel(newDomain, newCov)
 
@@ -145,7 +145,7 @@ object DiscreteGaussianProcess {
 
     val discreteMean = DiscreteVectorField[D, DO](domain, domainPoints.map(pt => gp.mean(pt)))
 
-    val k = (i: Int, j: Int) => gp.cov(domainPoints(i), domainPoints(j))
+    val k = (i: PointId, j: PointId) => gp.cov(domainPoints(i.id), domainPoints(j.id))
     val discreteCov = DiscreteMatrixValuedPDKernel(domain, k)
 
     new DiscreteGaussianProcess[D, DO](discreteMean, discreteCov)

--- a/src/main/scala/scalismo/statisticalmodel/DiscreteLowRankGaussianProcess.scala
+++ b/src/main/scala/scalismo/statisticalmodel/DiscreteLowRankGaussianProcess.scala
@@ -95,7 +95,7 @@ case class DiscreteLowRankGaussianProcess[D <: Dim: NDSpace, DO <: Dim: NDSpace]
   def coefficients(s: DiscreteVectorField[D, DO]): DenseVector[Float] = {
     val sigma2 = 1e-5f // regularization weight to avoid numerical problems
     val noiseDist = NDimensionalNormalDistribution(Vector.zeros[DO], SquareMatrix.eye[DO] * sigma2)
-    val td = s.values.zipWithIndex.map { case (v, id) => (id, v, noiseDist) }.toIndexedSeq
+    val td = s.valuesWithIds.map { case (v, id) => (id, v, noiseDist) }.toIndexedSeq
     val (minv, qtL, yVec, mVec) = DiscreteLowRankGaussianProcess.genericRegressionComputations(this, td)
     val mean_coeffs = (minv * qtL).map(_.toFloat) * (yVec - mVec)
     mean_coeffs
@@ -106,7 +106,7 @@ case class DiscreteLowRankGaussianProcess[D <: Dim: NDSpace, DO <: Dim: NDSpace]
    * data are defined by the pointId. The returned posterior process is defined at the same points.
    *
    */
-  def posterior(trainingData: IndexedSeq[(Int, Vector[DO])], sigma2: Double): DiscreteLowRankGaussianProcess[D, DO] = {
+  def posterior(trainingData: IndexedSeq[(PointId, Vector[DO])], sigma2: Double): DiscreteLowRankGaussianProcess[D, DO] = {
     val cov = NDimensionalNormalDistribution(Vector.zeros[DO], SquareMatrix.eye[DO] * sigma2)
     val newtd = trainingData.map { case (ptId, df) => (ptId, df, cov) }
     posterior(newtd)
@@ -117,14 +117,14 @@ case class DiscreteLowRankGaussianProcess[D <: Dim: NDSpace, DO <: Dim: NDSpace]
    * data are defined by the pointId. The returned posterior process is defined at the same points.
    *
    */
-  def posterior(trainingData: IndexedSeq[(Int, Vector[DO], NDimensionalNormalDistribution[DO])]): DiscreteLowRankGaussianProcess[D, DO] = {
+  def posterior(trainingData: IndexedSeq[(PointId, Vector[DO], NDimensionalNormalDistribution[DO])]): DiscreteLowRankGaussianProcess[D, DO] = {
     DiscreteLowRankGaussianProcess.regression(this, trainingData)
   }
 
-  override def marginal(pointIds: Seq[Int])(implicit domainCreator: CreateUnstructuredPointsDomain[D]): DiscreteLowRankGaussianProcess[D, DO] = {
+  override def marginal(pointIds: Seq[PointId])(implicit domainCreator: CreateUnstructuredPointsDomain[D]): DiscreteLowRankGaussianProcess[D, DO] = {
     val domainPts = domain.points.toIndexedSeq
 
-    val newPts = pointIds.map(id => domainPts(id)).toIndexedSeq
+    val newPts = pointIds.map(pointId => domainPts(pointId.id)).toIndexedSeq
     val newDomain = domainCreator.create(newPts)
 
     val newMean = DiscreteVectorField(newDomain, pointIds.toIndexedSeq.map(id => mean(id)))
@@ -196,14 +196,14 @@ case class DiscreteLowRankGaussianProcess[D <: Dim: NDSpace, DO <: Dim: NDSpace]
     // we will have the same oints for all the eigenfunctions
     val findClosestPointMemo = Memoize((pt: Point[D]) => domain.findClosestPoint(pt)._2, cacheSizeHint = 1000000)
 
-    def meanFun(closestPointFun: Point[D] => Int)(pt: Point[D]): Vector[DO] = {
+    def meanFun(closestPointFun: Point[D] => PointId)(pt: Point[D]): Vector[DO] = {
       val closestPtId = closestPointFun(pt)
       meanPD(closestPtId)
     }
 
-    def phi(i: Int, closetPointFun: Point[D] => Int)(pt: Point[D]): Vector[DO] = {
+    def phi(i: Int, closetPointFun: Point[D] => PointId)(pt: Point[D]): Vector[DO] = {
       val closestPtId = closetPointFun(pt)
-      Vector[DO](basisMatrix(closestPtId * outputDimensionality until (closestPtId + 1) * outputDimensionality, i).toArray)
+      Vector[DO](basisMatrix(closestPtId.id * outputDimensionality until (closestPtId.id + 1) * outputDimensionality, i).toArray)
     }
 
     val interpolatedKLBasis = {
@@ -283,7 +283,7 @@ object DiscreteLowRankGaussianProcess {
    * Discrete implementation of [[LowRankGaussianProcess.regression]]
    */
   def regression[D <: Dim: NDSpace, DO <: Dim: NDSpace](gp: DiscreteLowRankGaussianProcess[D, DO],
-    trainingData: IndexedSeq[(Int, Vector[DO], NDimensionalNormalDistribution[DO])]): DiscreteLowRankGaussianProcess[D, DO] = {
+    trainingData: IndexedSeq[(PointId, Vector[DO], NDimensionalNormalDistribution[DO])]): DiscreteLowRankGaussianProcess[D, DO] = {
 
     val dim = implicitly[NDSpace[DO]].dimensionality
 
@@ -328,9 +328,9 @@ object DiscreteLowRankGaussianProcess {
     val X = DenseMatrix.zeros[Float](n, p * dim)
     for (p1 <- transformations.zipWithIndex.par; p2 <- domain.pointsWithId) {
       val (t, i) = p1
-      val (x, j) = p2
+      val (x, ptId) = p2
       val ux = t(x) - x
-      X(i, j * dim until (j + 1) * dim) := ux.toBreezeVector.t
+      X(i, ptId.id * dim until (ptId.id + 1) * dim) := ux.toBreezeVector.t
     }
 
     def demean(X: DenseMatrix[Float]): (DenseMatrix[Double], DenseVector[Double]) = {
@@ -356,7 +356,7 @@ object DiscreteLowRankGaussianProcess {
   }
 
   private def genericRegressionComputations[D <: Dim: NDSpace, DO <: Dim: NDSpace](gp: DiscreteLowRankGaussianProcess[D, DO],
-    trainingData: IndexedSeq[(Int, Vector[DO], NDimensionalNormalDistribution[DO])]) = {
+    trainingData: IndexedSeq[(PointId, Vector[DO], NDimensionalNormalDistribution[DO])]) = {
     val dim = implicitly[NDSpace[DO]].dimensionality
     val (ptIds, ys, errorDistributions) = trainingData.unzip3
 
@@ -365,7 +365,7 @@ object DiscreteLowRankGaussianProcess {
     val yVec = flatten(ys)
     val meanValues = ptIds.map { ptId =>
       {
-        val v = gp.meanVector(ptId * dim until (ptId + 1) * dim).copy
+        val v = gp.meanVector(ptId.id * dim until (ptId.id + 1) * dim).copy
         Vector[DO](v.data)
       }
     }
@@ -373,7 +373,7 @@ object DiscreteLowRankGaussianProcess {
 
     val Q = DenseMatrix.zeros[Double](trainingData.size * dim, gp.rank)
     for ((ptId, i) <- ptIds.zipWithIndex; j <- 0 until gp.rank) {
-      val eigenVecAtPoint = gp.basisMatrix((ptId * dim) until ((ptId + 1) * dim), j).map(_.toDouble)
+      val eigenVecAtPoint = gp.basisMatrix((ptId.id * dim) until ((ptId.id + 1) * dim), j).map(_.toDouble)
       Q(i * dim until i * dim + dim, j) := eigenVecAtPoint * math.sqrt(gp.variance(j))
     }
 
@@ -399,10 +399,10 @@ object DiscreteLowRankGaussianProcess {
     basisMatrix: DenseMatrix[Float]) = {
 
     val outputDimensionality = implicitly[NDSpace[D]].dimensionality
-    def cov(ptId1: Int, ptId2: Int): SquareMatrix[DO] = {
+    def cov(ptId1: PointId, ptId2: PointId): SquareMatrix[DO] = {
 
-      val eigenMatrixForPtId1 = basisMatrix(ptId1 * outputDimensionality until (ptId1 + 1) * outputDimensionality, ::)
-      val eigenMatrixForPtId2 = basisMatrix(ptId2 * outputDimensionality until (ptId2 + 1) * outputDimensionality, ::)
+      val eigenMatrixForPtId1 = basisMatrix(ptId1.id * outputDimensionality until (ptId1.id + 1) * outputDimensionality, ::)
+      val eigenMatrixForPtId2 = basisMatrix(ptId2.id * outputDimensionality until (ptId2.id + 1) * outputDimensionality, ::)
       //val covValue = eigenMatrixForPtId1 * breeze.linalg.diag(stddev :* stddev) * eigenMatrixForPtId2.t
 
       // same as commented line above, but just much more efficient (as breeze does not have diag matrix,
@@ -410,10 +410,10 @@ object DiscreteLowRankGaussianProcess {
       val covValue = DenseMatrix.zeros[Float](outputDimensionality, outputDimensionality)
 
       for (i <- (0 until outputDimensionality).par) {
-        val ind1 = ptId1 * outputDimensionality + i
+        val ind1 = ptId1.id * outputDimensionality + i
         var j = 0
         while (j < outputDimensionality) {
-          val ind2 = ptId2 * outputDimensionality + j
+          val ind2 = ptId2.id * outputDimensionality + j
           var k = 0
           var valueIJ = 0f
           while (k < basisMatrix.cols) {

--- a/src/main/scala/scalismo/statisticalmodel/GaussianProcess.scala
+++ b/src/main/scala/scalismo/statisticalmodel/GaussianProcess.scala
@@ -55,8 +55,8 @@ class GaussianProcess[D <: Dim: NDSpace, DO <: Dim: NDSpace] protected (val mean
   def marginal(domain: DiscreteDomain[D]): DiscreteGaussianProcess[D, DO] = {
     val meanField = DiscreteVectorField(domain, domain.points.toIndexedSeq.map(pt => mean(pt)))
     val pts = domain.points.toIndexedSeq
-    def newCov(i: Int, j: Int): SquareMatrix[DO] = {
-      cov(pts(i), pts(j))
+    def newCov(i: PointId, j: PointId): SquareMatrix[DO] = {
+      cov(pts(i.id), pts(j.id))
     }
 
     val discreteCov = DiscreteMatrixValuedPDKernel[D, DO](domain, newCov)

--- a/src/main/scala/scalismo/statisticalmodel/StatisticalModel.scala
+++ b/src/main/scala/scalismo/statisticalmodel/StatisticalModel.scala
@@ -16,7 +16,7 @@
 package scalismo.statisticalmodel
 
 import breeze.linalg.{ DenseMatrix, DenseVector }
-import scalismo.common.DiscreteVectorField
+import scalismo.common.{ PointId, DiscreteVectorField }
 import scalismo.geometry.{ Point, _3D }
 import scalismo.mesh.{ Mesh, TriangleMesh }
 import scalismo.registration.{ RigidTransformation, Transformation }
@@ -45,7 +45,7 @@ case class StatisticalMeshModel private (val referenceMesh: TriangleMesh, val gp
    * The covariance between two points of the  mesh with given point id.
    * @see [[DiscreteLowRankGaussianProcess.cov]]
    */
-  def cov(ptId1: Int, ptId2: Int) = gp.cov(ptId1, ptId2)
+  def cov(ptId1: PointId, ptId2: PointId) = gp.cov(ptId1, ptId2)
 
   /**
    * draws a random shape.
@@ -82,7 +82,7 @@ case class StatisticalMeshModel private (val referenceMesh: TriangleMesh, val gp
    *
    * @see [[DiscreteLowRankGaussianProcess.marginal]]
    */
-  def marginal(ptIds: IndexedSeq[Int]) = {
+  def marginal(ptIds: IndexedSeq[PointId]) = {
     val clippedReference = Mesh.clipMesh(referenceMesh, p => { !ptIds.contains(referenceMesh.findClosestPoint(p)._2) })
     // not all of the ptIds remain in the reference after clipping, since their cells might disappear
     val remainingPtIds = clippedReference.points.map(p => referenceMesh.findClosestPoint(p)._2).toIndexedSeq
@@ -117,7 +117,7 @@ case class StatisticalMeshModel private (val referenceMesh: TriangleMesh, val gp
   /**
    * Similar to [[DiscreteLowRankGaussianProcess.posterior(Int, Point[_3D])], sigma2: Double)]], but the training data is defined by specifying the target point instead of the displacement vector
    */
-  def posterior(trainingData: IndexedSeq[(Int, Point[_3D])], sigma2: Double): StatisticalMeshModel = {
+  def posterior(trainingData: IndexedSeq[(PointId, Point[_3D])], sigma2: Double): StatisticalMeshModel = {
     val trainingDataWithDisplacements = trainingData.map { case (id, targetPoint) => (id, targetPoint - referenceMesh.point(id)) }
     val posteriorGp = gp.posterior(trainingDataWithDisplacements, sigma2)
     new StatisticalMeshModel(referenceMesh, posteriorGp)
@@ -126,7 +126,7 @@ case class StatisticalMeshModel private (val referenceMesh: TriangleMesh, val gp
   /**
    * Similar to [[DiscreteLowRankGaussianProcess.posterior(Int, Point[_3D], Double)]]], but the training data is defined by specifying the target point instead of the displacement vector
    */
-  def posterior(trainingData: IndexedSeq[(Int, Point[_3D], NDimensionalNormalDistribution[_3D])]): StatisticalMeshModel = {
+  def posterior(trainingData: IndexedSeq[(PointId, Point[_3D], NDimensionalNormalDistribution[_3D])]): StatisticalMeshModel = {
     val trainingDataWithDisplacements = trainingData.map { case (id, targetPoint, cov) => (id, targetPoint - referenceMesh.point(id), cov) }
     val posteriorGp = gp.posterior(trainingDataWithDisplacements)
     new StatisticalMeshModel(referenceMesh, posteriorGp)

--- a/src/main/scala/scalismo/statisticalmodel/asm/FeatureExtractor.scala
+++ b/src/main/scala/scalismo/statisticalmodel/asm/FeatureExtractor.scala
@@ -17,6 +17,7 @@ package scalismo.statisticalmodel.asm
 
 import breeze.linalg.DenseVector
 import ncsa.hdf.`object`.Group
+import scalismo.common.PointId
 import scalismo.geometry.{ Point, Vector, _3D }
 import scalismo.io.HDF5File
 import scalismo.mesh.TriangleMesh
@@ -25,7 +26,7 @@ import scalismo.statisticalmodel.asm.PreprocessedImage.{ Gradient, Intensity }
 import scala.collection.immutable
 import scala.util.{ Failure, Try }
 
-trait FeatureExtractor extends Function4[PreprocessedImage, Point[_3D], TriangleMesh, Int, Option[DenseVector[Float]]] with HasIOMetadata {
+trait FeatureExtractor extends Function4[PreprocessedImage, Point[_3D], TriangleMesh, PointId, Option[DenseVector[Float]]] with HasIOMetadata {
 
   /**
    * Actually extracts features from an image.
@@ -39,7 +40,7 @@ trait FeatureExtractor extends Function4[PreprocessedImage, Point[_3D], Triangle
    * @param profilePointId a point id on the mesh, corresponding to a profiled point id.
    * @return
    */
-  def apply(image: PreprocessedImage, featurePoint: Point[_3D], mesh: TriangleMesh, profilePointId: Int): Option[DenseVector[Float]]
+  def apply(image: PreprocessedImage, featurePoint: Point[_3D], mesh: TriangleMesh, profilePointId: PointId): Option[DenseVector[Float]]
 
   /**
    * Return the points at which feature components are extracted for a given mesh and point.
@@ -56,7 +57,7 @@ trait FeatureExtractor extends Function4[PreprocessedImage, Point[_3D], Triangle
    * @param featurePoint the actual point in space where the features are to be extracted
    * @return a sequence of points, or [[None]] if there is no sensible correspondence between feature and points, as outlined above.
    */
-  def featurePoints(mesh: TriangleMesh, profilePointId: Int, featurePoint: Point[_3D]): Option[immutable.IndexedSeq[Point[_3D]]]
+  def featurePoints(mesh: TriangleMesh, profilePointId: PointId, featurePoint: Point[_3D]): Option[immutable.IndexedSeq[Point[_3D]]]
 }
 
 trait FeatureExtractorIOHandler extends IOHandler[FeatureExtractor]
@@ -72,7 +73,7 @@ object NormalDirectionFeatureExtractor {
 }
 
 case class NormalDirectionFeatureExtractor(numberOfPoints: Int, spacing: Float, override val ioMetadata: IOMetadata = NormalDirectionFeatureExtractor.IOMetadata_Default) extends FeatureExtractor {
-  override def apply(image: PreprocessedImage, point: Point[_3D], mesh: TriangleMesh, profilePointId: Int): Option[DenseVector[Float]] = {
+  override def apply(image: PreprocessedImage, point: Point[_3D], mesh: TriangleMesh, profilePointId: PointId): Option[DenseVector[Float]] = {
     val normal: Vector[_3D] = mesh.normalAtPoint(mesh.point(profilePointId))
     val unitNormal = normal * (1.0 / normal.norm)
 
@@ -98,7 +99,7 @@ case class NormalDirectionFeatureExtractor(numberOfPoints: Int, spacing: Float, 
     Some(DenseVector(features.toArray))
   }
 
-  override def featurePoints(mesh: TriangleMesh, profilePointId: Int, centerPoint: Point[_3D]): Option[immutable.IndexedSeq[Point[_3D]]] = {
+  override def featurePoints(mesh: TriangleMesh, profilePointId: PointId, centerPoint: Point[_3D]): Option[immutable.IndexedSeq[Point[_3D]]] = {
     val normal: Vector[_3D] = mesh.normalAtPoint(mesh.point(profilePointId))
     val unitNormal = normal * (1.0 / normal.norm)
     require(math.abs(unitNormal.norm - 1.0) < 1e-5)

--- a/src/main/scala/scalismo/statisticalmodel/asm/Profiles.scala
+++ b/src/main/scala/scalismo/statisticalmodel/asm/Profiles.scala
@@ -17,27 +17,18 @@ package scalismo.statisticalmodel.asm
 
 import breeze.linalg.DenseVector
 import scalismo.common._
-import scalismo.geometry.{ Dim, NDSpace, Point, _3D }
+import scalismo.geometry.{ Dim, NDSpace, Point }
 import scalismo.statisticalmodel.MultivariateNormalDistribution
 
 import scala.collection.immutable
 
-case class Profile(pointId: Int, distribution: MultivariateNormalDistribution)
+final case class ProfileId(id: Int) extends AnyVal
 
-case class Profiles(domain: UnstructuredPointsDomain[_3D], data: immutable.IndexedSeq[Profile])
-    extends DiscreteField[_3D, Profile] {
-  require(domain.numberOfPoints == data.size)
+case class Profile(pointId: PointId, distribution: MultivariateNormalDistribution)
 
-  override def apply(i: Int) = data(i)
-
-  override def isDefinedAt(i: Int) = data.isDefinedAt(i)
-
-  override def values = data.iterator
-
-  override def interpolateNearestNeighbor(): Field[_3D, Profile] = {
-    Field(domain.boundingBox, (p: Point[_3D]) => apply(domain.findClosestPoint(p)._2))
-  }
-
+case class Profiles(private[scalismo] val data: immutable.IndexedSeq[Profile]) {
+  def apply(profileId: ProfileId): Profile = data(profileId.id)
+  def ids: IndexedSeq[ProfileId] = data.indices.map(idx => ProfileId(idx))
 }
 
 /**
@@ -47,11 +38,11 @@ case class Profiles(domain: UnstructuredPointsDomain[_3D], data: immutable.Index
  *
  */
 
-case class DiscreteFeatureField[D <: Dim: NDSpace](override val domain: DiscreteDomain[D], val _values: IndexedSeq[DenseVector[Float]]) extends DiscreteField[D, DenseVector[Float]] {
+case class DiscreteFeatureField[D <: Dim: NDSpace](override val domain: DiscreteDomain[D], _values: IndexedSeq[DenseVector[Float]]) extends DiscreteField[D, DenseVector[Float]] {
 
-  override def apply(i: Int) = _values(i)
+  override def apply(id: PointId) = _values(id.id)
 
-  override def isDefinedAt(i: Int) = i < domain.numberOfPoints
+  override def isDefinedAt(id: PointId) = id.id < domain.numberOfPoints
 
   override def values = _values.toIterator
 

--- a/src/main/scala/scalismo/statisticalmodel/asm/SearchPointSampler.scala
+++ b/src/main/scala/scalismo/statisticalmodel/asm/SearchPointSampler.scala
@@ -15,18 +15,19 @@
  */
 package scalismo.statisticalmodel.asm
 
+import scalismo.common.PointId
 import scalismo.geometry.{ Point, _3D }
 import scalismo.mesh.TriangleMesh
 
 import scala.collection.immutable
 
-trait SearchPointSampler extends Function2[TriangleMesh, Int, immutable.Seq[Point[_3D]]] {
+trait SearchPointSampler extends Function2[TriangleMesh, PointId, immutable.Seq[Point[_3D]]] {
 
 }
 
 case class NormalDirectionSearchPointSampler(numberOfPoints: Int, searchDistance: Float) extends SearchPointSampler {
 
-  override def apply(mesh: TriangleMesh, pointId: Int): immutable.Seq[Point[_3D]] = {
+  override def apply(mesh: TriangleMesh, pointId: PointId): immutable.Seq[Point[_3D]] = {
     val point = mesh.point(pointId)
     val interval = searchDistance * 2 / numberOfPoints
 

--- a/src/main/scala/scalismo/statisticalmodel/dataset/DataUtils.scala
+++ b/src/main/scala/scalismo/statisticalmodel/dataset/DataUtils.scala
@@ -15,19 +15,15 @@
  */
 package scalismo.statisticalmodel.dataset
 
-import java.io.File
-
 import scalismo.geometry.{ Point, _3D }
 import scalismo.mesh.TriangleMesh
 import scalismo.registration.Transformation
 
-import scala.util.Failure
-import scala.util.Success
-import scala.util.Try
+import scala.util.{ Failure, Success, Try }
 
 private object DataUtils {
   /**
-   *  Partitions a list os possible transformation (tries) into those that succeeded and those who failed
+   * Partitions a list os possible transformation (tries) into those that succeeded and those who failed
    */
   def partitionSuccAndFailedTries[A](tries: Seq[Try[A]]): (Seq[A], Seq[Throwable]) = {
     val (s, f) = tries.partition(_.isSuccess)
@@ -53,7 +49,7 @@ private object DataUtils {
         val targetPts = targetMesh.points.toIndexedSeq
         override val f = (x: Point[_3D]) => {
           val (_, ptId) = refMesh.findClosestPoint(x)
-          targetPts(ptId)
+          targetPts(ptId.id)
         }
       }
       Success(t)

--- a/src/test/scala/scalismo/image/DiscreteImageDomainTests.scala
+++ b/src/test/scala/scalismo/image/DiscreteImageDomainTests.scala
@@ -38,7 +38,7 @@ class DiscreteImageDomainTests extends ScalismoTestSuite {
       val domain = DiscreteImageDomain[_2D]((0f, 0f), (1.0f, 1.0f), (20, 20))
       for (pt <- domain.points) {
         val ptId = domain.pointId(pt).get
-        ptId should be < domain.numberOfPoints
+        ptId.id should be < domain.numberOfPoints
       }
     }
 
@@ -52,14 +52,14 @@ class DiscreteImageDomainTests extends ScalismoTestSuite {
 
     it("keeps the same boundingbox approximately the same when it is create with a new spacing") {
       val domain = DiscreteImageDomain[_2D]((1.0f, 3.5f), (1.0f, 2.1f), (42, 49))
-      val newDomain = DiscreteImageDomain(domain.boundingBox, spacing = domain.spacing.map(i => (i * 1.5f)))
+      val newDomain = DiscreteImageDomain(domain.boundingBox, spacing = domain.spacing.map(i => i * 1.5f))
 
       newDomain.boundingBox.origin should equal(domain.boundingBox.origin)
 
       // as the size needs to be integer, it can be that the imageBox is slightly larger.
       // The difference is, however , guaranteed to be smaller than the spacing in each direction. This is also
       // the difference between bounding and image box.
-      newDomain.boundingBox.volume should be >= (domain.boundingBox.volume)
+      newDomain.boundingBox.volume should be >= domain.boundingBox.volume
       newDomain.boundingBox.volume should be <= BoxDomain(domain.boundingBox.origin, domain.boundingBox.oppositeCorner + Vector(1f, 1f)).volume
     }
 
@@ -69,7 +69,7 @@ class DiscreteImageDomainTests extends ScalismoTestSuite {
         val (closestPt, closestPtId) = domain.findClosestPoint(pt)
         closestPt should equal(correctClosestPoint)
         closestPtId should equal(domain.pointId(closestPt).get)
-        closestPtId should be < domain.numberOfPoints
+        closestPtId.id should be < domain.numberOfPoints
       }
 
       // test all points that are inside the domain
@@ -86,7 +86,7 @@ class DiscreteImageDomainTests extends ScalismoTestSuite {
   describe("a discreteImageDomain  in 2d") {
     it("correctly maps a coordinate index to a linearIndex") {
       val domain = DiscreteImageDomain[_2D]((0.0f, 0.0f), (1.0f, 2.0f), (42, 49))
-      assert(domain.pointId((40, 34)) === 40 + 34 * domain.size(0))
+      assert(domain.pointId((40, 34)).id === 40 + 34 * domain.size(0))
     }
 
     it("can correclty map a linear index to an index and back") {
@@ -112,7 +112,7 @@ class DiscreteImageDomainTests extends ScalismoTestSuite {
   describe("a discreteImageDomain in 3d") {
     it("correctly maps a coordinate index to a linearIndex") {
       val domain = DiscreteImageDomain[_3D]((0.0f, 0.0f, 0.0f), (1.0f, 2.0f, 3.0f), (42, 49, 65))
-      assert(domain.pointId((40, 34, 15)) === 40 + 34 * domain.size(0) + 15 * domain.size(0) * domain.size(1))
+      assert(domain.pointId((40, 34, 15)).id === 40 + 34 * domain.size(0) + 15 * domain.size(0) * domain.size(1))
     }
 
     it("can correclty map a linear index to an index and back") {
@@ -144,8 +144,8 @@ class DiscreteImageDomainTests extends ScalismoTestSuite {
       assert((trans(Point(0, 0, 0)) - origImg.domain.origin).norm < 0.1f)
       assert(inverseTrans(origImg.domain.origin).toVector.norm < 0.1f)
 
-      (trans(Point(origImg.domain.size(0) - 1, origImg.domain.size(1) - 1, origImg.domain.size(2) - 1)) - origImg.domain.boundingBox.oppositeCorner).norm should be < (0.1)
-      (inverseTrans(origImg.domain.boundingBox.oppositeCorner) - Point(origImg.domain.size(0) - 1, origImg.domain.size(1) - 1, origImg.domain.size(2) - 1)).norm should be < (0.1)
+      (trans(Point(origImg.domain.size(0) - 1, origImg.domain.size(1) - 1, origImg.domain.size(2) - 1)) - origImg.domain.boundingBox.oppositeCorner).norm should be < 0.1
+      (inverseTrans(origImg.domain.boundingBox.oppositeCorner) - Point(origImg.domain.size(0) - 1, origImg.domain.size(1) - 1, origImg.domain.size(2) - 1)).norm should be < 0.1
     }
 
   }

--- a/src/test/scala/scalismo/image/ImageTests.scala
+++ b/src/test/scala/scalismo/image/ImageTests.scala
@@ -15,25 +15,22 @@
  */
 package scalismo.image
 
-import java.io.File
-
 import breeze.linalg.DenseVector
 import scalismo.ScalismoTestSuite
-import scalismo.common.{ BoxDomain, Scalar, ScalarArray }
+import scalismo.common.{ BoxDomain, PointId, Scalar, ScalarArray }
 import scalismo.geometry.Index.implicits._
 import scalismo.geometry.Point.implicits._
 import scalismo.geometry.Vector.implicits._
 import scalismo.geometry._
-import scalismo.io.ImageIO
 import scalismo.registration.TranslationSpace
 
 import scala.language.implicitConversions
 import scala.reflect.ClassTag
 
 class ImageTests extends ScalismoTestSuite {
-  implicit def doubleToFloat(d: Double) = d.toFloat
+  implicit def doubleToFloat(d: Double): Float = d.toFloat
 
-  implicit def arrayToScalarArray[A: Scalar: ClassTag](a: Array[A]) = ScalarArray(a)
+  implicit def arrayToScalarArray[A: Scalar: ClassTag](a: Array[A]): ScalarArray[A] = ScalarArray(a)
 
   describe("A discrete 1D image") {
     it("returns the same points for a 1d index and a coordinate index") {
@@ -55,7 +52,7 @@ class ImageTests extends ScalismoTestSuite {
         y <- 0 until domain.size(1);
         x <- 0 until domain.size(0)
       ) {
-        assert(discreteImage(y * domain.size(0) + x) === discreteImage((x, y)))
+        assert(discreteImage(PointId(y * domain.size(0) + x)) === discreteImage((x, y)))
       }
     }
   }

--- a/src/test/scala/scalismo/image/InterpolationTest.scala
+++ b/src/test/scala/scalismo/image/InterpolationTest.scala
@@ -19,6 +19,7 @@ import java.io.File
 
 import org.scalatest.PrivateMethodTester
 import scalismo.ScalismoTestSuite
+import scalismo.common.PointId
 import scalismo.common.ScalarArray.implicits._
 import scalismo.geometry.Index.implicits._
 import scalismo.geometry.Point.implicits._
@@ -30,7 +31,7 @@ import scala.language.implicitConversions
 
 class InterpolationTest extends ScalismoTestSuite with PrivateMethodTester {
 
-  implicit def doubleToFloat(d: Double) = d.toFloat
+  implicit def doubleToFloat(d: Double): Float = d.toFloat
 
   describe("A 1D Interpolation with 0rd order bspline") {
 
@@ -93,7 +94,7 @@ class InterpolationTest extends ScalismoTestSuite with PrivateMethodTester {
         val continuousImg = discreteImage.interpolate(0)
 
         for ((pt, idx) <- discreteImage.domain.points.zipWithIndex) {
-          continuousImg(pt) should be(discreteImage(idx) +- 0.0001f)
+          continuousImg(pt) should be(discreteImage(PointId(idx)) +- 0.0001f)
         }
       }
 
@@ -104,7 +105,7 @@ class InterpolationTest extends ScalismoTestSuite with PrivateMethodTester {
         val continuousImg = discreteImage.interpolate(0)
 
         for ((pt, idx) <- discreteImage.domain.points.zipWithIndex) {
-          continuousImg(pt) should be(discreteImage(idx) +- 0.0001f)
+          continuousImg(pt) should be(discreteImage(PointId(idx)) +- 0.0001f)
         }
       }
     }
@@ -116,7 +117,7 @@ class InterpolationTest extends ScalismoTestSuite with PrivateMethodTester {
         val continuousImg = discreteImage.interpolate(3)
 
         for ((pt, idx) <- discreteImage.domain.points.zipWithIndex) {
-          continuousImg(pt) should be(discreteImage(idx) +- 0.0001f)
+          continuousImg(pt) should be(discreteImage(PointId(idx)) +- 0.0001f)
         }
       }
 
@@ -126,7 +127,7 @@ class InterpolationTest extends ScalismoTestSuite with PrivateMethodTester {
         val interpolatedImage = discreteFixedImage.interpolate(2)
 
         for ((p, i) <- discreteFixedImage.domain.points.zipWithIndex) {
-          interpolatedImage(p).toShort should be(discreteFixedImage(i) +- 30)
+          interpolatedImage(p).toShort should be(discreteFixedImage(PointId(i)) +- 30)
         }
       }
 
@@ -154,7 +155,7 @@ class InterpolationTest extends ScalismoTestSuite with PrivateMethodTester {
         val continuousImg = discreteImage.interpolate(0)
 
         for ((pt, idx) <- discreteImage.domain.points.zipWithIndex) {
-          continuousImg(pt) should be(discreteImage(idx) +- 0.0001f)
+          continuousImg(pt) should be(discreteImage(PointId(idx)) +- 0.0001f)
         }
       }
     }
@@ -167,7 +168,7 @@ class InterpolationTest extends ScalismoTestSuite with PrivateMethodTester {
         val continuousImg = discreteImage.interpolate(1)
 
         for ((pt, idx) <- discreteImage.domain.points.zipWithIndex) {
-          continuousImg(pt) should be(discreteImage(idx) +- 0.0001f)
+          continuousImg(pt) should be(discreteImage(PointId(idx)) +- 0.0001f)
         }
       }
     }
@@ -180,7 +181,7 @@ class InterpolationTest extends ScalismoTestSuite with PrivateMethodTester {
         val continuousImg = discreteImage.interpolate(3)
 
         for ((pt, idx) <- discreteImage.domain.points.zipWithIndex) {
-          continuousImg(pt) should be(discreteImage(idx) +- 0.0001f)
+          continuousImg(pt) should be(discreteImage(PointId(idx)) +- 0.0001f)
         }
       }
 
@@ -204,7 +205,7 @@ class InterpolationTest extends ScalismoTestSuite with PrivateMethodTester {
         val continuousImage = discreteImage.interpolate(1)
 
         for ((p, i) <- discreteImage.domain.points.zipWithIndex.filter(p => p._2 % 100 == 0))
-          discreteImage(i) should be(continuousImage(p).toShort +- 1.toShort)
+          discreteImage(PointId(i)) should be(continuousImage(p).toShort +- 1.toShort)
       }
     }
   }

--- a/src/test/scala/scalismo/image/ResampleTests.scala
+++ b/src/test/scala/scalismo/image/ResampleTests.scala
@@ -18,6 +18,7 @@ package scalismo.image
 import java.io.File
 
 import scalismo.ScalismoTestSuite
+import scalismo.common.PointId
 import scalismo.io.ImageIO
 
 class ResampleTests extends ScalismoTestSuite {
@@ -35,7 +36,7 @@ class ResampleTests extends ScalismoTestSuite {
       val resampledImage = continuousImage.sample[Short](discreteImage.domain, 0)
       discreteImage.values.size should equal(resampledImage.values.size)
       for (i <- 0 until discreteImage.values.size) {
-        discreteImage(i) should be(resampledImage(i))
+        discreteImage(PointId(i)) should be(resampledImage(PointId(i)))
       }
     }
   }
@@ -48,7 +49,7 @@ class ResampleTests extends ScalismoTestSuite {
     it("yields the original discrete image") {
       val resampledImage = continuousImage.sample[Short](discreteImage.domain, 0)
       for (i <- 0 until discreteImage.values.size by 100) {
-        discreteImage(i) should be(resampledImage(i))
+        discreteImage(PointId(i)) should be(resampledImage(PointId(i)))
       }
     }
   }

--- a/src/test/scala/scalismo/io/ActiveShapeModelIOTests.scala
+++ b/src/test/scala/scalismo/io/ActiveShapeModelIOTests.scala
@@ -19,7 +19,6 @@ import java.io.File
 
 import breeze.linalg.{ DenseMatrix, DenseVector }
 import scalismo.ScalismoTestSuite
-import scalismo.common.UnstructuredPointsDomain
 import scalismo.numerics.FixedPointsUniformMeshSampler3D
 import scalismo.statisticalmodel.MultivariateNormalDistribution
 import scalismo.statisticalmodel.asm._
@@ -39,10 +38,9 @@ class ActiveShapeModelIOTests extends ScalismoTestSuite {
     val shapeModel = StatismoIO.readStatismoMeshModel(statismoFile).get
 
     val (sprofilePoints, _) = new FixedPointsUniformMeshSampler3D(shapeModel.referenceMesh, 100, 42).sample.unzip
-    val (profilePoints, pointIds) = sprofilePoints.map { point => shapeModel.referenceMesh.findClosestPoint(point) }.unzip
-    val ptDomain = UnstructuredPointsDomain(profilePoints)
-    val dists = for (i <- 0 until ptDomain.numberOfPoints) yield new MultivariateNormalDistribution(DenseVector.ones[Float](3) * i.toFloat, DenseMatrix.eye[Float](3) * i.toFloat)
-    val profiles = Profiles(ptDomain, pointIds.to[immutable.IndexedSeq].zip(dists).map { case (i, d) => Profile(i, d) })
+    val (_, pointIds) = sprofilePoints.map { point => shapeModel.referenceMesh.findClosestPoint(point) }.unzip
+    val dists = for (i <- pointIds.indices) yield new MultivariateNormalDistribution(DenseVector.ones[Float](3) * i.toFloat, DenseMatrix.eye[Float](3) * i.toFloat)
+    val profiles = new Profiles(pointIds.to[immutable.IndexedSeq].zip(dists).map { case (i, d) => Profile(i, d) })
     new ActiveShapeModel(shapeModel, profiles, GaussianGradientImagePreprocessor(1), NormalDirectionFeatureExtractor(1, 1))
   }
 

--- a/src/test/scala/scalismo/io/ImageIOTests.scala
+++ b/src/test/scala/scalismo/io/ImageIOTests.scala
@@ -20,7 +20,7 @@ import java.io.File
 import breeze.linalg.{ DenseMatrix, DenseVector }
 import niftijio.NiftiVolume
 import scalismo.ScalismoTestSuite
-import scalismo.common.{ Scalar, ScalarArray }
+import scalismo.common.{ PointId, Scalar, ScalarArray }
 import scalismo.geometry._
 import scalismo.image.{ DiscreteImageDomain, DiscreteScalarImage }
 import scalismo.utils.CanConvertToVtk
@@ -259,7 +259,7 @@ class ImageIOTests extends ScalismoTestSuite {
         (origImg.domain.spacing - rereadImg.domain.spacing).norm should be(0.0 +- 1e-2)
         origImg.domain.size should equal(rereadImg.domain.size)
         for (i <- 0 until origImg.values.size by origImg.values.size / 1000) {
-          origImg(i) should equal(rereadImg(i))
+          origImg(PointId(i)) should equal(rereadImg(PointId(i)))
         }
       }
     }

--- a/src/test/scala/scalismo/mesh/MeshMetricsTests.scala
+++ b/src/test/scala/scalismo/mesh/MeshMetricsTests.scala
@@ -18,12 +18,13 @@ package scalismo.mesh
 import java.io.File
 
 import scalismo.ScalismoTestSuite
+import scalismo.common.PointId
 import scalismo.geometry.{ Point, Vector, _3D }
 import scalismo.io.MeshIO
 
 class MeshMetricsTests extends ScalismoTestSuite {
 
-  val path = getClass().getResource("/facemesh.stl").getPath
+  val path = getClass.getResource("/facemesh.stl").getPath
   val mesh = MeshIO.readMesh(new File(path)).get
   val translationLength = 1.0f
   val translatedMesh = mesh.transform((pt: Point[_3D]) => pt + Vector(translationLength, 0.0f, 0.0f))
@@ -46,7 +47,7 @@ class MeshMetricsTests extends ScalismoTestSuite {
     }
 
     it("should be (slightly) lower than the average translation applied to each vertex") {
-      MeshMetrics.avgDistance(mesh, translatedMesh) should be < (translationLength.toDouble)
+      MeshMetrics.avgDistance(mesh, translatedMesh) should be < translationLength.toDouble
       MeshMetrics.avgDistance(mesh, translatedMesh) should be(translationLength.toDouble +- (translationLength * 0.2))
     }
   }
@@ -58,7 +59,7 @@ class MeshMetricsTests extends ScalismoTestSuite {
 
     it("returns the max distance") {
       // create a mesh where the first vector is displaced by a value of 1
-      val newMesh = mesh.transform((pt: Point[_3D]) => if (mesh.findClosestPoint(pt)._2 == 0) pt + Vector(1, 0, 0) else pt)
+      val newMesh = mesh.transform((pt: Point[_3D]) => if (mesh.findClosestPoint(pt)._2 == PointId(0)) pt + Vector(1, 0, 0) else pt)
       MeshMetrics.hausdorffDistance(mesh, newMesh) should be(1)
     }
 
@@ -68,7 +69,7 @@ class MeshMetricsTests extends ScalismoTestSuite {
   }
 
   describe("the dice coefficient") {
-    val path = getClass().getResource("/unit-sphere.stl").getPath
+    val path = getClass.getResource("/unit-sphere.stl").getPath
     val spheremesh = MeshIO.readMesh(new File(path)).get
 
     it("computes the right value for an unit sphere that compeltely overlaps itself") {

--- a/src/test/scala/scalismo/mesh/MeshTests.scala
+++ b/src/test/scala/scalismo/mesh/MeshTests.scala
@@ -19,6 +19,7 @@ import java.io.File
 
 import breeze.linalg.DenseVector
 import scalismo.ScalismoTestSuite
+import scalismo.common.PointId
 import scalismo.geometry.Point.implicits._
 import scalismo.geometry.{ Point, _3D }
 import scalismo.io.MeshIO
@@ -28,7 +29,8 @@ import scala.language.implicitConversions
 
 class MeshTests extends ScalismoTestSuite {
 
-  implicit def doubleToFloat(d: Double) = d.toFloat
+  implicit def doubleToFloat(d: Double): Float = d.toFloat
+  implicit def intToPointId(i: Int): PointId = PointId(i)
 
   describe("a mesh") {
     val path = getClass.getResource("/facemesh.stl").getPath
@@ -39,7 +41,7 @@ class MeshTests extends ScalismoTestSuite {
       for ((pt, id) <- facemesh.points.zipWithIndex) {
         val (closestPt, closestId) = facemesh.findClosestPoint(pt)
         assert(closestPt === pt)
-        assert(closestId === id)
+        assert(closestId.id === id)
       }
     }
     it("finds the right closest point for a point that is not defined on the mesh") {
@@ -49,7 +51,7 @@ class MeshTests extends ScalismoTestSuite {
 
       val newPt = Point(1.1, 1.1, 4)
       val (closestPt, closestPtId) = mesh.findClosestPoint(newPt)
-      assert(closestPtId === 2)
+      assert(closestPtId.id === 2)
       assert(closestPt === pts(2))
     }
     it("computes its area correctly for a triangle") {

--- a/src/test/scala/scalismo/registration/RegistrationTests.scala
+++ b/src/test/scala/scalismo/registration/RegistrationTests.scala
@@ -19,7 +19,7 @@ import java.io.File
 
 import breeze.linalg.DenseVector
 import scalismo.ScalismoTestSuite
-import scalismo.common.{ VectorField, RealSpace }
+import scalismo.common.{ PointId, VectorField, RealSpace }
 import scalismo.geometry._
 import scalismo.io.{ ImageIO, MeshIO }
 import scalismo.kernels.{ GaussianKernel, UncorrelatedKernel }
@@ -30,7 +30,7 @@ import scala.language.implicitConversions
 
 class RegistrationTests extends ScalismoTestSuite {
 
-  implicit def doubleToFloat(d: Double) = d.toFloat
+  implicit def doubleToFloat(d: Double): Float = d.toFloat
 
   describe("A 2D rigid landmark based registration") {
     it("can retrieve correct parameters") {
@@ -77,20 +77,22 @@ class RegistrationTests extends ScalismoTestSuite {
     it("can retrieve correct parameters") {
 
       for ((p, i) <- rigidRegTransformed.points.zipWithIndex) {
-        p(0) should be(rigidTransformed.point(i)(0) +- 0.0001)
-        p(1) should be(rigidTransformed.point(i)(1) +- 0.0001)
-        p(2) should be(rigidTransformed.point(i)(2) +- 0.0001)
+        val id = PointId(i)
+        p(0) should be(rigidTransformed.point(id)(0) +- 0.0001)
+        p(1) should be(rigidTransformed.point(id)(1) +- 0.0001)
+        p(2) should be(rigidTransformed.point(id)(2) +- 0.0001)
       }
     }
 
-    it("Rigid Transformation forth and back of a mesh gives the same points ") {
+    it("Rigid Transformation forth and back of a mesh gives the same points") {
       val inverseTrans = regResult.asInstanceOf[RigidTransformation[_3D]].inverse
       val tranformed = mesh.transform(regResult).transform(inverseTrans)
 
       for ((p, i) <- tranformed.points.zipWithIndex) {
-        p(0) should be(mesh.point(i)(0) +- 0.0001)
-        p(1) should be(mesh.point(i)(1) +- 0.0001)
-        p(2) should be(mesh.point(i)(2) +- 0.0001)
+        val id = PointId(i)
+        p(0) should be(mesh.point(id)(0) +- 0.0001)
+        p(1) should be(mesh.point(id)(1) +- 0.0001)
+        p(2) should be(mesh.point(id)(2) +- 0.0001)
       }
     }
   }
@@ -141,15 +143,16 @@ class RegistrationTests extends ScalismoTestSuite {
       val regSim = mesh transform regResult
 
       for ((p, i) <- regSim.points.zipWithIndex.take(100)) {
-        p(0) should be(translatedRotatedScaled.point(i)(0) +- 0.0001)
-        p(1) should be(translatedRotatedScaled.point(i)(1) +- 0.0001)
-        p(2) should be(translatedRotatedScaled.point(i)(2) +- 0.0001)
+        val id = PointId(i)
+        p(0) should be(translatedRotatedScaled.point(id)(0) +- 0.0001)
+        p(1) should be(translatedRotatedScaled.point(id)(1) +- 0.0001)
+        p(2) should be(translatedRotatedScaled.point(id)(2) +- 0.0001)
       }
     }
   }
 
   describe("A 2D image registration") {
-    it("Recovers the correct parameters for a translation transfrom") {
+    it("Recovers the correct parameters for a translation transform") {
       val testImgUrl = getClass.getResource("/dm128.vtk").getPath
 
       val discreteFixedImage = ImageIO.read2DScalarImage[Float](new File(testImgUrl)).get
@@ -174,7 +177,7 @@ class RegistrationTests extends ScalismoTestSuite {
       regResult.parameters(1) should be(translationParams(1) +- 0.01)
     }
 
-    it("Recovers the correct parameters for a rotation transfrom") {
+    it("Recovers the correct parameters for a rotation transform") {
       val testImgUrl = getClass.getResource("/dm128.vtk").getPath
       val discreteFixedImage = ImageIO.read2DScalarImage[Float](new File(testImgUrl)).get
       val fixedImage = discreteFixedImage.interpolate(3)
@@ -198,7 +201,7 @@ class RegistrationTests extends ScalismoTestSuite {
       regResult.parameters(0) should be(rotationParams(0) +- 0.01)
     }
 
-    it("Recovers the correct parameters for a gp transfrom") {
+    it("Recovers the correct parameters for a gp transform") {
       val testImgUrl = getClass.getResource("/dm128.vtk").getPath
 
       val discreteFixedImage = ImageIO.read2DScalarImage[Float](new File(testImgUrl)).get
@@ -227,7 +230,7 @@ class RegistrationTests extends ScalismoTestSuite {
       }
     }
 
-    it("Recovers the correct parameters for a gp transfrom with a nn interpolated gp") {
+    it("Recovers the correct parameters for a gp transform with a nn interpolated gp") {
       val testImgUrl = getClass.getResource("/dm128.vtk").getPath
 
       val discreteFixedImage = ImageIO.read2DScalarImage[Float](new File(testImgUrl)).get
@@ -265,11 +268,8 @@ class RegistrationTests extends ScalismoTestSuite {
     val fixedImage = discreteFixedImage.interpolate(3)
 
     val domain = discreteFixedImage.domain
-    val origin = domain.origin
-    val corener = domain.boundingBox.oppositeCorner
-    val center = ((corener - origin) * 0.5).toPoint
 
-    it("Recovers the correct parameters for a translation transfrom") {
+    it("Recovers the correct parameters for a translation transform") {
 
       val translationParams = DenseVector[Float](-10.0, 0, 0)
       val translationTransform = TranslationSpace[_3D].transformForParameters(translationParams)

--- a/src/test/scala/scalismo/registration/TransformationTests.scala
+++ b/src/test/scala/scalismo/registration/TransformationTests.scala
@@ -19,6 +19,7 @@ import java.io.File
 
 import breeze.linalg.DenseVector
 import scalismo.ScalismoTestSuite
+import scalismo.common.PointId
 import scalismo.geometry.Index.implicits._
 import scalismo.geometry.Point.implicits._
 import scalismo.geometry.Vector.implicits._
@@ -30,7 +31,7 @@ import scala.language.implicitConversions
 
 class TransformationTests extends ScalismoTestSuite {
 
-  implicit def doubleToFloat(d: Double) = d.toFloat
+  implicit def doubleToFloat(d: Double): Float = d.toFloat
 
   describe("A Transformation") {
     it("can be memoized and yields the same results") {
@@ -179,9 +180,10 @@ class TransformationTests extends ScalismoTestSuite {
       val rotRotMesh = mesh.transform(rotation).transform(inverseRotation)
       rotRotMesh.points.zipWithIndex.foreach {
         case (p, i) =>
-          p(0) should be(mesh.point(i)(0) +- 0.000001)
-          p(1) should be(mesh.point(i)(1) +- 0.000001)
-          p(2) should be(mesh.point(i)(2) +- 0.000001)
+          val id = PointId(i)
+          p(0) should be(mesh.point(id)(0) +- 0.000001)
+          p(1) should be(mesh.point(id)(1) +- 0.000001)
+          p(2) should be(mesh.point(id)(2) +- 0.000001)
       }
     }
 


### PR DESCRIPTION
So far PointIds were simply represented as Ints. In this PR we introduce an explicit type (value class) PointId. This makes method signatures more clear and avoids confusion when there are several different types of Ids, such as for example in ASMs, where we have to distinguish between PointId and ProfileId. 

Besides introducing the type PointId, we also introduce a type ProfileId in the ASM classes.