### PR TITLE
Landmark io refact

### DIFF
--- a/src/main/scala/scalismo/geometry/Landmark.scala
+++ b/src/main/scala/scalismo/geometry/Landmark.scala
@@ -18,21 +18,5 @@ package scalismo.geometry
 import scalismo.io.LandmarkIO
 import scalismo.statisticalmodel.NDimensionalNormalDistribution
 
-/* It's explicitly forbidden to extend this class (which is possible, but ugly anyway),
- * to force "extensions" to use composition instead of subclassing.
- *
- * The primary reason is to force implementations to provide the correct extension encode/decode functions when using
- * the LandmarkIO methods for reading and writing JSON representations of landmarks.
- */
-final case class Landmark[D <: Dim: NDSpace](id: String, point: Point[D], description: Option[String] = None, uncertainty: Option[NDimensionalNormalDistribution[D]] = None)
+case class Landmark[D <: Dim: NDSpace](id: String, point: Point[D], description: Option[String] = None, uncertainty: Option[NDimensionalNormalDistribution[D]] = None)
 
-object Landmark {
-
-  import scala.language.implicitConversions
-
-  implicit def noExtensionsEncodeFunction[D <: Dim: NDSpace]: LandmarkIO.ExtensionEncodeFunction[D, Landmark[D]] = { lm => (lm, None) }
-
-  implicit def noExtensionsDecodeFunction[D <: Dim: NDSpace]: LandmarkIO.ExtensionDecodeFunction[D, Landmark[D]] = {
-    case (lm, _) => lm
-  }
-}

