### PR TITLE
Set breeze dependency to version 0.11.2 instead of 0.11+

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -64,8 +64,8 @@ object Resolvers {
 object Dependencies {
   import BuildSettings.scalismoPlatform
   val scalatest = "org.scalatest" %% "scalatest" % "2.2+" % "test"
-  val breezeMath = "org.scalanlp" %% "breeze" % "0.11+"
-  val breezeNative = "org.scalanlp" %% "breeze-natives" % "0.11+"
+  val breezeMath = "org.scalanlp" %% "breeze" % "0.11.2"
+  val breezeNative = "org.scalanlp" %% "breeze-natives" % "0.11.2"
   val sprayJson = "io.spray" %% "spray-json" % "1.2.6"
   val scalismoNativeStub = "ch.unibas.cs.gravis" % "scalismo-native-stub" % "2.1.+"
   val scalismoNativeImpl = "ch.unibas.cs.gravis" % s"scalismo-native-$scalismoPlatform" % "2.1.+" % "test"


### PR DESCRIPTION
For some reason, dependent projects suddenly fail to find breeze if the version is set to 0.11+
So for now, just go with a "known-good" value of 0.11.2.
