### PR TITLE
Point & Vector with additional functionality: normalize, multiplyComponents

### DIFF
--- a/src/main/scala/scalismo/geometry/Point.scala
+++ b/src/main/scala/scalismo/geometry/Point.scala
@@ -68,6 +68,10 @@ case class Point1D(x: Float) extends Point[_1D] {
   override def mapWithIndex(f: (Float, Int) => Float): Point1D = Point1D(f(x, 0))
 }
 
+object Point1D {
+  val origin = Point1D(0f)
+}
+
 /** 2D point */
 case class Point2D(x: Float, y: Float) extends Point[_2D] {
   override def apply(i: Int): Float = i match {
@@ -87,6 +91,10 @@ case class Point2D(x: Float, y: Float) extends Point[_2D] {
   override def toArray = Array(x, y)
 
   override def mapWithIndex(f: (Float, Int) => Float): Point2D = Point2D(f(x, 0), f(y, 1))
+}
+
+object Point2D {
+  val origin = Point2D(0f, 0f)
 }
 
 /** 3D point */
@@ -109,6 +117,10 @@ case class Point3D(x: Float, y: Float, z: Float) extends Point[_3D] {
   override def toArray = Array(x, y, z)
 
   override def mapWithIndex(f: (Float, Int) => Float): Point3D = Point3D(f(x, 0), f(y, 1), f(z, 2))
+}
+
+object Point3D {
+  val origin = Point3D(0f, 0f, 0f)
 }
 
 object Point {
@@ -140,15 +152,32 @@ object Point {
   }
 
   def apply[D <: Dim: NDSpace](d: Array[Float])(implicit builder: Create[D]) = builder.createPoint(d)
-  def apply(x: Float): Point1D = Point1D(x)
-  def apply(x: Float, y: Float): Point2D = Point2D(x, y)
-  def apply(x: Float, y: Float, z: Float): Point3D = Point3D(x, y, z)
+  def apply(x: Float): Point[_1D] = Point1D(x)
+  def apply(x: Float, y: Float): Point[_2D] = Point2D(x, y)
+  def apply(x: Float, y: Float, z: Float): Point[_3D] = Point3D(x, y, z)
+
+  def origin[D <: Dim: NDSpace](implicit builder: Create[D]) = builder.createPoint(Array.fill(NDSpace[D].dimensionality)(0f))
 
   def fromBreezeVector[D <: Dim: NDSpace](breeze: DenseVector[Float])(implicit builder: Create[D]): Point[D] = {
     val dim = NDSpace[D].dimensionality
     require(breeze.size == dim, s"Invalid size of breeze vector (${breeze.size} != $dim)")
     Point.apply[D](breeze.data)
   }
+
+  /**
+   * create a Cartesian point from polar coordinates
+   * @param r radial distance, 0 .. infinity
+   * @param phi azimuth, 0 .. 2*Pi
+   */
+  def fromPolar(r: Float, phi: Float): Point[_2D] = Vector.fromPolar(r, phi).toPoint
+
+  /**
+   * create a Cartesian point from spherical coordinates
+   * @param r radial distance, 0 .. infinity
+   * @param theta inclination, 0 .. Pi
+   * @param phi azimuth, 0 .. 2*Pi
+   */
+  def fromSpherical(r: Float, theta: Float, phi: Float): Point[_3D] = Vector.fromSpherical(r, theta, phi).toPoint
 
   object implicits {
     implicit def point1DToFloat(p: Point[_1D]): Float = p.x

--- a/src/main/scala/scalismo/geometry/Vector.scala
+++ b/src/main/scala/scalismo/geometry/Vector.scala
@@ -54,7 +54,7 @@ sealed abstract class Vector[D <: Dim: NDSpace] {
 
   def dot(that: Vector[D]): Float
 
-  def multiplyComponents(that: Vector[D]): Vector[D]
+  def :*(that: Vector[D]): Vector[D]
 
   def normalize: Vector[D] = this / norm
 
@@ -107,7 +107,7 @@ case class Vector1D(x: Float) extends Vector[_1D] {
 
   override def *(s: Float): Vector1D = Vector1D(x * s)
 
-  override def multiplyComponents(that: Vector[_1D]): Vector1D = Vector1D(x * that.x)
+  override def :*(that: Vector[_1D]): Vector1D = Vector1D(x * that.x)
 
   override def toPoint: Point1D = Point1D(x)
 
@@ -140,7 +140,7 @@ case class Vector2D(x: Float, y: Float) extends Vector[_2D] {
 
   override def *(s: Float): Vector2D = Vector2D(x * s, y * s)
 
-  override def multiplyComponents(that: Vector[_2D]): Vector2D = Vector2D(x * that.x, y * that.y)
+  override def :*(that: Vector[_2D]): Vector2D = Vector2D(x * that.x, y * that.y)
 
   override def toPoint: Point2D = Point2D(x, y)
 
@@ -176,7 +176,7 @@ case class Vector3D(x: Float, y: Float, z: Float) extends Vector[_3D] {
 
   override def *(s: Float): Vector3D = Vector3D(x * s, y * s, z * s)
 
-  override def multiplyComponents(that: Vector[_3D]): Vector3D = Vector3D(x * that.x, y * that.y, z * that.z)
+  override def :*(that: Vector[_3D]): Vector3D = Vector3D(x * that.x, y * that.y, z * that.z)
 
   override def toPoint: Point[_3D] = Point3D(x, y, z)
 
@@ -248,6 +248,7 @@ object Vector {
 
   /**
    * create a Cartesian vector from polar coordinates
+   *
    * @param r radial distance, 0 .. infinity
    * @param phi azimuth, 0 .. 2*Pi
    */
@@ -257,6 +258,7 @@ object Vector {
 
   /**
    * create a Cartesian vector from spherical coordinates
+   *
    * @param r radial distance, 0 .. infinity
    * @param theta inclination, 0 .. Pi
    * @param phi azimuth, 0 .. 2*Pi

--- a/src/test/scala/scalismo/geometry/GeometryTests.scala
+++ b/src/test/scala/scalismo/geometry/GeometryTests.scala
@@ -19,6 +19,7 @@ import breeze.linalg.{ DenseMatrix, DenseVector }
 import scalismo.ScalismoTestSuite
 
 import scala.language.implicitConversions
+import scala.util.Random
 
 class GeometryTests extends ScalismoTestSuite {
 
@@ -322,6 +323,31 @@ class GeometryTests extends ScalismoTestSuite {
       vRes should equal(v.mapWithIndex({ case (f, i) => f * i }))
     }
   }
+
+  describe("Polar and Spherical coordinates constructors") {
+    it("A 3D point can be constructed from spherical coordinates (with random values)") {
+      Point.fromSpherical(2.0f, 2.0f, 0.5f) shouldBe Point(1.5959672f, 0.8718808f, -0.8322937f)
+    }
+
+    it("A 2D point can be constructed from polar coordinates (with random values)") {
+      Point.fromPolar(2.0f, 0.5f) shouldBe Point(1.7551651f, 0.9588511f)
+    }
+
+    it("polar and spherical coordinates are consistent in xy plane") {
+      val p2d: Point2D = Point.fromPolar(1.5f, 0.2f)
+      val p3d: Point3D = Point.fromSpherical(1.5f, math.Pi / 2, 0.2f)
+      (Point(p2d.x, p2d.y, 0.0f) - p3d).norm should be < 1e-4
+    }
+
+    it("A 3D vector constructed from spherical coordinates is identical to the corresponding point") {
+      Vector.fromSpherical(3.0f, 3.0f, 5.0f) shouldBe Point.fromSpherical(3.0f, 3.0f, 5.0f).toVector
+    }
+
+    it("A 2D vector constructed from spherical coordinates is identical to the corresponding point") {
+      Vector.fromPolar(2.0f, 0.5f) shouldBe Point.fromPolar(2.0f, 0.5f).toVector
+    }
+  }
+
   describe("a 3x3 matrix") {
 
     // storage is column major


### PR DESCRIPTION
Added a few methods to `Point` and `Vector`, namely:

- Vector: `.normalize` returns normalized version of vector
- Vector: `.multiplyComponents` multiplies component-wise
- constants: `origin` in Point, `unit` in Vector for unit length base vectors, `zero` in Vector for zero vectors
- convenience constructors from polar and spherical coordinates for Point
- Interface types changed to generic, e.g. `Point[_3D]` instead of `Point3D` where applicable

existing functionality should be unaffected