--- a/src/main/scala/scalismo/io/LandmarkIO.scala
+++ b/src/main/scala/scalismo/io/LandmarkIO.scala
@@ -78,19 +78,19 @@ object LandmarkIO {
   /* Convenience methods if the "standard" landmarks are used.
    * This simply avoids having to specify the Landmark[D] type all the time.
    */
-  def readLandmarksJson[D <: Dim: NDSpace](file: File): Try[List[Landmark[D]]] = {
+  def readLandmarksJson[D <: Dim: NDSpace](file: File): Try[immutable.Seq[Landmark[D]]] = {
     readLandmarksJson[D, Landmark[D]](file)
   }
 
-  def readLandmarksJsonFromSource[D <: Dim: NDSpace](source: Source): Try[List[Landmark[D]]] = {
+  def readLandmarksJsonFromSource[D <: Dim: NDSpace](source: Source): Try[immutable.Seq[Landmark[D]]] = {
     readLandmarksJsonFromSource[D, Landmark[D]](source)
   }
 
-  def readLandmarksJson[D <: Dim: NDSpace, A](file: File)(implicit extDecode: ExtensionDecodeFunction[D, A]): Try[List[A]] = {
+  def readLandmarksJson[D <: Dim: NDSpace, A](file: File)(implicit extDecode: ExtensionDecodeFunction[D, A]): Try[immutable.Seq[A]] = {
     readLandmarksJsonFromSource(Source.fromFile(file))
   }
 
-  def readLandmarksJsonFromSource[D <: Dim: NDSpace, A](source: Source)(implicit extDecode: ExtensionDecodeFunction[D, A]): Try[List[A]] = {
+  def readLandmarksJsonFromSource[D <: Dim: NDSpace, A](source: Source)(implicit extDecode: ExtensionDecodeFunction[D, A]): Try[immutable.Seq[A]] = {
     implicit val e = LandmarkJsonFormat[D]()
     for {
       result <- Try {
@@ -104,17 +104,17 @@ object LandmarkIO {
     } yield result
   }
 
-  def writeLandmarksJson[D <: Dim: NDSpace](file: File, landmarks: List[Landmark[D]]) = {
+  def writeLandmarksJson[D <: Dim: NDSpace](file: File, landmarks: immutable.Seq[Landmark[D]]) = {
     writeLandmarksJsonToStream[D, Landmark[D]](new FileOutputStream(file), landmarks)
   }
 
-  def writeLandmarksJsonToStream[D <: Dim, A](stream: OutputStream, landmarks: List[A])(implicit extEncode: ExtensionEncodeFunction[D, A], ndSpace: NDSpace[D]): Try[Unit] = Try {
+  def writeLandmarksJsonToStream[D <: Dim, A](stream: OutputStream, landmarks: immutable.Seq[A])(implicit extEncode: ExtensionEncodeFunction[D, A], ndSpace: NDSpace[D]): Try[Unit] = Try {
     val lms = landmarks.map(extEncode).map { case (lm, ext) => ExtLandmark(lm, ext) }
     implicit val e = LandmarkJsonFormat[D]()
     writeLandmarksJsonToStream(stream, lms)
   }.flatten
 
-  private def writeLandmarksJsonToStream[D <: Dim: NDSpace](stream: OutputStream, landmarks: List[ExtLandmark[D]])(implicit e: JsonFormat[ExtLandmark[D]]): Try[Unit] = {
+  private def writeLandmarksJsonToStream[D <: Dim: NDSpace](stream: OutputStream, landmarks: immutable.Seq[ExtLandmark[D]])(implicit e: JsonFormat[ExtLandmark[D]]): Try[Unit] = {
     val writer = new PrintWriter(stream, true)
     val result = Try {
       writer.println(landmarks.toJson.toString())
@@ -133,18 +133,18 @@ object LandmarkIO {
    * ****************************************************************************************************************
    */
 
-  def readLandmarksCsv[D <: Dim: NDSpace](file: File): Try[immutable.IndexedSeq[Landmark[D]]] = {
+  def readLandmarksCsv[D <: Dim: NDSpace](file: File): Try[immutable.Seq[Landmark[D]]] = {
     readLandmarksCsvFromSource(Source.fromFile(file))
   }
 
-  def readLandmarksCsvFromSource[D <: Dim: NDSpace](source: Source): Try[immutable.IndexedSeq[Landmark[D]]] = {
+  def readLandmarksCsvFromSource[D <: Dim: NDSpace](source: Source): Try[immutable.Seq[Landmark[D]]] = {
     val items = implicitly[NDSpace[D]].dimensionality
     for (landmarks <- readLandmarksCsvRaw(source)) yield {
       for (landmark <- landmarks) yield Landmark(landmark._1, Point(landmark._2.take(items)))
     }
   }
 
-  private def readLandmarksCsvRaw(source: Source): Try[immutable.IndexedSeq[(String, Array[Float])]] = {
+  private def readLandmarksCsvRaw(source: Source): Try[immutable.Seq[(String, Array[Float])]] = {
     val result = Try {
       val landmarks = for (line <- source.getLines() if line.nonEmpty && line(0) != '#') yield {
         val elements = line.split(',')
@@ -158,11 +158,11 @@ object LandmarkIO {
     result
   }
 
-  def writeLandmarksCsv[D <: Dim](file: File, landmarks: IndexedSeq[Landmark[D]]): Try[Unit] = {
+  def writeLandmarksCsv[D <: Dim](file: File, landmarks: immutable.Seq[Landmark[D]]): Try[Unit] = {
     writeLandmarksCsvToStream(new FileOutputStream(file), landmarks)
   }
 
-  def writeLandmarksCsvToStream[D <: Dim](stream: OutputStream, landmarks: IndexedSeq[Landmark[D]]): Try[Unit] = {
+  def writeLandmarksCsvToStream[D <: Dim](stream: OutputStream, landmarks: immutable.Seq[Landmark[D]]): Try[Unit] = {
     Try {
       val out = new PrintWriter(stream, true)
       for (landmark <- landmarks) {

--- a/src/main/scala/scalismo/io/LandmarkIO.scala
+++ b/src/main/scala/scalismo/io/LandmarkIO.scala
@@ -104,17 +104,13 @@ object LandmarkIO {
     } yield result
   }
 
-  def writeLandmarksJson[D <: Dim: NDSpace](file: File, landmarks: immutable.Seq[Landmark[D]]) = {
-    writeLandmarksJsonToStream[D, Landmark[D]](new FileOutputStream(file), landmarks)
-  }
+  @deprecated("Use method with the same name and inverted order of parameters. This method wil be removed in future versions.", "0.10.0")
+  def writeLandmarksJson[D <: Dim: NDSpace](file: File, landmarks: immutable.Seq[Landmark[D]]): Try[Unit] = writeLandmarksJson(landmarks, file)
 
-  def writeLandmarksJsonToStream[D <: Dim, A](stream: OutputStream, landmarks: immutable.Seq[A])(implicit extEncode: ExtensionEncodeFunction[D, A], ndSpace: NDSpace[D]): Try[Unit] = Try {
-    val lms = landmarks.map(extEncode).map { case (lm, ext) => ExtLandmark(lm, ext) }
-    implicit val e = LandmarkJsonFormat[D]()
-    writeLandmarksJsonToStream(stream, lms)
-  }.flatten
+  @deprecated("Use method with the same name and inverted order of parameters. This method wil be removed in future versions.", "0.10.0")
+  def writeLandmarksJsonToStream[D <: Dim, A](stream: OutputStream, landmarks: immutable.Seq[A])(implicit extEncode: ExtensionEncodeFunction[D, A], ndSpace: NDSpace[D]): Try[Unit] = writeLandmarksJsonToStream(landmarks, stream)
 
-  private def writeLandmarksJsonToStream[D <: Dim: NDSpace](stream: OutputStream, landmarks: immutable.Seq[ExtLandmark[D]])(implicit e: JsonFormat[ExtLandmark[D]]): Try[Unit] = {
+  private def writeLandmarksJsonToStreamP[D <: Dim: NDSpace](stream: OutputStream, landmarks: immutable.Seq[ExtLandmark[D]])(implicit e: JsonFormat[ExtLandmark[D]]): Try[Unit] = {
     val writer = new PrintWriter(stream, true)
     val result = Try {
       writer.println(landmarks.toJson.toString())
@@ -124,6 +120,16 @@ object LandmarkIO {
     }
     result
   }
+
+  def writeLandmarksJson[D <: Dim: NDSpace](landmarks: immutable.Seq[Landmark[D]], file: File): Try[Unit] = {
+    writeLandmarksJsonToStream[D, Landmark[D]](landmarks, new FileOutputStream(file))
+  }
+
+  def writeLandmarksJsonToStream[D <: Dim, A](landmarks: immutable.Seq[A], stream: OutputStream)(implicit extEncode: ExtensionEncodeFunction[D, A], ndSpace: NDSpace[D]): Try[Unit] = Try {
+    val lms = landmarks.map(extEncode).map { case (lm, ext) => ExtLandmark(lm, ext) }
+    implicit val e = LandmarkJsonFormat[D]()
+    writeLandmarksJsonToStreamP(stream, lms)
+  }.flatten
 
   /**
    * ******************************************************************************************************************
@@ -158,11 +164,17 @@ object LandmarkIO {
     result
   }
 
-  def writeLandmarksCsv[D <: Dim](file: File, landmarks: immutable.Seq[Landmark[D]]): Try[Unit] = {
-    writeLandmarksCsvToStream(new FileOutputStream(file), landmarks)
+  @deprecated("Use method with the same name and inverted order of parameters. This method wil be removed in future versions.", "0.10.0")
+  def writeLandmarksCsv[D <: Dim](file: File, landmarks: immutable.Seq[Landmark[D]]): Try[Unit] = writeLandmarksCsv(landmarks, file)
+
+  @deprecated("Use method with the same name and inverted order of parameters. This method wil be removed in future versions.", "0.10.0")
+  def writeLandmarksCsvToStream[D <: Dim](stream: OutputStream, landmarks: immutable.Seq[Landmark[D]]): Try[Unit] = writeLandmarksCsvToStream(landmarks, stream)
+
+  def writeLandmarksCsv[D <: Dim](landmarks: immutable.Seq[Landmark[D]], file: File): Try[Unit] = {
+    writeLandmarksCsvToStream(landmarks, new FileOutputStream(file))
   }
 
-  def writeLandmarksCsvToStream[D <: Dim](stream: OutputStream, landmarks: immutable.Seq[Landmark[D]]): Try[Unit] = {
+  def writeLandmarksCsvToStream[D <: Dim](landmarks: immutable.Seq[Landmark[D]], stream: OutputStream): Try[Unit] = {
     Try {
       val out = new PrintWriter(stream, true)
       for (landmark <- landmarks) {

--- a/src/test/scala/scalismo/io/LandmarkIOTests.scala
+++ b/src/test/scala/scalismo/io/LandmarkIOTests.scala
@@ -23,6 +23,7 @@ import scalismo.statisticalmodel.NDimensionalNormalDistribution
 
 import scala.io.Source
 import scala.language.implicitConversions
+import scala.collection.immutable.Seq
 
 class LandmarkIOTests extends ScalismoTestSuite {
 
@@ -76,7 +77,7 @@ class LandmarkIOTests extends ScalismoTestSuite {
       val tmpFile = File.createTempFile("landmark", "txt")
       tmpFile.deleteOnExit()
 
-      val landmarks = IndexedSeq(("first", Point(1.0, 2.0, 3.0)), ("second", Point(2.0, 1.0, 3.0))).map(t => Landmark(t._1, t._2))
+      val landmarks = Seq(("first", Point(1.0, 2.0, 3.0)), ("second", Point(2.0, 1.0, 3.0))).map(t => Landmark(t._1, t._2))
       LandmarkIO.writeLandmarksCsv(tmpFile, landmarks) should be a 'Success
 
       val restoredLandmarksTry = LandmarkIO.readLandmarksCsv[_3D](tmpFile)

--- a/src/test/scala/scalismo/io/LandmarkIOTests.scala
+++ b/src/test/scala/scalismo/io/LandmarkIOTests.scala
@@ -78,7 +78,7 @@ class LandmarkIOTests extends ScalismoTestSuite {
       tmpFile.deleteOnExit()
 
       val landmarks = Seq(("first", Point(1.0, 2.0, 3.0)), ("second", Point(2.0, 1.0, 3.0))).map(t => Landmark(t._1, t._2))
-      LandmarkIO.writeLandmarksCsv(tmpFile, landmarks) should be a 'Success
+      LandmarkIO.writeLandmarksCsv(landmarks, tmpFile) should be a 'Success
 
       val restoredLandmarksTry = LandmarkIO.readLandmarksCsv[_3D](tmpFile)
       restoredLandmarksTry should be a 'Success
@@ -107,7 +107,7 @@ class LandmarkIOTests extends ScalismoTestSuite {
 
     it("can serialize and deserialize simple landmarks using JSON") {
       val out = new ByteArrayOutputStream()
-      LandmarkIO.writeLandmarksJsonToStream(out, jsonLms)
+      LandmarkIO.writeLandmarksJsonToStream(jsonLms, out)
       val written = new String(out.toByteArray)
       val read = LandmarkIO.readLandmarksJsonFromSource[_3D](Source.fromString(written)).get
       read should equal(jsonLms)
@@ -147,7 +147,7 @@ class LandmarkIOTests extends ScalismoTestSuite {
 
     it("can serialize and deserialize complex landmarks using JSON") {
       val out = new ByteArrayOutputStream()
-      LandmarkIO.writeLandmarksJsonToStream(out, extLms)
+      LandmarkIO.writeLandmarksJsonToStream(extLms, out)
       val read = LandmarkIO.readLandmarksJsonFromSource[_3D, TestLandmark](Source.fromBytes(out.toByteArray)).get
       read should equal(extLms)
     }

--- a/src/test/scala/scalismo/io/LandmarkIOTests.scala
+++ b/src/test/scala/scalismo/io/LandmarkIOTests.scala
@@ -91,7 +91,7 @@ class LandmarkIOTests extends ScalismoTestSuite {
     }
 
     /*
-     * SIMPLE JSON LANDMARKS (no extensions)
+     * SIMPLE JSON LANDMARKS
      */
 
     def distWithDefaultVectors(d1: Float, d2: Float, d3: Float): NDimensionalNormalDistribution[_3D] = {
@@ -118,50 +118,5 @@ class LandmarkIOTests extends ScalismoTestSuite {
       read should equal(jsonLms)
     }
 
-    /*
-     * COMPLEX JSON LANDMARKS (with extensions)
-     * This example uses two additional (bogus) attributes: color, and visibility.
-     * For simplicity, it uses an internal case class.
-     */
-
-    import spray.json.DefaultJsonProtocol._
-    import spray.json._
-
-    case class LMData(color: Option[String], visible: Boolean)
-    implicit val LMDataProtocol = jsonFormat2(LMData)
-
-    case class TestLandmark(lm: Landmark[_3D], data: LMData)
-
-    val extLm1 = TestLandmark(jsonLm1, LMData(None, visible = false))
-    val extLm2 = TestLandmark(jsonLm2, LMData(Some("red"), visible = true))
-    val extLm2E = TestLandmark(jsonLm2, LMData(None, visible = false))
-
-    val extLms = List(extLm1, extLm2)
-    val extLmsE = List(extLm1, extLm2E)
-
-    implicit val extEncode: LandmarkIO.ExtensionEncodeFunction[_3D, TestLandmark] = { tlm => (tlm.lm, Some(Map("test.ext" -> tlm.data.toJson))) }
-    implicit val extDecode: LandmarkIO.ExtensionDecodeFunction[_3D, TestLandmark] = { (lm, json) =>
-      val data = json.map(_.get("test.ext")).flatMap(_.map(_.convertTo[LMData]))
-      TestLandmark(lm, data.getOrElse(LMData(None, visible = false)))
-    }
-
-    it("can serialize and deserialize complex landmarks using JSON") {
-      val out = new ByteArrayOutputStream()
-      LandmarkIO.writeLandmarksJsonToStream(extLms, out)
-      val read = LandmarkIO.readLandmarksJsonFromSource[_3D, TestLandmark](Source.fromBytes(out.toByteArray)).get
-      read should equal(extLms)
-    }
-
-    it("can read complex landmarks from a JSON Stream") {
-      val read = LandmarkIO.readLandmarksJsonFromSource[_3D, TestLandmark](jsonComplexStream()).get
-      read should equal(extLms)
-    }
-
-    it("can handle unexpected and missing extensions in JSON landmarks") {
-      val cs = LandmarkIO.readLandmarksJsonFromSource[_3D, TestLandmark](jsonStream()).get
-      cs should equal(extLmsE)
-      val sc = LandmarkIO.readLandmarksJsonFromSource[_3D](jsonComplexStream()).get
-      sc should equal(jsonLms)
-    }
   }
 }


### PR DESCRIPTION
Note that there is still the problem with ambiguous implicits when calling readLandmarksCsv or readLandmarksJson without specifying the dimensionality as a type parameters. This is however a  problem beyond the LandmarkIO and manifests also for other factory methods (Point, Vector ...)

This problem should resolve by itself with scala 2.12 where an @implicitAmbiguous annotation will be added (http://www.scala-lang.org/news/2.12.0-M3/), where we could display more friendly messages.  

Another option would be to try something like this : http://stackoverflow.com/questions/4403906/is-it-possible-in-scala-to-force-the-caller-to-specify-a-type-parameter-for-a-po/6629984#6629984
and try to default to a type parameter.