### PR TITLE
Make kdtree and pointId computations lazy.

### DIFF
--- a/src/main/scala/scalismo/common/UnstructuredPointsDomain.scala
+++ b/src/main/scala/scalismo/common/UnstructuredPointsDomain.scala
@@ -27,8 +27,8 @@ sealed abstract class UnstructuredPointsDomain[D <: Dim: NDSpace] private[scalis
 
   override def point(id: PointId) = pointSeq(id.id)
 
-  private[this] val kdTreeMap = KDTreeMap.fromSeq(pointSeq.zipWithIndex)
-  private[this] val pointIDMap = pointSeq.zipWithIndex.map { case (pt, id) => (pt, PointId(id)) }.toMap
+  private[this] lazy val kdTreeMap = KDTreeMap.fromSeq(pointSeq.zipWithIndex)
+  private[this] lazy val pointIDMap = pointSeq.zipWithIndex.map { case (pt, id) => (pt, PointId(id)) }.toMap
 
   override def isDefinedAt(pt: Point[D]) = pointIDMap.contains(pt)
 


### PR DESCRIPTION
Currently, the KDTree and PointIDMap are computed whenever an UnstructuredPointsDomain is contructed, even though these data structures are only required when we perform search operations on the points. To speed up the creation of the UnstructuredPointsDomain (which includes creation of  a TriangleMesh) this PR proposes to make these lazy vals. 