### PR TITLE
Replaced `val dimensionality` by `def` -> stable initialization

### DIFF
--- a/src/main/scala/scalismo/geometry/IntVector.scala
+++ b/src/main/scala/scalismo/geometry/IntVector.scala
@@ -24,7 +24,7 @@ import scala.reflect.ClassTag
 sealed abstract class IntVector[D <: Dim: NDSpace] {
   def apply(a: Int): Int
 
-  val dimensionality: Int = implicitly[NDSpace[D]].dimensionality
+  def dimensionality: Int = implicitly[NDSpace[D]].dimensionality
 
   def toArray: Array[Int]
 

--- a/src/main/scala/scalismo/geometry/Point.scala
+++ b/src/main/scala/scalismo/geometry/Point.scala
@@ -26,7 +26,7 @@ import scala.reflect.ClassTag
 sealed abstract class Point[D <: Dim: NDSpace] {
   def apply(i: Int): Float
 
-  val dimensionality: Int = implicitly[NDSpace[D]].dimensionality
+  def dimensionality: Int = implicitly[NDSpace[D]].dimensionality
 
   def +(that: Vector[D]): Point[D]
 

--- a/src/main/scala/scalismo/geometry/Vector.scala
+++ b/src/main/scala/scalismo/geometry/Vector.scala
@@ -26,7 +26,7 @@ import scala.language.implicitConversions
 sealed abstract class Vector[D <: Dim: NDSpace] {
   def apply(i: Int): Float
 
-  val dimensionality: Int = implicitly[NDSpace[D]].dimensionality
+  def dimensionality: Int = implicitly[NDSpace[D]].dimensionality
 
   def norm: Double = math.sqrt(norm2)
 


### PR DESCRIPTION
in `Vector`/`Point`/`IntVector` the field `dimensionality` was a `val` which led to troubles with initializer blocks in depending code (is not properly initialized and has value `0`)

- replaced by `def dimensionality` in `Vector`/`Point`/`IntVector`