### PR TITLE
added sbt-buildinfo plugin usage

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -7,6 +7,8 @@ import com.typesafe.sbt.SbtGit.git
 
 import com.banno.license.Plugin.LicenseKeys._
 import com.banno.license.Licenses._
+import sbtbuildinfo.Plugin._
+
 
 object BuildSettings {
   val buildOrganization = "ch.unibas.cs.gravis"
@@ -95,6 +97,12 @@ object STKBuild extends Build {
       ++ ghpages.settings ++
       Seq(
         git.remoteRepo := "git@github.com:unibas-gravis/scalismo.git"
+      )++
+      buildInfoSettings ++
+      Seq(
+      sourceGenerators in Compile <+= buildInfo,
+      buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion),
+      buildInfoPackage := "scalismo"
       )
 )
   // Sub-project specific dependencies

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,3 +14,5 @@ addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.6.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "0.8.1")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.5.3")
+
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.3.2")


### PR DESCRIPTION
scalismo version is automatically generated into object scalismo.BuildInfo 
(in target directory, i.e. not src)