### PR TITLE
Diagonal kernel

### DIFF
--- a/src/main/scala/scalismo/geometry/SquareMatrix.scala
+++ b/src/main/scala/scalismo/geometry/SquareMatrix.scala
@@ -171,6 +171,15 @@ object SquareMatrix {
     new SquareMatrix[D](data)
   }
 
+  def diag[D <: Dim](vector : Vector[D])(implicit ev: NDSpace[D]): SquareMatrix[D] = {
+    val dim = ev.dimensionality
+    val data = Array.fill(dim * dim)(0f)
+    for (i <- 0 until dim) {
+      data(i * dim + i) = vector(i)
+    }
+    new SquareMatrix[D](data)
+  }
+
   def zeros[D <: Dim: NDSpace]: SquareMatrix[D] = SquareMatrix.fill[D](0)
   def ones[D <: Dim: NDSpace]: SquareMatrix[D] = SquareMatrix.fill[D](1)
 

--- a/src/main/scala/scalismo/geometry/SquareMatrix.scala
+++ b/src/main/scala/scalismo/geometry/SquareMatrix.scala
@@ -171,7 +171,7 @@ object SquareMatrix {
     new SquareMatrix[D](data)
   }
 
-  def diag[D <: Dim](vector : Vector[D])(implicit ev: NDSpace[D]): SquareMatrix[D] = {
+  def diag[D <: Dim](vector: Vector[D])(implicit ev: NDSpace[D]): SquareMatrix[D] = {
     val dim = ev.dimensionality
     val data = Array.fill(dim * dim)(0f)
     for (i <- 0 until dim) {

--- a/src/main/scala/scalismo/kernels/Kernel.scala
+++ b/src/main/scala/scalismo/kernels/Kernel.scala
@@ -15,7 +15,7 @@
  */
 package scalismo.kernels
 
-import breeze.linalg.{ DenseVector, pinv, diag, DenseMatrix }
+import breeze.linalg.{ DenseMatrix, diag, pinv }
 import scalismo.common._
 import scalismo.geometry._
 import scalismo.numerics.{ RandomSVD, Sampler }
@@ -117,7 +117,7 @@ abstract class MatrixValuedPDKernel[D <: Dim: NDSpace, DO <: Dim: NDSpace] { sel
 
 }
 
-case class UncorrelatedKernel[D <: Dim: NDSpace](kernel: PDKernel[D]) extends MatrixValuedPDKernel[D, D] {
+case class DiagonalKernel[D <: Dim: NDSpace](kernel: PDKernel[D]) extends MatrixValuedPDKernel[D, D] {
   val I = SquareMatrix.eye[D]
   def k(x: Point[D], y: Point[D]) = I * (kernel(x, y)) // k is scalar valued
   override def domain = kernel.domain

--- a/src/main/scala/scalismo/kernels/Kernel.scala
+++ b/src/main/scala/scalismo/kernels/Kernel.scala
@@ -125,21 +125,21 @@ case class UncorrelatedKernel[D <: Dim: NDSpace](kernel: PDKernel[D]) extends Ma
 
 trait DiagonalKernel[D <: Dim] extends MatrixValuedPDKernel[D, D]
 
-case class IsotropicDiagonalKernel[D <: Dim: NDSpace] private[kernels] (kernel: PDKernel[D]) extends DiagonalKernel[D] {
+private[kernels] case class IsotropicDiagonalKernel[D <: Dim: NDSpace](kernel: PDKernel[D]) extends DiagonalKernel[D] {
   val I = SquareMatrix.eye[D]
   def k(x: Point[D], y: Point[D]) = I * (kernel(x, y)) // k is scalar valued
   override def domain = kernel.domain
 }
 
-case class AnisotropicDiagonalKernel[D <: Dim: NDSpace] private[kernels] (kernels: IndexedSeq[PDKernel[D]]) extends DiagonalKernel[D] {
+private[kernels] case class AnisotropicDiagonalKernel[D <: Dim: NDSpace](kernels: IndexedSeq[PDKernel[D]]) extends DiagonalKernel[D] {
   def k(x: Point[D], y: Point[D]) = SquareMatrix.diag(Vector(kernels.map(k => k(x, y).toFloat).toArray))
   override def domain = kernels.map(_.domain).reduce(Domain.intersection(_, _))
 }
 
 object DiagonalKernel {
-  def apply[D <: Dim: NDSpace](kernel: PDKernel[D]): IsotropicDiagonalKernel[D] = IsotropicDiagonalKernel(kernel)
-  def apply(xKernel: PDKernel[_2D], yKernel: PDKernel[_2D]): AnisotropicDiagonalKernel[_2D] = AnisotropicDiagonalKernel(IndexedSeq(xKernel, yKernel))
-  def apply(xKernel: PDKernel[_3D], yKernel: PDKernel[_3D], zKernel: PDKernel[_3D]): AnisotropicDiagonalKernel[_3D] = AnisotropicDiagonalKernel(IndexedSeq(xKernel, yKernel, zKernel))
+  def apply[D <: Dim: NDSpace](kernel: PDKernel[D]): DiagonalKernel[D] = IsotropicDiagonalKernel(kernel)
+  def apply(xKernel: PDKernel[_2D], yKernel: PDKernel[_2D]): DiagonalKernel[_2D] = AnisotropicDiagonalKernel(IndexedSeq(xKernel, yKernel))
+  def apply(xKernel: PDKernel[_3D], yKernel: PDKernel[_3D], zKernel: PDKernel[_3D]): DiagonalKernel[_3D] = AnisotropicDiagonalKernel(IndexedSeq(xKernel, yKernel, zKernel))
 }
 
 case class MultiScaleKernel[D <: Dim: NDSpace](kernel: MatrixValuedPDKernel[D, D],

--- a/src/main/scala/scalismo/kernels/Kernel.scala
+++ b/src/main/scala/scalismo/kernels/Kernel.scala
@@ -116,6 +116,12 @@ abstract class MatrixValuedPDKernel[D <: Dim: NDSpace, DO <: Dim: NDSpace] { sel
   }
 
 }
+@deprecated("use DiagonalKernel instead", "0.10.0")
+case class UncorrelatedKernel[D <: Dim: NDSpace](kernel: PDKernel[D]) extends MatrixValuedPDKernel[D, D] {
+  val I = SquareMatrix.eye[D]
+  def k(x: Point[D], y: Point[D]) = I * (kernel(x, y)) // k is scalar valued
+  override def domain = kernel.domain
+}
 
 case class DiagonalKernel[D <: Dim: NDSpace](kernel: PDKernel[D]) extends MatrixValuedPDKernel[D, D] {
   val I = SquareMatrix.eye[D]

--- a/src/test/scala/scalismo/kernels/KernelTests.scala
+++ b/src/test/scala/scalismo/kernels/KernelTests.scala
@@ -61,7 +61,7 @@ class KernelTests extends ScalismoTestSuite {
 
       val samplerForNystromApprox = UniformSampler(domain, 7 * 7 * 7)
 
-      val k = UncorrelatedKernel[_3D](GaussianKernel[_3D](100.0))
+      val k = DiagonalKernel[_3D](GaussianKernel[_3D](100.0))
       val mu = (pt: Point[_3D]) => Vector(1, 10, -5)
       val gp = LowRankGaussianProcess.approximateGP(GaussianProcess(VectorField(domain, mu), k), samplerForNystromApprox, 500)
 
@@ -117,8 +117,8 @@ class KernelTests extends ScalismoTestSuite {
 
   describe("Two matrix valued kernels") {
     it("can be added and multiplied") {
-      val k1 = UncorrelatedKernel[_1D](GaussianKernel[_1D](1.0))
-      val k2 = UncorrelatedKernel[_1D](GaussianKernel[_1D](1.0))
+      val k1 = DiagonalKernel[_1D](GaussianKernel[_1D](1.0))
+      val k2 = DiagonalKernel[_1D](GaussianKernel[_1D](1.0))
       val ksum = k1 + k2
       val x = Point(0)
       val y = Point(1)

--- a/src/test/scala/scalismo/numerics/RandomSVDTest.scala
+++ b/src/test/scala/scalismo/numerics/RandomSVDTest.scala
@@ -19,7 +19,7 @@ import breeze.linalg.DenseMatrix
 import breeze.linalg.svd.SVD
 import scalismo.ScalismoTestSuite
 import scalismo.geometry.{ Point, _1D }
-import scalismo.kernels.{ GaussianKernel, Kernel, UncorrelatedKernel }
+import scalismo.kernels.{ GaussianKernel, Kernel, DiagonalKernel }
 
 class RandomSVDTest extends ScalismoTestSuite {
 
@@ -27,7 +27,7 @@ class RandomSVDTest extends ScalismoTestSuite {
 
     it("accurately approximates the first 10 eigenvectors and eigenvalues of a gaussian kernel matrix") {
 
-      val k = UncorrelatedKernel[_1D](GaussianKernel[_1D](100))
+      val k = DiagonalKernel[_1D](GaussianKernel[_1D](100))
       val xs = (0 until 1000).map(x => Point(x))
 
       val K = Kernel.computeKernelMatrix(xs, k)

--- a/src/test/scala/scalismo/registration/KernelTransformationTests.scala
+++ b/src/test/scala/scalismo/registration/KernelTransformationTests.scala
@@ -21,7 +21,7 @@ import scalismo.common.BoxDomain
 import scalismo.geometry.Point.implicits._
 import scalismo.geometry._
 import scalismo.image.{ DifferentiableScalarImage, DiscreteImageDomain }
-import scalismo.kernels.{ GaussianKernel, Kernel, UncorrelatedKernel }
+import scalismo.kernels.{ GaussianKernel, Kernel, DiagonalKernel }
 import scalismo.numerics.{ GridSampler, Integrator, RandomSVD, UniformSampler }
 import scalismo.statisticalmodel.LowRankGaussianProcess.Eigenpair
 
@@ -35,7 +35,7 @@ class KernelTransformationTests extends ScalismoTestSuite {
 
   describe("The Nystroem approximation of a Kernel matrix") {
     it("Is close enough to a scalar valued kernel matrix") {
-      val kernel = UncorrelatedKernel[_1D](GaussianKernel[_1D](20))
+      val kernel = DiagonalKernel[_1D](GaussianKernel[_1D](20))
       val domain = BoxDomain(-5.0f, 195.0f)
 
       val sampler = UniformSampler(domain, 500)
@@ -58,7 +58,7 @@ class KernelTransformationTests extends ScalismoTestSuite {
 
     it("Its eigenvalues are close enough to the real eigenvalues for 1D") {
       val kernelDim = 1
-      val scalarKernel = UncorrelatedKernel[_1D](GaussianKernel[_1D](10))
+      val scalarKernel = DiagonalKernel[_1D](GaussianKernel[_1D](10))
       val domain = BoxDomain(0.0f, 10.0f)
       val numPoints = 500
       val sampler = UniformSampler(domain, numPoints)
@@ -84,7 +84,7 @@ class KernelTransformationTests extends ScalismoTestSuite {
 
       val kernelDim = 2
       val scalarKernel = GaussianKernel[_2D](10)
-      val ndKernel = UncorrelatedKernel[_2D](scalarKernel)
+      val ndKernel = DiagonalKernel[_2D](scalarKernel)
       val domain = BoxDomain((0.0f, 0.0f), (5.0f, 5.0f))
       val sampler = UniformSampler(domain, 400)
       val (pts, _) = sampler.sample.unzip
@@ -105,7 +105,7 @@ class KernelTransformationTests extends ScalismoTestSuite {
     }
 
     it("It leads to orthogonal basis functions on the domain (-5, 5)") {
-      val kernel = UncorrelatedKernel[_1D](GaussianKernel[_1D](1.0))
+      val kernel = DiagonalKernel[_1D](GaussianKernel[_1D](1.0))
       val domain = BoxDomain(-5.0f, 5.0f)
       val grid = DiscreteImageDomain(domain.origin, domain.extent * (1.0 / 1000.0), IntVector(1000))
       val sampler = GridSampler(grid)

--- a/src/test/scala/scalismo/registration/RegistrationTests.scala
+++ b/src/test/scala/scalismo/registration/RegistrationTests.scala
@@ -22,7 +22,7 @@ import scalismo.ScalismoTestSuite
 import scalismo.common.{ PointId, VectorField, RealSpace }
 import scalismo.geometry._
 import scalismo.io.{ ImageIO, MeshIO }
-import scalismo.kernels.{ GaussianKernel, UncorrelatedKernel }
+import scalismo.kernels.{ GaussianKernel, DiagonalKernel }
 import scalismo.numerics.{ GradientDescentOptimizer, LBFGSOptimizer, UniformSampler }
 import scalismo.statisticalmodel.{ LowRankGaussianProcess, GaussianProcess }
 
@@ -209,7 +209,7 @@ class RegistrationTests extends ScalismoTestSuite {
 
       val domain = discreteFixedImage.domain
 
-      val gp = GaussianProcess(VectorField(RealSpace[_2D], (_: Point[_2D]) => Vector.zeros[_2D]), UncorrelatedKernel[_2D](GaussianKernel(50.0) * 50.0))
+      val gp = GaussianProcess(VectorField(RealSpace[_2D], (_: Point[_2D]) => Vector.zeros[_2D]), DiagonalKernel[_2D](GaussianKernel(50.0) * 50.0))
       val sampler = UniformSampler(domain.boundingBox, numberOfPoints = 200)
       val lowRankGp = LowRankGaussianProcess.approximateGP(gp, sampler, numBasisFunctions = 3)
       val regConf = RegistrationConfiguration[_2D, GaussianProcessTransformationSpace[_2D]](
@@ -238,7 +238,7 @@ class RegistrationTests extends ScalismoTestSuite {
 
       val domain = discreteFixedImage.domain
 
-      val gp = GaussianProcess(VectorField(RealSpace[_2D], (_: Point[_2D]) => Vector.zeros[_2D]), UncorrelatedKernel[_2D](GaussianKernel(50.0) * 50.0))
+      val gp = GaussianProcess(VectorField(RealSpace[_2D], (_: Point[_2D]) => Vector.zeros[_2D]), DiagonalKernel[_2D](GaussianKernel(50.0) * 50.0))
       val sampler = UniformSampler(domain.boundingBox, numberOfPoints = 200)
       val lowRankGp = LowRankGaussianProcess.approximateGP(gp, sampler, numBasisFunctions = 3)
       val nnInterpolatedGp = lowRankGp.discretize(domain).interpolateNearestNeighbor

--- a/src/test/scala/scalismo/statisticalmodel/GaussianProcessTests.scala
+++ b/src/test/scala/scalismo/statisticalmodel/GaussianProcessTests.scala
@@ -21,7 +21,7 @@ import scalismo.common._
 import scalismo.geometry.Point.implicits._
 import scalismo.geometry._
 import scalismo.image.DiscreteImageDomain
-import scalismo.kernels.{ GaussianKernel, MatrixValuedPDKernel, UncorrelatedKernel }
+import scalismo.kernels.{ GaussianKernel, MatrixValuedPDKernel, DiagonalKernel }
 import scalismo.numerics.{ GridSampler, UniformSampler }
 
 import scala.language.implicitConversions
@@ -61,7 +61,7 @@ class GaussianProcessTests extends ScalismoTestSuite {
     it("have the correct mean and variance for a full gp") {
       val domain = BoxDomain(Point(-1.0), Point(1.0))
       val m = VectorField(domain, (_: Point[_1D]) => Vector(0))
-      val k = UncorrelatedKernel[_1D](GaussianKernel[_1D](2.0))
+      val k = DiagonalKernel[_1D](GaussianKernel[_1D](2.0))
       val gp = GaussianProcess[_1D, _1D](m, k)
       testVarianceForGP(gp, domain)
     }
@@ -69,7 +69,7 @@ class GaussianProcessTests extends ScalismoTestSuite {
     it("have the correct mean and variance for a low-rank gp") {
       val domain = BoxDomain(Point(-1.0), Point(1.0))
       val m = VectorField(domain, (_: Point[_1D]) => Vector(0))
-      val k = UncorrelatedKernel[_1D](GaussianKernel[_1D](2.0))
+      val k = DiagonalKernel[_1D](GaussianKernel[_1D](2.0))
       val sampler = UniformSampler(domain, 500)
       val lgp = LowRankGaussianProcess.approximateGP(GaussianProcess(m, k), sampler, 100)
 
@@ -79,7 +79,7 @@ class GaussianProcessTests extends ScalismoTestSuite {
     it("yields the same values as the original gp at the given points") {
       val domain = BoxDomain(Point(-2.0f, 1.0f), Point(1.0f, 2.0f))
       val m = VectorField(domain, (_: Point[_2D]) => Vector(0.0f, 0.0f))
-      val gp = GaussianProcess(m, UncorrelatedKernel[_2D](GaussianKernel[_2D](1.0)))
+      val gp = GaussianProcess(m, DiagonalKernel[_2D](GaussianKernel[_2D](1.0)))
 
       val testPts = IndexedSeq(Point(-1.0f, 1.5f), Point(0.0f, 1.7f))
       val discreteGP = gp.marginal(UnstructuredPointsDomain(testPts))
@@ -97,7 +97,7 @@ class GaussianProcessTests extends ScalismoTestSuite {
   describe("A Gaussian process regression") {
     it("keeps the landmark points fixed for a 1D case") {
       val domain = BoxDomain(-5.0f, 5f)
-      val kernel = UncorrelatedKernel[_1D](GaussianKernel[_1D](5))
+      val kernel = DiagonalKernel[_1D](GaussianKernel[_1D](5))
       val gp = GaussianProcess(VectorField(domain, (_: Point[_1D]) => Vector(0f)), kernel)
       val gpLowRank = LowRankGaussianProcess.approximateGP(gp, UniformSampler(domain, 500), 100)
 
@@ -113,7 +113,7 @@ class GaussianProcessTests extends ScalismoTestSuite {
 
     it("yields a larger posterior variance for points that are less strongly constrained") {
       val domain = BoxDomain(-5.0f, 5f)
-      val kernel = UncorrelatedKernel[_1D](GaussianKernel[_1D](1.0))
+      val kernel = DiagonalKernel[_1D](GaussianKernel[_1D](1.0))
       val gp = GaussianProcess(VectorField(domain, (_: Point[_1D]) => Vector(0f)), kernel)
       val gpLowRank = LowRankGaussianProcess.approximateGP(gp, UniformSampler(domain, 500), 100)
 
@@ -136,7 +136,7 @@ class GaussianProcessTests extends ScalismoTestSuite {
     it("keeps the landmark points fixed for a 2D case") {
       val domain = BoxDomain((-5.0f, -5.0f), (5.0f, 5.0f))
       val gp = GaussianProcess[_2D, _2D](VectorField(domain, _ => Vector(0.0, 0.0)),
-        UncorrelatedKernel[_2D](GaussianKernel[_2D](5)))
+        DiagonalKernel[_2D](GaussianKernel[_2D](5)))
       val gpLowRank = LowRankGaussianProcess.approximateGP[_2D, _2D](gp, UniformSampler(domain, 400), 100)
 
       val trainingData = IndexedSeq((Point(-3.0, -3.0), Vector(1.0, 1.0)), (Point(-1.0, 3.0), Vector(0.0, -1.0)))
@@ -156,7 +156,7 @@ class GaussianProcessTests extends ScalismoTestSuite {
     it("keeps the landmark points fixed for a 3D case") {
       val domain = BoxDomain((-5.0f, -5.0f, -5.0f), (5.0f, 5.0f, 5.0f))
       val gp = GaussianProcess[_3D, _3D](VectorField(domain, _ => Vector(0.0, 0.0, 0.0)),
-        UncorrelatedKernel[_3D](GaussianKernel[_3D](5)))
+        DiagonalKernel[_3D](GaussianKernel[_3D](5)))
       val gpLowRank = LowRankGaussianProcess.approximateGP[_3D, _3D](gp, UniformSampler(domain, 6 * 6 * 6), 50)
 
       val trainingData = IndexedSeq((Point(-3.0, -3.0, -1.0), Vector(1.0, 1.0, 2.0)), (Point(-1.0, 3.0, 0.0), Vector(0.0, -1.0, 0.0)))
@@ -180,7 +180,7 @@ class GaussianProcessTests extends ScalismoTestSuite {
     object Fixture {
       val domain = BoxDomain((-5.0f, -5.0f, -5.0f), (5.0f, 5.0f, 5.0f))
       val sampler = GridSampler(DiscreteImageDomain(domain.origin, domain.extent * (1.0 / 7), IntVector(7, 7, 7)))
-      val kernel = UncorrelatedKernel[_3D](GaussianKernel[_3D](10))
+      val kernel = DiagonalKernel[_3D](GaussianKernel[_3D](10))
       val gp = {
         LowRankGaussianProcess.approximateGP[_3D, _3D](GaussianProcess(VectorField(domain, _ => Vector(0.0, 0.0, 0.0)), kernel), sampler, 200)
       }
@@ -270,7 +270,7 @@ class GaussianProcessTests extends ScalismoTestSuite {
       val domain = BoxDomain((-5.0f, -5.0f, -5.0f), (5.0f, 5.0f, 5.0f))
       val sampler = UniformSampler(domain, 6 * 6 * 6)
       val mean = VectorField[_3D, _3D](RealSpace[_3D], _ => Vector(0.0, 0.0, 0.0))
-      val gp = GaussianProcess(mean, UncorrelatedKernel[_3D](GaussianKernel[_3D](5)))
+      val gp = GaussianProcess(mean, DiagonalKernel[_3D](GaussianKernel[_3D](5)))
       val lowRankGp = LowRankGaussianProcess.approximateGP(gp, sampler, 100)
 
       val discretizationPoints = sampler.sample.map(_._1)
@@ -296,7 +296,7 @@ class GaussianProcessTests extends ScalismoTestSuite {
       val domain = BoxDomain((-5.0f, -5.0f, -5.0f), (5.0f, 5.0f, 5.0f))
       val sampler = UniformSampler(domain, 6 * 6 * 6)
       val mean = VectorField[_3D, _3D](RealSpace[_3D], _ => Vector(0.0, 0.0, 0.0))
-      val gp = GaussianProcess(mean, UncorrelatedKernel[_3D](GaussianKernel[_3D](5)))
+      val gp = GaussianProcess(mean, DiagonalKernel[_3D](GaussianKernel[_3D](5)))
 
       val lowRankGp = LowRankGaussianProcess.approximateGP(gp, sampler, 200)
 

--- a/src/test/scala/scalismo/statisticalmodel/dataset/DataCollectionTests.scala
+++ b/src/test/scala/scalismo/statisticalmodel/dataset/DataCollectionTests.scala
@@ -21,7 +21,7 @@ import scalismo.ScalismoTestSuite
 import scalismo.common.VectorField
 import scalismo.geometry._
 import scalismo.io.MeshIO
-import scalismo.kernels.{ GaussianKernel, UncorrelatedKernel }
+import scalismo.kernels.{ GaussianKernel, DiagonalKernel }
 import scalismo.mesh.MeshMetrics
 import scalismo.registration.{ LandmarkRegistration, TranslationTransform }
 import scalismo.statisticalmodel.GaussianProcess
@@ -110,7 +110,7 @@ class DataCollectionTests extends ScalismoTestSuite {
   describe("Generalization") {
 
     val zeroMean = VectorField(Fixture.dc.reference.boundingBox, (pt: Point[_3D]) => Vector(0, 0, 0))
-    val matrixValuedGaussian = UncorrelatedKernel[_3D](GaussianKernel(25) * 20)
+    val matrixValuedGaussian = DiagonalKernel[_3D](GaussianKernel(25) * 20)
     val bias: GaussianProcess[_3D, _3D] = GaussianProcess(zeroMean, matrixValuedGaussian)
     val augmentedModel = PCAModel.augmentModel(Fixture.pcaModel, bias, Fixture.pcaModel.rank + 5)
 


### PR DESCRIPTION
The last commit is the debatable one. Seems to me to be the only way to still have an efficient implementation of the isotropic kernel. Alternative would be that diagonal kernel is by default anisotropic and the isotropic case is implemented via a factory method duplicating the same kernel. This would however result in computing the same  value 3 times in a 3D case.