### PR TITLE
Image resampling speedup

### DIFF
--- a/src/main/scala/scalismo/common/Domain.scala
+++ b/src/main/scala/scalismo/common/Domain.scala
@@ -53,34 +53,50 @@ object RealSpace {
   def apply[D <: Dim] = new RealSpace[D]
 }
 
-abstract class BoxDomainCommon[D <: Dim] extends Domain[D] {
+trait BoxDomain[D <: Dim] extends Domain[D] {
 
   val origin: Point[D]
   val oppositeCorner: Point[D]
 
   def isDefinedAt(pt: Point[D]): Boolean = {
-    isInside(pt)
+    def isInsideAxis(i: Int) = pt(i) >= origin(i) && pt(i) <= oppositeCorner(i)
+    (0 until pt.dimensionality).forall(i => isInsideAxis(i))
   }
 
   val extent: Vector[D] = oppositeCorner - origin
   val volume: Double = (0 until origin.dimensionality).foldLeft(1.0)((prod, i) => prod * (oppositeCorner(i) - origin(i)))
 
-  def isInside(pt: Point[D]): Boolean = {
-    def isInsideAxis(i: Int) = pt(i) >= origin(i) && pt(i) <= oppositeCorner(i)
-    (0 until pt.dimensionality).forall(i => isInsideAxis(i))
+}
+
+object BoxDomain {
+  def apply(origin: Point1D, oppositeCorner: Point1D) = BoxDomain1D(origin, oppositeCorner)
+  def apply(origin: Point2D, oppositeCorner: Point2D) = BoxDomain2D(origin, oppositeCorner)
+  def apply(origin: Point3D, oppositeCorner: Point3D) = BoxDomain3D(origin, oppositeCorner)
+
+  def apply[D <: Dim: NDSpace](orig: Point[D], oppCorner: Point[D]) = new BoxDomain[D] {
+    override val oppositeCorner = oppCorner
+    override val origin = orig
   }
 }
 
-case class BoxDomain[D <: Dim](origin: Point[D], oppositeCorner: Point[D]) extends BoxDomainCommon[D]
-
-case class BoxDomain3D(val origin: Point3D, val oppositeCorner: Point3D) extends BoxDomainCommon[_3D] {
-  override def isDefinedAt(pt: Point[_3D]): Boolean = {
-    pt(0) >= origin.x && pt(0) <= oppositeCorner.x &&
-      pt(1) >= origin.y && pt(1) <= oppositeCorner.y &&
-      pt(2) >= origin.z && pt(2) <= oppositeCorner.z
+case class BoxDomain1D(origin: Point1D, oppositeCorner: Point1D) extends BoxDomain[_1D] {
+  override def isDefinedAt(p: Point[_1D]): Boolean = {
+    val pt: Point1D = p
+    pt.x >= origin.x && pt.x <= oppositeCorner.x
   }
+}
 
-  def isDefinedAt(pt: Point3D): Boolean = {
+case class BoxDomain2D(origin: Point2D, oppositeCorner: Point2D) extends BoxDomain[_2D] {
+  override def isDefinedAt(p: Point[_2D]): Boolean = {
+    val pt: Point2D = p
+    pt.x >= origin.x && pt.x <= oppositeCorner.x &&
+      pt.y >= origin.y && pt.y <= oppositeCorner.y
+  }
+}
+
+case class BoxDomain3D(origin: Point3D, oppositeCorner: Point3D) extends BoxDomain[_3D] {
+  override def isDefinedAt(p: Point[_3D]): Boolean = {
+    val pt: Point3D = p
     pt.x >= origin.x && pt.x <= oppositeCorner.x &&
       pt.y >= origin.y && pt.y <= oppositeCorner.y &&
       pt.z >= origin.z && pt.z <= oppositeCorner.z

--- a/src/main/scala/scalismo/common/Domain.scala
+++ b/src/main/scala/scalismo/common/Domain.scala
@@ -67,14 +67,20 @@ trait BoxDomain[D <: Dim] extends Domain[D] {
   val volume: Double = (0 until origin.dimensionality).foldLeft(1.0)((prod, i) => prod * (oppositeCorner(i) - origin(i)))
 
 }
+
 object BoxDomain {
   def apply(origin: Point1D, oppositeCorner: Point1D) = BoxDomain1D(origin, oppositeCorner)
   def apply(origin: Point2D, oppositeCorner: Point2D) = BoxDomain2D(origin, oppositeCorner)
   def apply(origin: Point3D, oppositeCorner: Point3D) = BoxDomain3D(origin, oppositeCorner)
 
+  /**
+   * Creates a BoxDomain of dimensionality D. Attention, due to the fact that it is a generic
+   * constructor, the isDefinedAt method of the resulting object will not be as optimized as when created for a
+   * specific dimensionality
+   */
   def apply[D <: Dim: NDSpace](orig: Point[D], oppCorner: Point[D]) = new BoxDomain[D] {
-    override val oppositeCorner = oppCorner
-    override val origin = orig
+    override lazy val oppositeCorner = oppCorner
+    override lazy val origin = orig
   }
 }
 

--- a/src/main/scala/scalismo/common/Domain.scala
+++ b/src/main/scala/scalismo/common/Domain.scala
@@ -67,7 +67,6 @@ trait BoxDomain[D <: Dim] extends Domain[D] {
   val volume: Double = (0 until origin.dimensionality).foldLeft(1.0)((prod, i) => prod * (oppositeCorner(i) - origin(i)))
 
 }
-
 object BoxDomain {
   def apply(origin: Point1D, oppositeCorner: Point1D) = BoxDomain1D(origin, oppositeCorner)
   def apply(origin: Point2D, oppositeCorner: Point2D) = BoxDomain2D(origin, oppositeCorner)

--- a/src/main/scala/scalismo/common/UnstructuredPointsDomain.scala
+++ b/src/main/scala/scalismo/common/UnstructuredPointsDomain.scala
@@ -86,7 +86,7 @@ class UnstructuredPointsDomain1D private[scalismo] (pointSeq: IndexedSeq[Point[_
   override def boundingBox: BoxDomain[_1D] = {
     val minx = pointSeq.map(_(0)).min
     val maxx = pointSeq.map(_(0)).max
-    BoxDomain[_1D](Point(minx), Point(maxx))
+    BoxDomain(Point(minx), Point(maxx))
   }
 
   override def transform(t: Point[_1D] => Point[_1D]): UnstructuredPointsDomain1D = {
@@ -102,7 +102,7 @@ class UnstructuredPointsDomain2D private[scalismo] (pointSeq: IndexedSeq[Point[_
     val miny = pointSeq.map(_(1)).min
     val maxx = pointSeq.map(_(0)).max
     val maxy = pointSeq.map(_(1)).max
-    BoxDomain[_2D](Point(minx, miny), Point(maxx, maxy))
+    BoxDomain(Point(minx, miny), Point(maxx, maxy))
   }
 
   override def transform(t: Point[_2D] => Point[_2D]): UnstructuredPointsDomain2D = {
@@ -120,7 +120,7 @@ class UnstructuredPointsDomain3D private[scalismo] (pointSeq: IndexedSeq[Point[_
     val maxx = pointSeq.map(_(0)).max
     val maxy = pointSeq.map(_(1)).max
     val maxz = pointSeq.map(_(2)).max
-    BoxDomain[_3D](Point(minx, miny, minz), Point(maxx, maxy, maxz))
+    BoxDomain(Point(minx, miny, minz), Point(maxx, maxy, maxz))
   }
 
   override def transform(t: Point[_3D] => Point[_3D]): UnstructuredPointsDomain3D = {

--- a/src/main/scala/scalismo/image/DiscreteImageDomain.scala
+++ b/src/main/scala/scalismo/image/DiscreteImageDomain.scala
@@ -208,7 +208,7 @@ object DiscreteImageDomain {
 //
 case class DiscreteImageDomain1D(size: Index[_1D], indexToPhysicalCoordinateTransform: AnisotropicSimilarityTransformation[_1D]) extends DiscreteImageDomain[_1D] {
 
-  def origin = indexToPhysicalCoordinateTransform(Point(0))
+  override val origin = indexToPhysicalCoordinateTransform(Point(0))
   private val iVecImage = indexToPhysicalCoordinateTransform(Point(1)) - indexToPhysicalCoordinateTransform(Point(0))
   override def spacing = Vector(iVecImage.norm.toFloat)
   def points = for (i <- (0 until size(0)).toIterator) yield Point(origin(0) + spacing(0) * i) // TODO replace with operator version
@@ -235,7 +235,7 @@ case class DiscreteImageDomain2D(size: Index[_2D], indexToPhysicalCoordinateTran
 
   private val inverseAnisotropicTransform = indexToPhysicalCoordinateTransform.inverse
 
-  def origin = indexToPhysicalCoordinateTransform(Point(0, 0))
+  override val origin = indexToPhysicalCoordinateTransform(Point(0, 0))
 
   private val iVecImage = indexToPhysicalCoordinateTransform(Point(1, 0)) - indexToPhysicalCoordinateTransform(Point(0, 0))
   private val jVecImage = indexToPhysicalCoordinateTransform(Point(0, 1)) - indexToPhysicalCoordinateTransform(Point(0, 0))
@@ -265,7 +265,7 @@ case class DiscreteImageDomain3D(size: Index[_3D], indexToPhysicalCoordinateTran
 
   private val inverseAnisotropicTransform = indexToPhysicalCoordinateTransform.inverse
 
-  override def origin = indexToPhysicalCoordinateTransform(Point(0, 0, 0))
+  override val origin = indexToPhysicalCoordinateTransform(Point(0, 0, 0))
 
   private val positiveScalingParameters = indexToPhysicalCoordinateTransform.parameters(6 to 8).map(math.abs)
   override def spacing = Vector(positiveScalingParameters(0), positiveScalingParameters(1), positiveScalingParameters(2))

--- a/src/main/scala/scalismo/image/DiscreteImageDomain.scala
+++ b/src/main/scala/scalismo/image/DiscreteImageDomain.scala
@@ -284,7 +284,8 @@ case class DiscreteImageDomain2D(size: Index[_2D], indexToPhysicalCoordinateTran
   }
 
   override def indexToPoint(i: Index[_2D]) = {
-    Point2D(origin.x + iVecImage.x * i(0) + jVecImage.x * i(1), origin.y + iVecImage.y * i(0) + jVecImage.y * i(1))
+    val idx: Index2D = i
+    Point2D(origin.x + iVecImage.x * idx.i + jVecImage.x * idx.j, origin.y + iVecImage.y * idx.i + jVecImage.y * idx.j)
   }
   override def boundingBox: BoxDomain[_2D] = {
     val extendData = (0 until 2).map(i => size(i) * spacing(i))
@@ -359,10 +360,11 @@ case class DiscreteImageDomain3D(size: Index[_3D], indexToPhysicalCoordinateTran
     ranges.sliding(2).toIndexedSeq.map(minMaxK => generateIterator(minMaxK(0), minMaxK(1), 0, size(1), 0, size(0)))
   }
 
-  override def indexToPoint(i: Index[_3D]) = {
-    Point3D(origin.x + iVecImage.x * i(0) + jVecImage.x * i(1) + kVecImage.x * i(2),
-      origin.y + iVecImage.y * i(0) + jVecImage.y * i(1) + kVecImage.y * i(2),
-      origin.z + iVecImage.z * i(0) + jVecImage.z * i(1) + kVecImage.z * i(2))
+  override def indexToPoint(indx: Index[_3D]) = {
+    val idx: Index3D = indx
+    Point3D(origin.x + iVecImage.x * idx.i + jVecImage.x * idx.j + kVecImage.x * idx.k,
+      origin.y + iVecImage.y * idx.i + jVecImage.y * idx.j + kVecImage.y * idx.k,
+      origin.z + iVecImage.z * idx.i + jVecImage.z * idx.j + kVecImage.z * idx.k)
   }
 
   override def index(pointId: PointId) =

--- a/src/main/scala/scalismo/image/DiscreteImageDomain.scala
+++ b/src/main/scala/scalismo/image/DiscreteImageDomain.scala
@@ -208,9 +208,9 @@ object DiscreteImageDomain {
 //
 case class DiscreteImageDomain1D(size: Index[_1D], indexToPhysicalCoordinateTransform: AnisotropicSimilarityTransformation[_1D]) extends DiscreteImageDomain[_1D] {
 
-  override val origin = indexToPhysicalCoordinateTransform(Point(0))
+  override val origin = Point1D(indexToPhysicalCoordinateTransform(Point(0))(0))
   private val iVecImage = indexToPhysicalCoordinateTransform(Point(1)) - indexToPhysicalCoordinateTransform(Point(0))
-  override val spacing = Vector(iVecImage.norm.toFloat)
+  override val spacing = Vector1D(iVecImage.norm.toFloat)
   def points = for (i <- (0 until size(0)).toIterator) yield Point(origin(0) + spacing(0) * i) // TODO replace with operator version
 
   //override def indexToPhysicalCoordinateTransform = transform
@@ -235,13 +235,16 @@ case class DiscreteImageDomain2D(size: Index[_2D], indexToPhysicalCoordinateTran
 
   private val inverseAnisotropicTransform = indexToPhysicalCoordinateTransform.inverse
 
-  override val origin = indexToPhysicalCoordinateTransform(Point(0, 0))
+  override val origin = {
+    val p = indexToPhysicalCoordinateTransform(Point(0, 0))
+    Point2D(p(0), p(1))
+  }
 
   private val iVecImage = indexToPhysicalCoordinateTransform(Point(1, 0)) - indexToPhysicalCoordinateTransform(Point(0, 0))
   private val jVecImage = indexToPhysicalCoordinateTransform(Point(0, 1)) - indexToPhysicalCoordinateTransform(Point(0, 0))
 
   override val directions = SquareMatrix[_2D]((iVecImage * (1.0 / iVecImage.norm)).toArray ++ (jVecImage * (1.0 / jVecImage.norm)).toArray)
-  override val spacing = Vector(iVecImage.norm.toFloat, jVecImage.norm.toFloat)
+  override val spacing = Vector2D(iVecImage.norm.toFloat, jVecImage.norm.toFloat)
 
   def points = for (j <- (0 until size(1)).toIterator; i <- (0 until size(0)).view) yield indexToPhysicalCoordinateTransform(Point(i, j))
 
@@ -265,10 +268,13 @@ case class DiscreteImageDomain3D(size: Index[_3D], indexToPhysicalCoordinateTran
 
   private val inverseAnisotropicTransform = indexToPhysicalCoordinateTransform.inverse
 
-  override val origin = indexToPhysicalCoordinateTransform(Point(0, 0, 0))
+  override val origin = {
+    val p = indexToPhysicalCoordinateTransform(Point(0, 0, 0))
+    Point3D(p(0), p(1), p(2))
+  }
 
   private val positiveScalingParameters = indexToPhysicalCoordinateTransform.parameters(6 to 8).map(math.abs)
-  override val spacing = Vector(positiveScalingParameters(0), positiveScalingParameters(1), positiveScalingParameters(2))
+  override val spacing = Vector3D(positiveScalingParameters(0), positiveScalingParameters(1), positiveScalingParameters(2))
 
   override def boundingBox: BoxDomain[_3D] = {
 

--- a/src/main/scala/scalismo/image/DiscreteImageDomain.scala
+++ b/src/main/scala/scalismo/image/DiscreteImageDomain.scala
@@ -310,7 +310,7 @@ case class DiscreteImageDomain3D(size: Index[_3D], indexToPhysicalCoordinateTran
       ++ (kVecImage * (1.0 / kVecImage.norm)).toArray)
   )
 
-  def points = for (k <- Iterator.range(0, size(2)); j <- Iterator.range(0, size(1)); i <- Iterator.range(0, size(0))) yield {
+  override def points = for (k <- Iterator.range(0, size(2)); j <- Iterator.range(0, size(1)); i <- Iterator.range(0, size(0))) yield {
     Point3D(origin.x + iVecImage.x * i + jVecImage.x * j + kVecImage.x * k,
       origin.y + iVecImage.y * i + jVecImage.y * j + kVecImage.y * k,
       origin.z + iVecImage.z * i + jVecImage.z * j + kVecImage.z * k)

--- a/src/main/scala/scalismo/image/DiscreteImageDomain.scala
+++ b/src/main/scala/scalismo/image/DiscreteImageDomain.scala
@@ -310,7 +310,7 @@ case class DiscreteImageDomain3D(size: Index[_3D], indexToPhysicalCoordinateTran
       ++ (kVecImage * (1.0 / kVecImage.norm)).toArray)
   )
 
-  def points =  for (k <- Iterator.range(0, size(2)); j <- Iterator.range(0, size(1)); i <- Iterator.range(0, size(0))) yield {
+  def points = for (k <- Iterator.range(0, size(2)); j <- Iterator.range(0, size(1)); i <- Iterator.range(0, size(0))) yield {
     Point3D(origin.x + iVecImage.x * i + jVecImage.x * j + kVecImage.x * k,
       origin.y + iVecImage.y * i + jVecImage.y * j + kVecImage.y * k,
       origin.z + iVecImage.z * i + jVecImage.z * j + kVecImage.z * k)

--- a/src/main/scala/scalismo/image/DiscreteImageDomain.scala
+++ b/src/main/scala/scalismo/image/DiscreteImageDomain.scala
@@ -240,13 +240,15 @@ case class DiscreteImageDomain2D(size: Index[_2D], indexToPhysicalCoordinateTran
     Point2D(p(0), p(1))
   }
 
-  private val iVecImage = indexToPhysicalCoordinateTransform(Point(1, 0)) - indexToPhysicalCoordinateTransform(Point(0, 0))
-  private val jVecImage = indexToPhysicalCoordinateTransform(Point(0, 1)) - indexToPhysicalCoordinateTransform(Point(0, 0))
+  private val iVecImage = Vector.parametricToConcrete2D(indexToPhysicalCoordinateTransform(Point(1, 0)) - indexToPhysicalCoordinateTransform(Point(0, 0)))
+  private val jVecImage = Vector.parametricToConcrete2D(indexToPhysicalCoordinateTransform(Point(0, 1)) - indexToPhysicalCoordinateTransform(Point(0, 0)))
 
   override val directions = SquareMatrix[_2D]((iVecImage * (1.0 / iVecImage.norm)).toArray ++ (jVecImage * (1.0 / jVecImage.norm)).toArray)
   override val spacing = Vector2D(iVecImage.norm.toFloat, jVecImage.norm.toFloat)
 
-  def points = for (j <- (0 until size(1)).toIterator; i <- (0 until size(0)).view) yield indexToPhysicalCoordinateTransform(Point(i, j))
+  def points = for (j <- (0 until size(1)).toIterator; i <- (0 until size(0)).view) yield {
+    Point2D(origin.x + iVecImage.x * i + jVecImage.x * j, origin.y + iVecImage.y * i + jVecImage.y * j)
+  }
 
   override def index(ptId: PointId) = (Index(ptId.id % size(0), ptId.id / size(0)))
   override def pointId(idx: Index[_2D]) = PointId(idx(0) + idx(1) * size(0))
@@ -255,6 +257,9 @@ case class DiscreteImageDomain2D(size: Index[_2D], indexToPhysicalCoordinateTran
     new UnstructuredPointsDomain2D(points.map(t).toIndexedSeq)
   }
 
+  override def indexToPoint(i: Index[_2D]) = {
+    Point2D(origin.x + iVecImage.x * i(0) + jVecImage.x * i(1), origin.y + iVecImage.y * i(0) + jVecImage.y * i(1))
+  }
   override def boundingBox: BoxDomain[_2D] = {
     val extendData = (0 until 2).map(i => size(i) * spacing(i))
     val extent = Vector[_2D](extendData.toArray)
@@ -310,7 +315,6 @@ case class DiscreteImageDomain3D(size: Index[_3D], indexToPhysicalCoordinateTran
       origin.y + iVecImage.y * i + jVecImage.y * j + kVecImage.y * k,
       origin.z + iVecImage.z * i + jVecImage.z * j + kVecImage.z * k)
   }
-  
 
   override def indexToPoint(i: Index[_3D]) = {
     Point3D(origin.x + iVecImage.x * i(0) + jVecImage.x * i(1) + kVecImage.x * i(2),

--- a/src/main/scala/scalismo/image/DiscreteImageDomain.scala
+++ b/src/main/scala/scalismo/image/DiscreteImageDomain.scala
@@ -310,7 +310,7 @@ case class DiscreteImageDomain3D(size: Index[_3D], indexToPhysicalCoordinateTran
       ++ (kVecImage * (1.0 / kVecImage.norm)).toArray)
   )
 
-  def points = for (k <- (0 until size(2)).toIterator; j <- (0 until size(1)).view; i <- (0 until size(0)).view) yield {
+  def points =  for (k <- Iterator.range(0, size(2)); j <- Iterator.range(0, size(1)); i <- Iterator.range(0, size(0))) yield {
     Point3D(origin.x + iVecImage.x * i + jVecImage.x * j + kVecImage.x * k,
       origin.y + iVecImage.y * i + jVecImage.y * j + kVecImage.y * k,
       origin.z + iVecImage.z * i + jVecImage.z * j + kVecImage.z * k)

--- a/src/main/scala/scalismo/image/DiscreteImageDomain.scala
+++ b/src/main/scala/scalismo/image/DiscreteImageDomain.scala
@@ -310,11 +310,14 @@ case class DiscreteImageDomain3D(size: Index[_3D], indexToPhysicalCoordinateTran
       ++ (kVecImage * (1.0 / kVecImage.norm)).toArray)
   )
 
-  override def points = for (k <- Iterator.range(0, size(2)); j <- Iterator.range(0, size(1)); i <- Iterator.range(0, size(0))) yield {
+  private def generateIterator(maxK : Int, maxY: Int, maxX: Int) =
+    for (k <- Iterator.range(0, maxK); j <- Iterator.range(0, maxY); i <- Iterator.range(0, maxX)) yield {
     Point3D(origin.x + iVecImage.x * i + jVecImage.x * j + kVecImage.x * k,
       origin.y + iVecImage.y * i + jVecImage.y * j + kVecImage.y * k,
       origin.z + iVecImage.z * i + jVecImage.z * j + kVecImage.z * k)
   }
+
+  override def points = generateIterator(size(2), size(1), size(0))
 
   override def indexToPoint(i: Index[_3D]) = {
     Point3D(origin.x + iVecImage.x * i(0) + jVecImage.x * i(1) + kVecImage.x * i(2),

--- a/src/main/scala/scalismo/image/DiscreteImageDomain.scala
+++ b/src/main/scala/scalismo/image/DiscreteImageDomain.scala
@@ -220,7 +220,7 @@ object DiscreteImageDomain {
 case class DiscreteImageDomain1D(size: Index[_1D], indexToPhysicalCoordinateTransform: AnisotropicSimilarityTransformation[_1D]) extends DiscreteImageDomain[_1D] {
 
   override val origin = Point1D(indexToPhysicalCoordinateTransform(Point(0))(0))
-  private val iVecImage = indexToPhysicalCoordinateTransform(Point(1)) - indexToPhysicalCoordinateTransform(Point(0))
+  private val iVecImage: Vector1D = indexToPhysicalCoordinateTransform(Point(1)) - indexToPhysicalCoordinateTransform(Point(0))
   override val spacing = Vector1D(iVecImage.norm.toFloat)
 
   private def generateIterator(minX: Int, maxX: Int) = {
@@ -262,8 +262,8 @@ case class DiscreteImageDomain2D(size: Index[_2D], indexToPhysicalCoordinateTran
     Point2D(p(0), p(1))
   }
 
-  private val iVecImage = Vector.parametricToConcrete2D(indexToPhysicalCoordinateTransform(Point(1, 0)) - indexToPhysicalCoordinateTransform(Point(0, 0)))
-  private val jVecImage = Vector.parametricToConcrete2D(indexToPhysicalCoordinateTransform(Point(0, 1)) - indexToPhysicalCoordinateTransform(Point(0, 0)))
+  private val iVecImage: Vector2D = indexToPhysicalCoordinateTransform(Point(1, 0)) - indexToPhysicalCoordinateTransform(Point(0, 0))
+  private val jVecImage: Vector2D = indexToPhysicalCoordinateTransform(Point(0, 1)) - indexToPhysicalCoordinateTransform(Point(0, 0))
 
   override val directions = SquareMatrix[_2D]((iVecImage * (1.0 / iVecImage.norm)).toArray ++ (jVecImage * (1.0 / jVecImage.norm)).toArray)
   override val spacing = Vector2D(iVecImage.norm.toFloat, jVecImage.norm.toFloat)
@@ -333,9 +333,9 @@ case class DiscreteImageDomain3D(size: Index[_3D], indexToPhysicalCoordinateTran
     BoxDomain(Point(originX, originY, originZ), Point(oppositeX, oppositeY, oppositeZ))
   }
 
-  private val iVecImage = Vector.parametricToConcrete3D(indexToPhysicalCoordinateTransform(Point(1, 0, 0)) - indexToPhysicalCoordinateTransform(Point(0, 0, 0)))
-  private val jVecImage = Vector.parametricToConcrete3D(indexToPhysicalCoordinateTransform(Point(0, 1, 0)) - indexToPhysicalCoordinateTransform(Point(0, 0, 0)))
-  private val kVecImage = Vector.parametricToConcrete3D(indexToPhysicalCoordinateTransform(Point(0, 0, 1)) - indexToPhysicalCoordinateTransform(Point(0, 0, 0)))
+  private val iVecImage: Vector3D = indexToPhysicalCoordinateTransform(Point(1, 0, 0)) - indexToPhysicalCoordinateTransform(Point(0, 0, 0))
+  private val jVecImage: Vector3D = indexToPhysicalCoordinateTransform(Point(0, 1, 0)) - indexToPhysicalCoordinateTransform(Point(0, 0, 0))
+  private val kVecImage: Vector3D = indexToPhysicalCoordinateTransform(Point(0, 0, 1)) - indexToPhysicalCoordinateTransform(Point(0, 0, 0))
 
   val directions = SquareMatrix[_3D](
     ((iVecImage * (1.0 / iVecImage.norm)).toArray

--- a/src/main/scala/scalismo/image/DiscreteImageDomain.scala
+++ b/src/main/scala/scalismo/image/DiscreteImageDomain.scala
@@ -268,11 +268,8 @@ case class DiscreteImageDomain2D(size: Index[_2D], indexToPhysicalCoordinateTran
   override val directions = SquareMatrix[_2D]((iVecImage * (1.0 / iVecImage.norm)).toArray ++ (jVecImage * (1.0 / jVecImage.norm)).toArray)
   override val spacing = Vector2D(iVecImage.norm.toFloat, jVecImage.norm.toFloat)
 
-  private def generateIterator(minY: Int, maxY: Int, minX: Int, maxX: Int) = {
-    for (j <- Iterator.range(minY, maxY); i <- Iterator.range(minX, maxX)) yield {
-      Point2D(origin.x + iVecImage.x * i + jVecImage.x * j, origin.y + iVecImage.y * i + jVecImage.y * j)
-    }
-  }
+  private def generateIterator(minY: Int, maxY: Int, minX: Int, maxX: Int) =
+    for (j <- Iterator.range(minY, maxY); i <- Iterator.range(minX, maxX)) yield { ijToPoint(i, j) }
 
   override def points: Iterator[Point2D] = generateIterator(0, size(1), 0, size(0))
 
@@ -283,10 +280,13 @@ case class DiscreteImageDomain2D(size: Index[_2D], indexToPhysicalCoordinateTran
     new UnstructuredPointsDomain2D(points.map(t).toIndexedSeq)
   }
 
+  private def ijToPoint(i: Int, j: Int) = Point2D(origin.x + iVecImage.x * i + jVecImage.x * j, origin.y + iVecImage.y * i + jVecImage.y * j)
+
   override def indexToPoint(i: Index[_2D]) = {
     val idx: Index2D = i
-    Point2D(origin.x + iVecImage.x * idx.i + jVecImage.x * idx.j, origin.y + iVecImage.y * idx.i + jVecImage.y * idx.j)
+    ijToPoint(idx.i, idx.j)
   }
+
   override def boundingBox: BoxDomain[_2D] = {
     val extendData = (0 until 2).map(i => size(i) * spacing(i))
     val extent = Vector[_2D](extendData.toArray)
@@ -346,9 +346,7 @@ case class DiscreteImageDomain3D(size: Index[_3D], indexToPhysicalCoordinateTran
 
   private def generateIterator(minK: Int, maxK: Int, minY: Int, maxY: Int, minX: Int, maxX: Int) = {
     for (k <- Iterator.range(minK, maxK); j <- Iterator.range(minY, maxY); i <- Iterator.range(minX, maxX)) yield {
-      Point3D(origin.x + iVecImage.x * i + jVecImage.x * j + kVecImage.x * k,
-        origin.y + iVecImage.y * i + jVecImage.y * j + kVecImage.y * k,
-        origin.z + iVecImage.z * i + jVecImage.z * j + kVecImage.z * k)
+      ijkToPoint(i, j, k)
     }
   }
   override def points = generateIterator(0, size(2), 0, size(1), 0, size(0))
@@ -360,11 +358,15 @@ case class DiscreteImageDomain3D(size: Index[_3D], indexToPhysicalCoordinateTran
     ranges.sliding(2).toIndexedSeq.map(minMaxK => generateIterator(minMaxK(0), minMaxK(1), 0, size(1), 0, size(0)))
   }
 
+  private def ijkToPoint(i: Int, j: Int, k: Int) = {
+    Point3D(origin.x + iVecImage.x * i + jVecImage.x * j + kVecImage.x * k,
+      origin.y + iVecImage.y * i + jVecImage.y * j + kVecImage.y * k,
+      origin.z + iVecImage.z * i + jVecImage.z * j + kVecImage.z * k)
+  }
+
   override def indexToPoint(indx: Index[_3D]) = {
     val idx: Index3D = indx
-    Point3D(origin.x + iVecImage.x * idx.i + jVecImage.x * idx.j + kVecImage.x * idx.k,
-      origin.y + iVecImage.y * idx.i + jVecImage.y * idx.j + kVecImage.y * idx.k,
-      origin.z + iVecImage.z * idx.i + jVecImage.z * idx.j + kVecImage.z * idx.k)
+    ijkToPoint(idx.i, idx.j, idx.k)
   }
 
   override def index(pointId: PointId) =

--- a/src/main/scala/scalismo/image/DiscreteImageDomain.scala
+++ b/src/main/scala/scalismo/image/DiscreteImageDomain.scala
@@ -210,7 +210,7 @@ case class DiscreteImageDomain1D(size: Index[_1D], indexToPhysicalCoordinateTran
 
   override val origin = indexToPhysicalCoordinateTransform(Point(0))
   private val iVecImage = indexToPhysicalCoordinateTransform(Point(1)) - indexToPhysicalCoordinateTransform(Point(0))
-  override def spacing = Vector(iVecImage.norm.toFloat)
+  override val spacing = Vector(iVecImage.norm.toFloat)
   def points = for (i <- (0 until size(0)).toIterator) yield Point(origin(0) + spacing(0) * i) // TODO replace with operator version
 
   //override def indexToPhysicalCoordinateTransform = transform
@@ -241,7 +241,7 @@ case class DiscreteImageDomain2D(size: Index[_2D], indexToPhysicalCoordinateTran
   private val jVecImage = indexToPhysicalCoordinateTransform(Point(0, 1)) - indexToPhysicalCoordinateTransform(Point(0, 0))
 
   override val directions = SquareMatrix[_2D]((iVecImage * (1.0 / iVecImage.norm)).toArray ++ (jVecImage * (1.0 / jVecImage.norm)).toArray)
-  override def spacing = Vector(iVecImage.norm.toFloat, jVecImage.norm.toFloat)
+  override val spacing = Vector(iVecImage.norm.toFloat, jVecImage.norm.toFloat)
 
   def points = for (j <- (0 until size(1)).toIterator; i <- (0 until size(0)).view) yield indexToPhysicalCoordinateTransform(Point(i, j))
 
@@ -268,7 +268,7 @@ case class DiscreteImageDomain3D(size: Index[_3D], indexToPhysicalCoordinateTran
   override val origin = indexToPhysicalCoordinateTransform(Point(0, 0, 0))
 
   private val positiveScalingParameters = indexToPhysicalCoordinateTransform.parameters(6 to 8).map(math.abs)
-  override def spacing = Vector(positiveScalingParameters(0), positiveScalingParameters(1), positiveScalingParameters(2))
+  override val spacing = Vector(positiveScalingParameters(0), positiveScalingParameters(1), positiveScalingParameters(2))
 
   override def boundingBox: BoxDomain[_3D] = {
 

--- a/src/main/scala/scalismo/image/DiscreteScalarImage.scala
+++ b/src/main/scala/scalismo/image/DiscreteScalarImage.scala
@@ -295,7 +295,8 @@ private class DiscreteScalarImage3D[A: Scalar: ClassTag](domain: DiscreteImageDo
       val dfz = (iterateOnPoints(x, splineBasisD3) * (1 / domain.spacing(2))).toFloat
       Vector(dfx, dfy, dfz)
     }
-    DifferentiableScalarImage(domain.boundingBox, f, df)
+    val bbox = domain.boundingBox
+    DifferentiableScalarImage(BoxDomain3D(bbox.origin, bbox.oppositeCorner), f, df)
 
   }
 

--- a/src/main/scala/scalismo/image/Image.scala
+++ b/src/main/scala/scalismo/image/Image.scala
@@ -108,10 +108,10 @@ class ScalarImage[D <: Dim: NDSpace] protected (override val domain: Domain[D], 
    */
   def sample[Pixel: Scalar: ClassTag](domain: DiscreteImageDomain[D], outsideValue: Float)(implicit ev: DiscreteScalarImage.Create[D]): DiscreteScalarImage[D, Pixel] = {
     val numeric = implicitly[Scalar[Pixel]]
-
+    val convertedOutsideValue = numeric.fromFloat(outsideValue)
     val sampledValues = domain.points.toIterable.par.map((pt: Point[D]) => {
-      if (isDefinedAt(pt)) numeric.fromFloat(this(pt))
-      else numeric.fromFloat(outsideValue)
+      if (isDefinedAt(pt)) numeric.fromFloat(f(pt))
+      else convertedOutsideValue
     })
 
     DiscreteScalarImage(domain, ScalarArray(sampledValues.toArray))

--- a/src/main/scala/scalismo/image/Image.scala
+++ b/src/main/scala/scalismo/image/Image.scala
@@ -109,12 +109,17 @@ class ScalarImage[D <: Dim: NDSpace] protected (override val domain: Domain[D], 
   def sample[Pixel: Scalar: ClassTag](domain: DiscreteImageDomain[D], outsideValue: Float)(implicit ev: DiscreteScalarImage.Create[D]): DiscreteScalarImage[D, Pixel] = {
     val numeric = implicitly[Scalar[Pixel]]
     val convertedOutsideValue = numeric.fromFloat(outsideValue)
-    val sampledValues = domain.points.map((pt: Point[D]) => {
-      if (isDefinedAt(pt)) numeric.fromFloat(f(pt))
-      else convertedOutsideValue
-    })
 
-    DiscreteScalarImage(domain, ScalarArray(sampledValues.toArray))
+    val nbChunks = Runtime.getRuntime().availableProcessors() + 1
+
+    val parallelArrays = domain.pointsInChunks(nbChunks).par.map { chunkIterator =>
+      chunkIterator.map(pt => {
+        if (isDefinedAt(pt)) numeric.fromFloat(f(pt))
+        else convertedOutsideValue
+      }).toArray
+    }
+
+    DiscreteScalarImage(domain, ScalarArray(parallelArrays.reduce(_ ++ _)))
   }
 
 }

--- a/src/main/scala/scalismo/image/Image.scala
+++ b/src/main/scala/scalismo/image/Image.scala
@@ -109,7 +109,7 @@ class ScalarImage[D <: Dim: NDSpace] protected (override val domain: Domain[D], 
   def sample[Pixel: Scalar: ClassTag](domain: DiscreteImageDomain[D], outsideValue: Float)(implicit ev: DiscreteScalarImage.Create[D]): DiscreteScalarImage[D, Pixel] = {
     val numeric = implicitly[Scalar[Pixel]]
     val convertedOutsideValue = numeric.fromFloat(outsideValue)
-    val sampledValues = domain.points.toIterable.par.map((pt: Point[D]) => {
+    val sampledValues = domain.points.map((pt: Point[D]) => {
       if (isDefinedAt(pt)) numeric.fromFloat(f(pt))
       else convertedOutsideValue
     })

--- a/src/main/scala/scalismo/image/Image.scala
+++ b/src/main/scala/scalismo/image/Image.scala
@@ -110,8 +110,7 @@ class ScalarImage[D <: Dim: NDSpace] protected (override val domain: Domain[D], 
     val numeric = implicitly[Scalar[Pixel]]
     val convertedOutsideValue = numeric.fromFloat(outsideValue)
 
-    val nbChunks = Runtime.getRuntime().availableProcessors() + 1
-
+    val nbChunks = Runtime.getRuntime().availableProcessors() * 2
     val parallelArrays = domain.pointsInChunks(nbChunks).par.map { chunkIterator =>
       chunkIterator.map(pt => {
         if (isDefinedAt(pt)) numeric.fromFloat(f(pt))

--- a/src/main/scala/scalismo/image/filter/Filter.scala
+++ b/src/main/scala/scalismo/image/filter/Filter.scala
@@ -41,7 +41,7 @@ case class GaussianFilter1D(stddev: Double) extends Filter[_1D] {
   }
 
   val radius = (3.0 * stddev).toFloat
-  def support = BoxDomain[_1D](Point(-radius), Point(radius))
+  def support = BoxDomain(Point(-radius), Point(radius))
 }
 
 /**
@@ -54,7 +54,7 @@ case class GaussianFilter2D(stddev: Double) extends Filter[_2D] {
   }
 
   val radius = (3.0 * stddev).toFloat
-  def support = BoxDomain[_2D](Point(-radius, -radius), Point(radius, radius))
+  def support = BoxDomain(Point(-radius, -radius), Point(radius, radius))
 }
 /**
  * 3 dimensional Gaussian blur filter. See [[GaussianFilter1D]]
@@ -70,7 +70,7 @@ case class GaussianFilter3D(stddev: Double) extends Filter[_3D] {
   }
 
   val radius = (3.0 * stddev).toFloat
-  def support = BoxDomain[_3D](Point(-radius, -radius, -radius), Point(radius, radius, radius))
+  def support = BoxDomain(Point(-radius, -radius, -radius), Point(radius, radius, radius))
 }
 /**
  * D- dimensional box Blurring Filter to be used in a convolution. The filter has a value 1 in its support and 0 otherwise

--- a/src/main/scala/scalismo/mesh/MeshMetrics.scala
+++ b/src/main/scala/scalismo/mesh/MeshMetrics.scala
@@ -83,7 +83,7 @@ object MeshMetrics {
 
     val box1 = m1.boundingBox
     val box2 = m2.boundingBox
-    val evaluationRegion = BoxDomain[_3D](minPoint(box1.origin, box2.origin), maxPoint(box1.oppositeCorner, box2.oppositeCorner))
+    val evaluationRegion = BoxDomain(minPoint(box1.origin, box2.origin), maxPoint(box1.oppositeCorner, box2.oppositeCorner))
 
     val sampler = UniformSampler[_3D](evaluationRegion, 10000)
     val samplePts = sampler.sample.map(_._1)

--- a/src/test/scala/scalismo/image/DiscreteImageDomainTests.scala
+++ b/src/test/scala/scalismo/image/DiscreteImageDomainTests.scala
@@ -111,7 +111,7 @@ class DiscreteImageDomainTests extends ScalismoTestSuite {
 
   describe("a discreteImageDomain in 3d") {
 
-    object Fixture{
+    object Fixture {
       val pathH5 = getClass.getResource("/3dimage.nii").getPath
       val img = ImageIO.read3DScalarImage[Short](new File(pathH5)).get
     }
@@ -157,7 +157,7 @@ class DiscreteImageDomainTests extends ScalismoTestSuite {
       val points = Fixture.img.domain.points
       val chunkedPoints = Fixture.img.domain.pointsInChunks(24)
       val concatenated = chunkedPoints.reduce(_ ++ _)
-      points zip concatenated foreach { case (p1,p2) => assert(p1 == p2) }
+      points zip concatenated foreach { case (p1, p2) => assert(p1 == p2) }
     }
 
   }

--- a/src/test/scala/scalismo/image/DiscreteImageDomainTests.scala
+++ b/src/test/scala/scalismo/image/DiscreteImageDomainTests.scala
@@ -110,6 +110,11 @@ class DiscreteImageDomainTests extends ScalismoTestSuite {
   }
 
   describe("a discreteImageDomain in 3d") {
+
+    object Fixture{
+      val pathH5 = getClass.getResource("/3dimage.nii").getPath
+      val img = ImageIO.read3DScalarImage[Short](new File(pathH5)).get
+    }
     it("correctly maps a coordinate index to a linearIndex") {
       val domain = DiscreteImageDomain[_3D]((0.0f, 0.0f, 0.0f), (1.0f, 2.0f, 3.0f), (42, 49, 65))
       assert(domain.pointId((40, 34, 15)).id === 40 + 34 * domain.size(0) + 15 * domain.size(0) * domain.size(1))
@@ -135,17 +140,24 @@ class DiscreteImageDomainTests extends ScalismoTestSuite {
     }
 
     it("the anisotropic similarity transform defining the domain is correct and invertible") {
-      val pathH5 = getClass.getResource("/3dimage.nii").getPath
-      val origImg = ImageIO.read3DScalarImage[Short](new File(pathH5)).get
 
-      val trans = origImg.domain.indexToPhysicalCoordinateTransform
+      val img = Fixture.img
+
+      val trans = img.domain.indexToPhysicalCoordinateTransform
       val inverseTrans = trans.inverse
 
-      assert((trans(Point(0, 0, 0)) - origImg.domain.origin).norm < 0.1f)
-      assert(inverseTrans(origImg.domain.origin).toVector.norm < 0.1f)
+      assert((trans(Point(0, 0, 0)) - img.domain.origin).norm < 0.1f)
+      assert(inverseTrans(img.domain.origin).toVector.norm < 0.1f)
 
-      (trans(Point(origImg.domain.size(0) - 1, origImg.domain.size(1) - 1, origImg.domain.size(2) - 1)) - origImg.domain.boundingBox.oppositeCorner).norm should be < 0.1
-      (inverseTrans(origImg.domain.boundingBox.oppositeCorner) - Point(origImg.domain.size(0) - 1, origImg.domain.size(1) - 1, origImg.domain.size(2) - 1)).norm should be < 0.1
+      (trans(Point(img.domain.size(0) - 1, img.domain.size(1) - 1, img.domain.size(2) - 1)) - img.domain.boundingBox.oppositeCorner).norm should be < 0.1
+      (inverseTrans(img.domain.boundingBox.oppositeCorner) - Point(img.domain.size(0) - 1, img.domain.size(1) - 1, img.domain.size(2) - 1)).norm should be < 0.1
+    }
+
+    it("Domain points in chunks returns the correct list of points") {
+      val points = Fixture.img.domain.points
+      val chunkedPoints = Fixture.img.domain.pointsInChunks(24)
+      val concatenated = chunkedPoints.reduce(_ ++ _)
+      points zip concatenated foreach { case (p1,p2) => assert(p1 == p2) }
     }
 
   }

--- a/src/test/scala/scalismo/image/ImageTests.scala
+++ b/src/test/scala/scalismo/image/ImageTests.scala
@@ -60,7 +60,7 @@ class ImageTests extends ScalismoTestSuite {
   describe("A continuous 1D image") {
     it("yields the right values after composing with a translation") {
 
-      val image = DifferentiableScalarImage(BoxDomain[_1D](-4.0f, 6.0f),
+      val image = DifferentiableScalarImage(BoxDomain(-4.0f, 6.0f),
         (x: Point[_1D]) => Math.sin(x(0).toDouble).toFloat,
         (x: Point[_1D]) => Vector(Math.cos(x(0).toDouble).toFloat))
       val translationTransform = TranslationSpace[_1D].transformForParameters(DenseVector(1f))
@@ -74,7 +74,7 @@ class ImageTests extends ScalismoTestSuite {
 
     it("yields the right values after warping with a translation") {
 
-      val image = DifferentiableScalarImage(BoxDomain[_1D](-4.0f, 6.0f),
+      val image = DifferentiableScalarImage(BoxDomain(-4.0f, 6.0f),
         (x: Point[_1D]) => Math.sin(x(0).toDouble).toFloat,
         (x: Point[_1D]) => Vector(Math.cos(x(0).toDouble).toFloat))
 
@@ -97,7 +97,7 @@ class ImageTests extends ScalismoTestSuite {
   describe("A continuous 2D image") {
     it("can be translated to a new place") {
 
-      val cImg = ScalarImage(BoxDomain[_2D]((0.0f, 0.0f), (1.0f, 1.0f)), (_: Point[_2D]) => 1.0)
+      val cImg = ScalarImage(BoxDomain((0.0f, 0.0f), (1.0f, 1.0f)), (_: Point[_2D]) => 1.0)
 
       def t = TranslationSpace[_2D].transformForParameters(DenseVector(2.0, 2.0))
       val warpedImg = cImg.compose(t)

--- a/src/test/scala/scalismo/kernels/KernelTests.scala
+++ b/src/test/scala/scalismo/kernels/KernelTests.scala
@@ -57,7 +57,7 @@ class KernelTests extends ScalismoTestSuite {
   describe("A sample covariance kernel") {
     it("can reproduce the covariance function from random samples") {
 
-      val domain = BoxDomain[_3D](Point(-5, 1, 3), Point(100, 90, 25))
+      val domain = BoxDomain(Point(-5, 1, 3), Point(100, 90, 25))
 
       val samplerForNystromApprox = UniformSampler(domain, 7 * 7 * 7)
 

--- a/src/test/scala/scalismo/numerics/IntegrationTest.scala
+++ b/src/test/scala/scalismo/numerics/IntegrationTest.scala
@@ -30,7 +30,7 @@ class IntegrationTest extends ScalismoTestSuite {
   describe("An integration in 1D") {
     it("Correctly integrates x squared on interval [-1,1]") {
 
-      val domain = BoxDomain[_1D](0f, 1.0f)
+      val domain = BoxDomain(0f, 1.0f)
       val img = DifferentiableScalarImage(domain, (x: Point[_1D]) => x * x, (x: Point[_1D]) => Vector(2f) * x(0))
 
       val grid = DiscreteImageDomain(domain.origin, domain.extent * (1.0 / 255.0), Index(255))
@@ -59,10 +59,10 @@ class IntegrationTest extends ScalismoTestSuite {
 
     it("Correctly integrates a compact function") {
 
-      val img = ScalarImage(BoxDomain[_1D](-1.0f, 1.0f), (x: Point[_1D]) => 1.0)
+      val img = ScalarImage(BoxDomain(-1.0f, 1.0f), (x: Point[_1D]) => 1.0)
 
-      val region1 = BoxDomain[_1D](-1.0f, 1.0f)
-      val region2 = BoxDomain[_1D](-8.0f, 8.0f)
+      val region1 = BoxDomain(-1.0f, 1.0f)
+      val region2 = BoxDomain(-8.0f, 8.0f)
 
       val numPoints = 200
       val grid1 = DiscreteImageDomain(Point(-1.0), Vector(2.0 / numPoints), Index(numPoints))

--- a/src/test/scala/scalismo/registration/KernelTransformationTests.scala
+++ b/src/test/scala/scalismo/registration/KernelTransformationTests.scala
@@ -36,7 +36,7 @@ class KernelTransformationTests extends ScalismoTestSuite {
   describe("The Nystroem approximation of a Kernel matrix") {
     it("Is close enough to a scalar valued kernel matrix") {
       val kernel = UncorrelatedKernel[_1D](GaussianKernel[_1D](20))
-      val domain = BoxDomain[_1D](-5.0f, 195.0f)
+      val domain = BoxDomain(-5.0f, 195.0f)
 
       val sampler = UniformSampler(domain, 500)
 
@@ -59,7 +59,7 @@ class KernelTransformationTests extends ScalismoTestSuite {
     it("Its eigenvalues are close enough to the real eigenvalues for 1D") {
       val kernelDim = 1
       val scalarKernel = UncorrelatedKernel[_1D](GaussianKernel[_1D](10))
-      val domain = BoxDomain[_1D](0.0f, 10.0f)
+      val domain = BoxDomain(0.0f, 10.0f)
       val numPoints = 500
       val sampler = UniformSampler(domain, numPoints)
       val (points, _) = sampler.sample.unzip
@@ -85,7 +85,7 @@ class KernelTransformationTests extends ScalismoTestSuite {
       val kernelDim = 2
       val scalarKernel = GaussianKernel[_2D](10)
       val ndKernel = UncorrelatedKernel[_2D](scalarKernel)
-      val domain = BoxDomain[_2D]((0.0f, 0.0f), (5.0f, 5.0f))
+      val domain = BoxDomain((0.0f, 0.0f), (5.0f, 5.0f))
       val sampler = UniformSampler(domain, 400)
       val (pts, _) = sampler.sample.unzip
 
@@ -106,7 +106,7 @@ class KernelTransformationTests extends ScalismoTestSuite {
 
     it("It leads to orthogonal basis functions on the domain (-5, 5)") {
       val kernel = UncorrelatedKernel[_1D](GaussianKernel[_1D](1.0))
-      val domain = BoxDomain[_1D](-5.0f, 5.0f)
+      val domain = BoxDomain(-5.0f, 5.0f)
       val grid = DiscreteImageDomain(domain.origin, domain.extent * (1.0 / 1000.0), Index(1000))
       val sampler = GridSampler(grid)
 

--- a/src/test/scala/scalismo/registration/MetricTests.scala
+++ b/src/test/scala/scalismo/registration/MetricTests.scala
@@ -27,8 +27,8 @@ class MetricTests extends ScalismoTestSuite {
   describe("A mean squares metric (1D)") {
     it("returns 0 if provided twice the same image") {
 
-      val domain = BoxDomain[_1D](0f, 1.0f)
-      val img = DifferentiableScalarImage(BoxDomain[_1D](0.0f, 1.0f),
+      val domain = BoxDomain(0f, 1.0f)
+      val img = DifferentiableScalarImage(BoxDomain(0.0f, 1.0f),
         (x: Point[_1D]) => x * x,
         (x: Point[_1D]) => Vector(2f) * x(0))
       val transSpace = TranslationSpace[_1D]

--- a/src/test/scala/scalismo/statisticalmodel/GaussianProcessTests.scala
+++ b/src/test/scala/scalismo/statisticalmodel/GaussianProcessTests.scala
@@ -59,7 +59,7 @@ class GaussianProcessTests extends ScalismoTestSuite {
     }
 
     it("have the correct mean and variance for a full gp") {
-      val domain = BoxDomain[_1D](Point(-1.0), Point(1.0))
+      val domain = BoxDomain(Point(-1.0), Point(1.0))
       val m = VectorField(domain, (_: Point[_1D]) => Vector(0))
       val k = UncorrelatedKernel[_1D](GaussianKernel[_1D](2.0))
       val gp = GaussianProcess[_1D, _1D](m, k)
@@ -67,7 +67,7 @@ class GaussianProcessTests extends ScalismoTestSuite {
     }
 
     it("have the correct mean and variance for a low-rank gp") {
-      val domain = BoxDomain[_1D](Point(-1.0), Point(1.0))
+      val domain = BoxDomain(Point(-1.0), Point(1.0))
       val m = VectorField(domain, (_: Point[_1D]) => Vector(0))
       val k = UncorrelatedKernel[_1D](GaussianKernel[_1D](2.0))
       val sampler = UniformSampler(domain, 500)
@@ -77,7 +77,7 @@ class GaussianProcessTests extends ScalismoTestSuite {
     }
 
     it("yields the same values as the original gp at the given points") {
-      val domain = BoxDomain[_2D](Point(-2.0f, 1.0f), Point(1.0f, 2.0f))
+      val domain = BoxDomain(Point(-2.0f, 1.0f), Point(1.0f, 2.0f))
       val m = VectorField(domain, (_: Point[_2D]) => Vector(0.0f, 0.0f))
       val gp = GaussianProcess(m, UncorrelatedKernel[_2D](GaussianKernel[_2D](1.0)))
 
@@ -96,7 +96,7 @@ class GaussianProcessTests extends ScalismoTestSuite {
 
   describe("A Gaussian process regression") {
     it("keeps the landmark points fixed for a 1D case") {
-      val domain = BoxDomain[_1D](-5.0f, 5f)
+      val domain = BoxDomain(-5.0f, 5f)
       val kernel = UncorrelatedKernel[_1D](GaussianKernel[_1D](5))
       val gp = GaussianProcess(VectorField(domain, (_: Point[_1D]) => Vector(0f)), kernel)
       val gpLowRank = LowRankGaussianProcess.approximateGP(gp, UniformSampler(domain, 500), 100)
@@ -112,7 +112,7 @@ class GaussianProcessTests extends ScalismoTestSuite {
     }
 
     it("yields a larger posterior variance for points that are less strongly constrained") {
-      val domain = BoxDomain[_1D](-5.0f, 5f)
+      val domain = BoxDomain(-5.0f, 5f)
       val kernel = UncorrelatedKernel[_1D](GaussianKernel[_1D](1.0))
       val gp = GaussianProcess(VectorField(domain, (_: Point[_1D]) => Vector(0f)), kernel)
       val gpLowRank = LowRankGaussianProcess.approximateGP(gp, UniformSampler(domain, 500), 100)
@@ -134,7 +134,7 @@ class GaussianProcessTests extends ScalismoTestSuite {
     }
 
     it("keeps the landmark points fixed for a 2D case") {
-      val domain = BoxDomain[_2D]((-5.0f, -5.0f), (5.0f, 5.0f))
+      val domain = BoxDomain((-5.0f, -5.0f), (5.0f, 5.0f))
       val gp = GaussianProcess[_2D, _2D](VectorField(domain, _ => Vector(0.0, 0.0)),
         UncorrelatedKernel[_2D](GaussianKernel[_2D](5)))
       val gpLowRank = LowRankGaussianProcess.approximateGP[_2D, _2D](gp, UniformSampler(domain, 400), 100)
@@ -154,7 +154,7 @@ class GaussianProcessTests extends ScalismoTestSuite {
     }
 
     it("keeps the landmark points fixed for a 3D case") {
-      val domain = BoxDomain[_3D]((-5.0f, -5.0f, -5.0f), (5.0f, 5.0f, 5.0f))
+      val domain = BoxDomain((-5.0f, -5.0f, -5.0f), (5.0f, 5.0f, 5.0f))
       val gp = GaussianProcess[_3D, _3D](VectorField(domain, _ => Vector(0.0, 0.0, 0.0)),
         UncorrelatedKernel[_3D](GaussianKernel[_3D](5)))
       val gpLowRank = LowRankGaussianProcess.approximateGP[_3D, _3D](gp, UniformSampler(domain, 6 * 6 * 6), 50)
@@ -178,7 +178,7 @@ class GaussianProcessTests extends ScalismoTestSuite {
 
   describe("a lowRankGaussian process") {
     object Fixture {
-      val domain = BoxDomain[_3D]((-5.0f, -5.0f, -5.0f), (5.0f, 5.0f, 5.0f))
+      val domain = BoxDomain((-5.0f, -5.0f, -5.0f), (5.0f, 5.0f, 5.0f))
       val sampler = GridSampler(DiscreteImageDomain(domain.origin, domain.extent * (1.0 / 7), Index(7, 7, 7)))
       val kernel = UncorrelatedKernel[_3D](GaussianKernel[_3D](10))
       val gp = {
@@ -247,7 +247,7 @@ class GaussianProcessTests extends ScalismoTestSuite {
         }
       }
 
-      val domain = BoxDomain[_3D]((-5.0f, -5.0f, -5.0f), (5.0f, 5.0f, 5.0f))
+      val domain = BoxDomain((-5.0f, -5.0f, -5.0f), (5.0f, 5.0f, 5.0f))
       val sampler = UniformSampler(domain, 7 * 7 * 7)
       val kernel = covKernel
       val gp = {
@@ -267,7 +267,7 @@ class GaussianProcessTests extends ScalismoTestSuite {
 
     it("can be discretized and yields the correct values at the discretization points") {
 
-      val domain = BoxDomain[_3D]((-5.0f, -5.0f, -5.0f), (5.0f, 5.0f, 5.0f))
+      val domain = BoxDomain((-5.0f, -5.0f, -5.0f), (5.0f, 5.0f, 5.0f))
       val sampler = UniformSampler(domain, 6 * 6 * 6)
       val mean = VectorField[_3D, _3D](RealSpace[_3D], _ => Vector(0.0, 0.0, 0.0))
       val gp = GaussianProcess(mean, UncorrelatedKernel[_3D](GaussianKernel[_3D](5)))
@@ -293,7 +293,7 @@ class GaussianProcessTests extends ScalismoTestSuite {
   describe("a discrete LowRank Gaussian process") {
 
     object Fixture {
-      val domain = BoxDomain[_3D]((-5.0f, -5.0f, -5.0f), (5.0f, 5.0f, 5.0f))
+      val domain = BoxDomain((-5.0f, -5.0f, -5.0f), (5.0f, 5.0f, 5.0f))
       val sampler = UniformSampler(domain, 6 * 6 * 6)
       val mean = VectorField[_3D, _3D](RealSpace[_3D], _ => Vector(0.0, 0.0, 0.0))
       val gp = GaussianProcess(mean, UncorrelatedKernel[_3D](GaussianKernel[_3D](5)))


### PR DESCRIPTION
Multiple optimizations to speedup image resampling.

For a reasonably sized image (332 * 365 * 393), the speedup of resampling a cubic spline interpolation on the same domain is 10x (9.7). 

As a repercussion, image alignment with a cubic spline interpolation has a speedup of 16x.
(An alignment with level-0 interpolation had a speedup of 35x)
