### PR TITLE
rename Index to IntVector

### DIFF
--- a/src/main/scala/scalismo/geometry/Dim.scala
+++ b/src/main/scala/scalismo/geometry/Dim.scala
@@ -25,7 +25,7 @@ trait _3D extends Dim
 trait NDSpace[D <: Dim]
     extends Vector.Create[D]
     with Point.Create[D]
-    with Index.Create[D] {
+    with IntVector.Create[D] {
   def dimensionality: Int
 }
 
@@ -37,21 +37,21 @@ object Dim {
   implicit object OneDSpace extends NDSpace[_1D]
       with Vector.Create1D
       with Point.Create1D
-      with Index.Create1D {
+      with IntVector.Create1D {
     override val dimensionality = 1
   }
 
   implicit object TwoDSpace extends NDSpace[_2D]
       with Vector.Create2D
       with Point.Create2D
-      with Index.Create2D {
+      with IntVector.Create2D {
     override val dimensionality = 2
   }
 
   implicit object ThreeDSpace extends NDSpace[_3D]
       with Vector.Create3D
       with Point.Create3D
-      with Index.Create3D {
+      with IntVector.Create3D {
     override val dimensionality = 3
   }
 }

--- a/src/main/scala/scalismo/image/DiscreteImage.scala
+++ b/src/main/scala/scalismo/image/DiscreteImage.scala
@@ -39,9 +39,9 @@ trait DiscreteImage[D <: Dim, Pixel] extends DiscreteField[D, Pixel] {
 
   val dimensionality = ndSpace.dimensionality
 
-  def apply(idx: Index[D]): Pixel = this(domain.pointId(idx))
+  def apply(idx: IntVector[D]): Pixel = this(domain.pointId(idx))
 
-  def isDefinedAt(idx: Index[D]): Boolean = {
+  def isDefinedAt(idx: IntVector[D]): Boolean = {
     (0 until dimensionality).foldLeft(true)((res, d) => res && idx(d) >= 0 && idx(d) < domain.size(d))
   }
 

--- a/src/main/scala/scalismo/image/DiscreteImageDomain.scala
+++ b/src/main/scala/scalismo/image/DiscreteImageDomain.scala
@@ -41,7 +41,7 @@ abstract class DiscreteImageDomain[D <: Dim: NDSpace] extends DiscreteDomain[D] 
   def spacing: Vector[D]
 
   /** the number of points in each direction */
-  def size: Index[D]
+  def size: IntVector[D]
 
   /** Direction cosine matrix */
   def directions: SquareMatrix[D]
@@ -54,10 +54,10 @@ abstract class DiscreteImageDomain[D <: Dim: NDSpace] extends DiscreteDomain[D] 
   override def point(id: PointId): Point[D] = indexToPoint(index(id))
 
   /** converts a grid index into a id that identifies a point */
-  def pointId(idx: Index[D]): PointId
+  def pointId(idx: IntVector[D]): PointId
 
   /** The index for the given point id */
-  def index(pointId: PointId): Index[D]
+  def index(pointId: PointId): IntVector[D]
 
   /** the point corresponding to the given index */
   //def indexToPoint(i: Index[D]): Point[D]
@@ -98,14 +98,14 @@ abstract class DiscreteImageDomain[D <: Dim: NDSpace] extends DiscreteDomain[D] 
 
   override def findNClosestPoints(pt: Point[D], n: Int): Seq[(Point[D], PointId)] = throw new UnsupportedOperationException
 
-  private def continuousIndextoIndex(cidx: Vector[D]): Index[D] = {
+  private def continuousIndextoIndex(cidx: Vector[D]): IntVector[D] = {
     var d = 0
     val indexData = new Array[Int](dimensionality)
     while (d < dimensionality) {
       indexData(d) = Math.min(Math.round(cidx(d)), size(d) - 1)
       d += 1
     }
-    Index[D](indexData)
+    IntVector[D](indexData)
   }
 
   private def pointToContinuousIndex(pt: Point[D]): Vector[D] = {
@@ -113,7 +113,7 @@ abstract class DiscreteImageDomain[D <: Dim: NDSpace] extends DiscreteDomain[D] 
     Vector[D](data.toArray)
   }
 
-  def indexToPoint(i: Index[D]) = {
+  def indexToPoint(i: IntVector[D]) = {
     indexToPhysicalCoordinateTransform(Point[D](i.toArray.map(_.toFloat)))
   }
 
@@ -161,12 +161,12 @@ abstract class DiscreteImageDomain[D <: Dim: NDSpace] extends DiscreteDomain[D] 
 object DiscreteImageDomain {
 
   /** Create a new discreteImageDomain with given origin, spacing and size*/
-  def apply[D <: Dim](origin: Point[D], spacing: Vector[D], size: Index[D])(implicit evDim: NDSpace[D], evCreate: CreateDiscreteImageDomain[D]) = {
+  def apply[D <: Dim](origin: Point[D], spacing: Vector[D], size: IntVector[D])(implicit evDim: NDSpace[D], evCreate: CreateDiscreteImageDomain[D]) = {
     evCreate.createImageDomain(origin, spacing, size)
   }
 
   /** Create a new discreteImageDomain with given image box (i.e. a box that determines the area where the image is defined) and size */
-  def apply[D <: Dim](imageBox: BoxDomain[D], size: Index[D])(implicit evDim: NDSpace[D], evCreate: CreateDiscreteImageDomain[D]): DiscreteImageDomain[D] = {
+  def apply[D <: Dim](imageBox: BoxDomain[D], size: IntVector[D])(implicit evDim: NDSpace[D], evCreate: CreateDiscreteImageDomain[D]): DiscreteImageDomain[D] = {
     val spacing = imageBox.extent.mapWithIndex({ case (ithExtent, i) => ithExtent / size(i) })
     evCreate.createImageDomain(imageBox.origin, spacing, size)
   }
@@ -174,7 +174,7 @@ object DiscreteImageDomain {
   /** Create a new discreteImageDomain with given image box (i.e. a box that determines the area where the image is defined) and size */
   def apply[D <: Dim](imageBox: BoxDomain[D], spacing: Vector[D])(implicit evDim: NDSpace[D], evCreate: CreateDiscreteImageDomain[D]): DiscreteImageDomain[D] = {
     val sizeFractional = imageBox.extent.mapWithIndex({ case (ithExtent, i) => ithExtent / spacing(i) })
-    val size = Index.apply[D](sizeFractional.toArray.map(s => Math.ceil(s).toInt))
+    val size = IntVector.apply[D](sizeFractional.toArray.map(s => Math.ceil(s).toInt))
     evCreate.createImageDomain(imageBox.origin, spacing, size)
   }
 
@@ -182,7 +182,7 @@ object DiscreteImageDomain {
    * Create a discreteImageDomain where the points are defined as transformations of the indices (from (0,0,0) to (size - 1, size - 1 , size -1)
    * This makes it possible to define image regions which are not aligned to the coordinate axis.
    */
-  private[scalismo] def apply[D <: Dim](size: Index[D], transform: AnisotropicSimilarityTransformation[D])(implicit evDim: NDSpace[D], evCreateRot: CreateDiscreteImageDomain[D]) = {
+  private[scalismo] def apply[D <: Dim](size: IntVector[D], transform: AnisotropicSimilarityTransformation[D])(implicit evDim: NDSpace[D], evCreateRot: CreateDiscreteImageDomain[D]) = {
     evCreateRot.createWithTransform(size, transform)
   }
 
@@ -217,7 +217,7 @@ object DiscreteImageDomain {
 //
 // The actual implementations for each dimension
 //
-case class DiscreteImageDomain1D(size: Index[_1D], indexToPhysicalCoordinateTransform: AnisotropicSimilarityTransformation[_1D]) extends DiscreteImageDomain[_1D] {
+case class DiscreteImageDomain1D(size: IntVector[_1D], indexToPhysicalCoordinateTransform: AnisotropicSimilarityTransformation[_1D]) extends DiscreteImageDomain[_1D] {
 
   override val origin = Point1D(indexToPhysicalCoordinateTransform(Point(0))(0))
   private val iVecImage: Vector1D = indexToPhysicalCoordinateTransform(Point(1)) - indexToPhysicalCoordinateTransform(Point(0))
@@ -230,8 +230,8 @@ case class DiscreteImageDomain1D(size: Index[_1D], indexToPhysicalCoordinateTran
 
   //override def indexToPhysicalCoordinateTransform = transform
 
-  override def index(linearIdx: PointId) = Index(linearIdx.id)
-  override def pointId(idx: Index[_1D]) = PointId(idx(0))
+  override def index(linearIdx: PointId) = IntVector(linearIdx.id)
+  override def pointId(idx: IntVector[_1D]) = PointId(idx(0))
 
   override val directions = SquareMatrix(1.0f)
 
@@ -253,7 +253,7 @@ case class DiscreteImageDomain1D(size: Index[_1D], indexToPhysicalCoordinateTran
 
 }
 
-case class DiscreteImageDomain2D(size: Index[_2D], indexToPhysicalCoordinateTransform: AnisotropicSimilarityTransformation[_2D]) extends DiscreteImageDomain[_2D] {
+case class DiscreteImageDomain2D(size: IntVector[_2D], indexToPhysicalCoordinateTransform: AnisotropicSimilarityTransformation[_2D]) extends DiscreteImageDomain[_2D] {
 
   private val inverseAnisotropicTransform = indexToPhysicalCoordinateTransform.inverse
 
@@ -273,8 +273,8 @@ case class DiscreteImageDomain2D(size: Index[_2D], indexToPhysicalCoordinateTran
 
   override def points: Iterator[Point2D] = generateIterator(0, size(1), 0, size(0))
 
-  override def index(ptId: PointId) = (Index(ptId.id % size(0), ptId.id / size(0)))
-  override def pointId(idx: Index[_2D]) = PointId(idx(0) + idx(1) * size(0))
+  override def index(ptId: PointId) = (IntVector(ptId.id % size(0), ptId.id / size(0)))
+  override def pointId(idx: IntVector[_2D]) = PointId(idx(0) + idx(1) * size(0))
 
   override def transform(t: Point[_2D] => Point[_2D]): UnstructuredPointsDomain[_2D] = {
     new UnstructuredPointsDomain2D(points.map(t).toIndexedSeq)
@@ -282,8 +282,8 @@ case class DiscreteImageDomain2D(size: Index[_2D], indexToPhysicalCoordinateTran
 
   @inline private def ijToPoint(i: Int, j: Int) = Point2D(origin.x + iVecImage.x * i + jVecImage.x * j, origin.y + iVecImage.y * i + jVecImage.y * j)
 
-  override def indexToPoint(i: Index[_2D]) = {
-    val idx: Index2D = i
+  override def indexToPoint(i: IntVector[_2D]) = {
+    val idx: IntVector2D = i
     ijToPoint(idx.i, idx.j)
   }
 
@@ -303,7 +303,7 @@ case class DiscreteImageDomain2D(size: Index[_2D], indexToPhysicalCoordinateTran
 
 }
 
-case class DiscreteImageDomain3D(size: Index[_3D], indexToPhysicalCoordinateTransform: AnisotropicSimilarityTransformation[_3D]) extends DiscreteImageDomain[_3D] {
+case class DiscreteImageDomain3D(size: IntVector[_3D], indexToPhysicalCoordinateTransform: AnisotropicSimilarityTransformation[_3D]) extends DiscreteImageDomain[_3D] {
 
   private val inverseAnisotropicTransform = indexToPhysicalCoordinateTransform.inverse
 
@@ -318,8 +318,8 @@ case class DiscreteImageDomain3D(size: Index[_3D], indexToPhysicalCoordinateTran
   override def boundingBox: BoxDomain[_3D] = {
 
     val corners = List(
-      Index(0, 0, 0), Index(size(0) - 1, 0, 0), Index(0, size(1) - 1, 0), Index(0, 0, size(2) - 1), Index(size(0) - 1, size(1) - 1, 0),
-      Index(size(0) - 1, 0, size(2) - 1), Index(0, size(1) - 1, size(2) - 1), Index(size(0) - 1, size(1) - 1, size(2) - 1)
+      IntVector(0, 0, 0), IntVector(size(0) - 1, 0, 0), IntVector(0, size(1) - 1, 0), IntVector(0, 0, size(2) - 1), IntVector(size(0) - 1, size(1) - 1, 0),
+      IntVector(size(0) - 1, 0, size(2) - 1), IntVector(0, size(1) - 1, size(2) - 1), IntVector(size(0) - 1, size(1) - 1, size(2) - 1)
     )
     val cornerImages = corners.map(i => indexToPoint(i))
 
@@ -364,18 +364,18 @@ case class DiscreteImageDomain3D(size: Index[_3D], indexToPhysicalCoordinateTran
       origin.z + iVecImage.z * i + jVecImage.z * j + kVecImage.z * k)
   }
 
-  override def indexToPoint(indx: Index[_3D]) = {
-    val idx: Index3D = indx
+  override def indexToPoint(indx: IntVector[_3D]) = {
+    val idx: IntVector3D = indx
     ijkToPoint(idx.i, idx.j, idx.k)
   }
 
   override def index(pointId: PointId) =
-    Index(
+    IntVector(
       pointId.id % (size(0) * size(1)) % size(0),
       pointId.id % (size(0) * size(1)) / size(0),
       pointId.id / (size(0) * size(1)))
 
-  override def pointId(idx: Index[_3D]): PointId = {
+  override def pointId(idx: IntVector[_3D]): PointId = {
     PointId(idx(0) + idx(1) * size(0) + idx(2) * size(0) * size(1))
   }
 
@@ -387,14 +387,14 @@ case class DiscreteImageDomain3D(size: Index[_3D], indexToPhysicalCoordinateTran
 
 /** Typeclass for creating domains of arbitrary dimensionality */
 sealed trait CreateDiscreteImageDomain[D <: Dim] {
-  def createImageDomain(origin: Point[D], spacing: Vector[D], size: Index[D]): DiscreteImageDomain[D]
-  def createWithTransform(size: Index[D], transform: AnisotropicSimilarityTransformation[D]): DiscreteImageDomain[D]
+  def createImageDomain(origin: Point[D], spacing: Vector[D], size: IntVector[D]): DiscreteImageDomain[D]
+  def createWithTransform(size: IntVector[D], transform: AnisotropicSimilarityTransformation[D]): DiscreteImageDomain[D]
 }
 
 object CreateDiscreteImageDomain {
 
   implicit object CreateDiscreteImageDomain1D extends CreateDiscreteImageDomain[_1D] {
-    override def createImageDomain(origin: Point[_1D], spacing: Vector[_1D], size: Index[_1D]): DiscreteImageDomain[_1D] = {
+    override def createImageDomain(origin: Point[_1D], spacing: Vector[_1D], size: IntVector[_1D]): DiscreteImageDomain[_1D] = {
       val rigidParameters = origin.toArray ++ Array(0f)
       val anisotropicScalingParameters = spacing.toArray
       val anisotropSimTransform = AnisotropicSimilarityTransformationSpace[_1D](Point(0)).transformForParameters(DenseVector(rigidParameters ++ anisotropicScalingParameters))
@@ -402,31 +402,31 @@ object CreateDiscreteImageDomain {
 
     }
 
-    override def createWithTransform(size: Index[_1D], transform: AnisotropicSimilarityTransformation[_1D]): DiscreteImageDomain[_1D] = {
+    override def createWithTransform(size: IntVector[_1D], transform: AnisotropicSimilarityTransformation[_1D]): DiscreteImageDomain[_1D] = {
       new DiscreteImageDomain1D(size, transform)
     }
   }
 
   implicit object CreateDiscreteImageDomain2D extends CreateDiscreteImageDomain[_2D] {
-    override def createImageDomain(origin: Point[_2D], spacing: Vector[_2D], size: Index[_2D]): DiscreteImageDomain[_2D] = {
+    override def createImageDomain(origin: Point[_2D], spacing: Vector[_2D], size: IntVector[_2D]): DiscreteImageDomain[_2D] = {
       val rigidParameters = origin.toArray ++ Array(0f)
       val anisotropicScalingParameters = spacing.toArray
       val anisotropSimTransform = AnisotropicSimilarityTransformationSpace[_2D](Point(0, 0)).transformForParameters(DenseVector(rigidParameters ++ anisotropicScalingParameters))
       new DiscreteImageDomain2D(size, anisotropSimTransform)
     }
 
-    override def createWithTransform(size: Index[_2D], transform: AnisotropicSimilarityTransformation[_2D]): DiscreteImageDomain[_2D] = new DiscreteImageDomain2D(size, transform)
+    override def createWithTransform(size: IntVector[_2D], transform: AnisotropicSimilarityTransformation[_2D]): DiscreteImageDomain[_2D] = new DiscreteImageDomain2D(size, transform)
   }
 
   implicit object CreateDiscreteImageDomain3D extends CreateDiscreteImageDomain[_3D] {
-    override def createImageDomain(origin: Point[_3D], spacing: Vector[_3D], size: Index[_3D]): DiscreteImageDomain[_3D] = {
+    override def createImageDomain(origin: Point[_3D], spacing: Vector[_3D], size: IntVector[_3D]): DiscreteImageDomain[_3D] = {
       val rigidParameters = origin.toArray ++ Array(0f, 0f, 0f)
       val anisotropicScalingParameters = spacing.toArray
       val anisotropSimTransform = AnisotropicSimilarityTransformationSpace[_3D](Point(0, 0, 0)).transformForParameters(DenseVector(rigidParameters ++ anisotropicScalingParameters))
       new DiscreteImageDomain3D(size, anisotropSimTransform)
     }
 
-    override def createWithTransform(size: Index[_3D], transform: AnisotropicSimilarityTransformation[_3D]): DiscreteImageDomain[_3D] = new DiscreteImageDomain3D(size, transform)
+    override def createWithTransform(size: IntVector[_3D], transform: AnisotropicSimilarityTransformation[_3D]): DiscreteImageDomain[_3D] = new DiscreteImageDomain3D(size, transform)
   }
 
 }

--- a/src/main/scala/scalismo/image/DiscreteScalarImage.scala
+++ b/src/main/scala/scalismo/image/DiscreteScalarImage.scala
@@ -188,7 +188,7 @@ private class DiscreteScalarImage2D[A: Scalar: ClassTag](domain: DiscreteImageDo
         var k = k1
         while (k <= k1 + K - 1) {
           val kBC = DiscreteScalarImage.applyMirrorBoundaryCondition(k, domain.size(0))
-          val pointId = domain.pointId(Index(kBC, lBC))
+          val pointId = domain.pointId(IntVector(kBC, lBC))
           result = result + ck(pointId.id) * splineBasis(xUnit - k, yUnit - l)
           k = k + 1
         }
@@ -223,13 +223,13 @@ private class DiscreteScalarImage2D[A: Scalar: ClassTag](domain: DiscreteImageDo
     val coeffs = DenseVector.zeros[Float](img.values.size)
     var y = 0
     while (y < img.domain.size(1)) {
-      val rowValues = (0 until img.domain.size(0)).map(x => img(img.domain.pointId(Index(x, y))))
+      val rowValues = (0 until img.domain.size(0)).map(x => img(img.domain.pointId(IntVector(x, y))))
 
       // the c is an input-output argument here
       val c = rowValues.map(numeric.toFloat).toArray
       BSplineCoefficients.getSplineInterpolationCoefficients(degree, c)
 
-      val idxInCoeffs = img.domain.pointId(Index(0, y)).id
+      val idxInCoeffs = img.domain.pointId(IntVector(0, y)).id
       coeffs(idxInCoeffs until idxInCoeffs + img.domain.size(0)) := DenseVector(c)
       y = y + 1
     }
@@ -268,7 +268,7 @@ private class DiscreteScalarImage3D[A: Scalar: ClassTag](domain: DiscreteImageDo
           k = k1
           while (k <= k1 + K - 1) {
             val kBC = DiscreteScalarImage.applyMirrorBoundaryCondition(k, domain.size(0))
-            val pointId = domain.pointId(Index(kBC, lBC, mBC))
+            val pointId = domain.pointId(IntVector(kBC, lBC, mBC))
             result = result + ck(pointId.id) * splineBasis(xUnit - k, yUnit - l, zUnit - m)
             k = k + 1
           }
@@ -308,12 +308,12 @@ private class DiscreteScalarImage3D[A: Scalar: ClassTag](domain: DiscreteImageDo
     while (z < img.domain.size(2)) {
       y = 0
       while (y < img.domain.size(1)) {
-        val rowValues = (0 until img.domain.size(0)).map(x => img(Index(x, y, z)))
+        val rowValues = (0 until img.domain.size(0)).map(x => img(IntVector(x, y, z)))
 
         // the c is an input-output argument here
         val c = rowValues.map(numeric.toFloat).toArray
         BSplineCoefficients.getSplineInterpolationCoefficients(degree, c)
-        val idxInCoeffs = img.domain.pointId(Index(0, y, z)).id
+        val idxInCoeffs = img.domain.pointId(IntVector(0, y, z)).id
         coeffs(idxInCoeffs until idxInCoeffs + img.domain.size(0)) := DenseVector(c)
         y = y + 1
       }

--- a/src/main/scala/scalismo/image/Image.scala
+++ b/src/main/scala/scalismo/image/Image.scala
@@ -81,7 +81,7 @@ class ScalarImage[D <: Dim: NDSpace] protected (override val domain: Domain[D], 
 
     val dim = implicitly[NDSpace[D]].dimensionality
     val supportSpacing = filter.support.extent * (1f / numberOfPointsPerDim.toFloat)
-    val supportSize = Index[D]((0 until dim).map(_ => numberOfPointsPerDim).toArray)
+    val supportSize = IntVector[D]((0 until dim).map(_ => numberOfPointsPerDim).toArray)
     val origin = (supportSpacing * ((numberOfPointsPerDim - 1) * -0.5f)).toPoint
 
     val support = DiscreteImageDomain[D](origin, supportSpacing, supportSize)
@@ -186,7 +186,7 @@ class DifferentiableScalarImage[D <: Dim: NDSpace](_domain: Domain[D], _f: Point
 
     val dim = implicitly[NDSpace[D]].dimensionality
     val supportSpacing = filter.support.extent * (1f / numberOfPointsPerDim.toFloat)
-    val supportSize = Index[D]((0 until dim).map(_ => numberOfPointsPerDim).toArray)
+    val supportSize = IntVector[D]((0 until dim).map(_ => numberOfPointsPerDim).toArray)
     val origin = (supportSpacing * ((numberOfPointsPerDim - 1) * -0.5f)).toPoint
     val support = DiscreteImageDomain[D](origin, supportSpacing, supportSize)
 

--- a/src/main/scala/scalismo/io/ImageIO.scala
+++ b/src/main/scala/scalismo/io/ImageIO.scala
@@ -278,7 +278,7 @@ object ImageIO {
       val approxErrors = (origPs.map(transform) zip imgPs).map { case (o, i) => (o - i).norm }
       if (approxErrors.max > 0.01f) throw new Exception("Unable to approximate Nifti affine transform with anisotropic similarity transform")
       else {
-        val newDomain = DiscreteImageDomain[_3D](Index(nx, ny, nz), transform)
+        val newDomain = DiscreteImageDomain[_3D](IntVector(nx, ny, nz), transform)
         val im = DiscreteScalarImage(newDomain, volume.dataAsScalarArray)
 
         // if the domain is rotated, we resample the image to RAI voxel ordering
@@ -371,7 +371,7 @@ object ImageIO {
       // the data
 
       for (d <- 0 until dim; k <- 0 until size(2); j <- 0 until size(1); i <- 0 until size(0)) {
-        volume.data.set(i, j, k, d, scalarConv.toDouble(img(Index(i, j, k))))
+        volume.data.set(i, j, k, d, scalarConv.toDouble(img(IntVector(i, j, k))))
 
       }
 

--- a/src/main/scala/scalismo/utils/Conversions.scala
+++ b/src/main/scala/scalismo/utils/Conversions.scala
@@ -339,7 +339,7 @@ object CanConvertToVtk {
 
       val origin = Point(sp.GetOrigin()(0).toFloat, sp.GetOrigin()(1).toFloat)
       val spacing = Vector(sp.GetSpacing()(0).toFloat, sp.GetSpacing()(1).toFloat)
-      val size = Index(sp.GetDimensions()(0), sp.GetDimensions()(1))
+      val size = IntVector(sp.GetDimensions()(0), sp.GetDimensions()(1))
 
       val domain = DiscreteImageDomain[_2D](origin, spacing, size)
       val scalars = sp.GetPointData().GetScalars()
@@ -423,7 +423,7 @@ object CanConvertToVtk {
 
       val origin = Point(sp.GetOrigin()(0).toFloat, sp.GetOrigin()(1).toFloat, sp.GetOrigin()(2).toFloat)
       val spacing = Vector(sp.GetSpacing()(0).toFloat, sp.GetSpacing()(1).toFloat, sp.GetSpacing()(2).toFloat)
-      val size = Index(sp.GetDimensions()(0), sp.GetDimensions()(1), sp.GetDimensions()(2))
+      val size = IntVector(sp.GetDimensions()(0), sp.GetDimensions()(1), sp.GetDimensions()(2))
 
       val domain = DiscreteImageDomain[_3D](origin, spacing, size)
       val scalars = sp.GetPointData().GetScalars()

--- a/src/test/scala/scalismo/geometry/GeometryTests.scala
+++ b/src/test/scala/scalismo/geometry/GeometryTests.scala
@@ -196,7 +196,7 @@ class GeometryTests extends ScalismoTestSuite {
   checkVector[_3D]()
 
   def checkIndex[D <: Dim: NDSpace]() = {
-    def randomIndex(): Index[D] = Index[D](Array.fill(NDSpace[D].dimensionality)(scala.util.Random.nextInt()))
+    def randomIndex(): IntVector[D] = IntVector[D](Array.fill(NDSpace[D].dimensionality)(scala.util.Random.nextInt()))
     val ind = randomIndex()
 
     describe(s"A random nD Index $ind (n=${NDSpace[D].dimensionality})") {
@@ -205,7 +205,7 @@ class GeometryTests extends ScalismoTestSuite {
       }
 
       it("converts to an Array and back") {
-        Index[D](ind.toArray) should equal(ind)
+        IntVector[D](ind.toArray) should equal(ind)
       }
 
       it("converts to an Array of proper length") {
@@ -213,24 +213,24 @@ class GeometryTests extends ScalismoTestSuite {
       }
 
       it("converts to a Breeze vector and back") {
-        Index[D](ind.toBreezeVector.data) should equal(ind)
+        IntVector[D](ind.toBreezeVector.data) should equal(ind)
       }
 
       it("can map a constant value p.map(f) == 0 (f: x => 0)") {
-        val z = Index[D](Array.fill(NDSpace[D].dimensionality)(0))
+        val z = IntVector[D](Array.fill(NDSpace[D].dimensionality)(0))
         def f(x: Int): Int = 0
         ind.map(f) should equal(z)
       }
 
       it("can map a function p.map(f).map(g) == 0 (f: x => 2 + x, g: x => x - 2)") {
-        val z = Index[D](Array.fill(NDSpace[D].dimensionality)(0))
+        val z = IntVector[D](Array.fill(NDSpace[D].dimensionality)(0))
         val f = (x: Int) => 2 + x
         val g = (x: Int) => x - 2
         ind.map(f).map(g) should equal(ind)
       }
 
       it("can map a function using its index: p.mapWithIndex(f) == 0 (f: (v,i) => v - p(i))") {
-        val z = Index[D](Array.fill(NDSpace[D].dimensionality)(0))
+        val z = IntVector[D](Array.fill(NDSpace[D].dimensionality)(0))
         ind.mapWithIndex((v, i) => v - ind(i)) should equal(z)
       }
     }

--- a/src/test/scala/scalismo/image/DiscreteImageDomainTests.scala
+++ b/src/test/scala/scalismo/image/DiscreteImageDomainTests.scala
@@ -20,7 +20,7 @@ import java.io.File
 
 import scalismo.ScalismoTestSuite
 import scalismo.common.BoxDomain
-import scalismo.geometry.Index.implicits._
+import scalismo.geometry.IntVector.implicits._
 import scalismo.geometry.Point.implicits._
 import scalismo.geometry.Vector.implicits._
 import scalismo.geometry._
@@ -91,7 +91,7 @@ class DiscreteImageDomainTests extends ScalismoTestSuite {
 
     it("can correctly map a linear index to an index and back") {
       val domain = DiscreteImageDomain[_2D]((1.0f, 2.0f), (2.0f, 1.0f), (42, 49))
-      val idx = Index(5, 7)
+      val idx = IntVector(5, 7)
       val recIdx = domain.index(domain.pointId(idx))
       assert(recIdx === idx)
     }
@@ -123,7 +123,7 @@ class DiscreteImageDomainTests extends ScalismoTestSuite {
     it("can correctly map a linear index to an index and back") {
       val domain = DiscreteImageDomain[_3D]((0.0f, 0.0f, 0.0f), (1.0f, 2.0f, 3.0f), (42, 49, 65))
 
-      val idx = Index(5, 3, 7)
+      val idx = IntVector(5, 3, 7)
       val recIdx = domain.index(domain.pointId(idx))
       assert(recIdx === idx)
     }

--- a/src/test/scala/scalismo/image/ImageTests.scala
+++ b/src/test/scala/scalismo/image/ImageTests.scala
@@ -18,7 +18,7 @@ package scalismo.image
 import breeze.linalg.DenseVector
 import scalismo.ScalismoTestSuite
 import scalismo.common.{ BoxDomain, PointId, Scalar, ScalarArray }
-import scalismo.geometry.Index.implicits._
+import scalismo.geometry.IntVector.implicits._
 import scalismo.geometry.Point.implicits._
 import scalismo.geometry.Vector.implicits._
 import scalismo.geometry._

--- a/src/test/scala/scalismo/image/InterpolationTest.scala
+++ b/src/test/scala/scalismo/image/InterpolationTest.scala
@@ -21,7 +21,7 @@ import org.scalatest.PrivateMethodTester
 import scalismo.ScalismoTestSuite
 import scalismo.common.PointId
 import scalismo.common.ScalarArray.implicits._
-import scalismo.geometry.Index.implicits._
+import scalismo.geometry.IntVector.implicits._
 import scalismo.geometry.Point.implicits._
 import scalismo.geometry.Vector.implicits._
 import scalismo.geometry._

--- a/src/test/scala/scalismo/io/ImageIOTests.scala
+++ b/src/test/scala/scalismo/io/ImageIOTests.scala
@@ -154,7 +154,7 @@ class ImageIOTests extends ScalismoTestSuite {
 
     it("can be stored to VTK and re-read in right precision") {
       import scalismo.common.ScalarArray.implicits._
-      val domain = DiscreteImageDomain[_3D](Point(-72.85742f, -72.85742f, -273.0f), Vector(0.85546875f, 0.85546875f, 1.5f), Index(15, 15, 15))
+      val domain = DiscreteImageDomain[_3D](Point(-72.85742f, -72.85742f, -273.0f), Vector(0.85546875f, 0.85546875f, 1.5f), IntVector(15, 15, 15))
       val values = DenseVector.zeros[Short](15 * 15 * 15).data
       val discreteImage = DiscreteScalarImage(domain, values)
       val f = File.createTempFile("dummy", ".vtk")
@@ -258,9 +258,9 @@ class ImageIOTests extends ScalismoTestSuite {
       }
 
       val data = (1 to 8).toArray
-      val dom2 = DiscreteImageDomain(Point(0, 0), Vector(1, 1), Index(2, 2))
+      val dom2 = DiscreteImageDomain(Point(0, 0), Vector(1, 1), IntVector(2, 2))
       val img2 = DiscreteScalarImage(dom2, ScalarArray(data.take(4)))
-      val dom3 = DiscreteImageDomain(Point(0, 0, 0), Vector(1, 1, 1), Index(2, 2, 2))
+      val dom3 = DiscreteImageDomain(Point(0, 0, 0), Vector(1, 1, 1), IntVector(2, 2, 2))
       val img3 = DiscreteScalarImage(dom3, ScalarArray(data))
 
       def imageSeq[D <: Dim: NDSpace: CanConvertToVtk](img: DiscreteScalarImage[D, Int]) = Seq(

--- a/src/test/scala/scalismo/numerics/IntegrationTest.scala
+++ b/src/test/scala/scalismo/numerics/IntegrationTest.scala
@@ -33,7 +33,7 @@ class IntegrationTest extends ScalismoTestSuite {
       val domain = BoxDomain(0f, 1.0f)
       val img = DifferentiableScalarImage(domain, (x: Point[_1D]) => x * x, (x: Point[_1D]) => Vector(2f) * x(0))
 
-      val grid = DiscreteImageDomain(domain.origin, domain.extent * (1.0 / 255.0), Index(255))
+      val grid = DiscreteImageDomain(domain.origin, domain.extent * (1.0 / 255.0), IntVector(255))
       val integrator = Integrator[_1D](GridSampler(grid))
 
       val res = integrator.integrateScalar(img)
@@ -49,7 +49,7 @@ class IntegrationTest extends ScalismoTestSuite {
       )
 
       val numPoints = 1000
-      val grid = DiscreteImageDomain(Point(-math.Pi.toFloat), Vector(2 * math.Pi.toFloat / numPoints), Index(numPoints))
+      val grid = DiscreteImageDomain(Point(-math.Pi.toFloat), Vector(2 * math.Pi.toFloat / numPoints), IntVector(numPoints))
       val integrator = Integrator(GridSampler(grid))
 
       val res = integrator.integrateScalar(img)
@@ -65,8 +65,8 @@ class IntegrationTest extends ScalismoTestSuite {
       val region2 = BoxDomain(-8.0f, 8.0f)
 
       val numPoints = 200
-      val grid1 = DiscreteImageDomain(Point(-1.0), Vector(2.0 / numPoints), Index(numPoints))
-      val grid2 = DiscreteImageDomain(Point(-8.0), Vector(16.0 / numPoints), Index(numPoints))
+      val grid1 = DiscreteImageDomain(Point(-1.0), Vector(2.0 / numPoints), IntVector(numPoints))
+      val grid2 = DiscreteImageDomain(Point(-8.0), Vector(16.0 / numPoints), IntVector(numPoints))
       val integrator1 = Integrator(GridSampler(grid1))
       val integrator2 = Integrator(GridSampler(grid2))
       val res1 = integrator1.integrateScalar(img)

--- a/src/test/scala/scalismo/registration/KernelTransformationTests.scala
+++ b/src/test/scala/scalismo/registration/KernelTransformationTests.scala
@@ -107,7 +107,7 @@ class KernelTransformationTests extends ScalismoTestSuite {
     it("It leads to orthogonal basis functions on the domain (-5, 5)") {
       val kernel = UncorrelatedKernel[_1D](GaussianKernel[_1D](1.0))
       val domain = BoxDomain(-5.0f, 5.0f)
-      val grid = DiscreteImageDomain(domain.origin, domain.extent * (1.0 / 1000.0), Index(1000))
+      val grid = DiscreteImageDomain(domain.origin, domain.extent * (1.0 / 1000.0), IntVector(1000))
       val sampler = GridSampler(grid)
 
       val eigPairs = Kernel.computeNystromApproximation(kernel, 100, sampler)

--- a/src/test/scala/scalismo/registration/TransformationTests.scala
+++ b/src/test/scala/scalismo/registration/TransformationTests.scala
@@ -20,7 +20,7 @@ import java.io.File
 import breeze.linalg.DenseVector
 import scalismo.ScalismoTestSuite
 import scalismo.common.PointId
-import scalismo.geometry.Index.implicits._
+import scalismo.geometry.IntVector.implicits._
 import scalismo.geometry.Point.implicits._
 import scalismo.geometry.Vector.implicits._
 import scalismo.geometry._

--- a/src/test/scala/scalismo/statisticalmodel/GaussianProcessTests.scala
+++ b/src/test/scala/scalismo/statisticalmodel/GaussianProcessTests.scala
@@ -179,7 +179,7 @@ class GaussianProcessTests extends ScalismoTestSuite {
   describe("a lowRankGaussian process") {
     object Fixture {
       val domain = BoxDomain((-5.0f, -5.0f, -5.0f), (5.0f, 5.0f, 5.0f))
-      val sampler = GridSampler(DiscreteImageDomain(domain.origin, domain.extent * (1.0 / 7), Index(7, 7, 7)))
+      val sampler = GridSampler(DiscreteImageDomain(domain.origin, domain.extent * (1.0 / 7), IntVector(7, 7, 7)))
       val kernel = UncorrelatedKernel[_3D](GaussianKernel[_3D](10))
       val gp = {
         LowRankGaussianProcess.approximateGP[_3D, _3D](GaussianProcess(VectorField(domain, _ => Vector(0.0, 0.0, 0.0)), kernel), sampler, 200)
@@ -220,7 +220,7 @@ class GaussianProcessTests extends ScalismoTestSuite {
 
     it("yields the same covariance as given by the kernel") {
       val f = Fixture
-      val fewPointsSampler = GridSampler(DiscreteImageDomain(f.domain.origin, f.domain.extent * (1.0 / 8), Index(2, 2, 2)))
+      val fewPointsSampler = GridSampler(DiscreteImageDomain(f.domain.origin, f.domain.extent * (1.0 / 8), IntVector(2, 2, 2)))
       val pts = fewPointsSampler.sample.map(_._1)
       for (pt1 <- pts.par; pt2 <- pts) {
         val covGP = f.gp.cov(pt1, pt2)


### PR DESCRIPTION
The ```Index``` class is often used in places where not really an index, but just a n-tuple of Int's is required. A typical example is the ```size``` attribute of a ```DiscreteImageDomain```.
Compare
```
DiscreteImageDomain(origin = Point(0,0,0), spacing = Vector(3.1, 2.5, 1.0), size= Index(255,255,255))
```
with
```
DiscreteImageDomain(origin = Point(0,0,0), spacing = Vector(3.1, 2.5, 1.0), size= IntVector(255,255,255))
```
The second call is more clear. Simply renaming Index to IntVector should cover the case where an actual Index is needed, as well as the case where only a tuple of Ints is required. (If necessary, one could still introduce a type alias Index to make it explicit when really a Index required).
 