### PR TITLE
HDF5Utils issue fix: Various Try[Unit] methods always succeeded

### DIFF
--- a/src/test/scala/scalismo/io/HDF5UtilsTests.scala
+++ b/src/test/scala/scalismo/io/HDF5UtilsTests.scala
@@ -19,6 +19,8 @@ import java.io.File
 
 import scalismo.ScalismoTestSuite
 
+import scala.util.Try
+
 class HDF5UtilsTests extends ScalismoTestSuite {
 
   def createTmpH5File(): File = {
@@ -36,6 +38,36 @@ class HDF5UtilsTests extends ScalismoTestSuite {
       h5.writeInt("/agroup/anInt", anInt)
       val h5new = HDF5Utils.openFileForReading(h5file).get
       h5new.readInt("/agroup/anInt").get should be(anInt)
+    }
+
+    it("can write and read an NDArray[Int]") {
+      val h5file = createTmpH5File()
+      val h5: HDF5File = HDF5Utils.createFile(h5file).get
+      val arr = NDArray(IndexedSeq(2, 3), Array(1, 2, 3, 4, 5, 6))
+      h5.writeNDArray("/aGroup/array", arr).get
+      val h5new = HDF5Utils.openFileForReading(h5file).get
+      h5new.readNDArray("/aGroup/array").get.data.deep should be(arr.data.deep)
+    }
+
+    it("can write and read an NDArray[Float]") {
+      val h5file = createTmpH5File()
+      val h5: HDF5File = HDF5Utils.createFile(h5file).get
+      val arr = NDArray(IndexedSeq(2, 3), Array(1f, 2f, 3f, 4f, 5f, 6f))
+      h5.writeNDArray("/aGroup/array", arr).get
+      val h5new = HDF5Utils.openFileForReading(h5file).get
+      h5new.readNDArray("/aGroup/array").get.data.deep should be(arr.data.deep)
+    }
+
+    it("fails to write an unknown type") {
+      // find problems with Try[Unit] where map/flatMap issues arise
+      val h5file = createTmpH5File()
+      val h5: HDF5File = HDF5Utils.createFile(h5file).get
+      // new type, certainly unknown
+      case class NT(v: Double)
+      val arr: NDArray[NT] = NDArray(IndexedSeq(2, 3), Array(NT(1.0), NT(1.0), NT(1.0), NT(1.0), NT(1.0), NT(1.0)))
+      val result: Try[Unit] = h5.writeNDArray("/aGroup/array", arr)
+      // expect Exception: unknown type
+      intercept[Exception](result.get)
     }
   }
 }


### PR DESCRIPTION
Overview
-------------

- Fixed the `Try[Unit].map`/`flatMap` issue in `HDF5Utils`: The methods returned `Success(())` even on failure:
    - `writeNDArray`
    - `writeInt`
    - `writeFloat`
    - `writeString`

- Added a test which tries to write an unknown data type as `NDArray`, it should result in an exception
- Included possible failing of `h5file.get(path)` in return `Try` (method could still throw)

Details
---------

In `HDF5Utils` Methods with `Try[Unit]` as return type have an issue: they use `map` where `flatMap` should be used.

A problem usually caught by the type system. Not with `Try[Unit]`. When using `map`, the return type of the anonymous function is inferred to be of type `Unit` - compatible with `Success` and `Failure` - the type system is happy, the programmer not so much.

```scala
    val a: Try[Unit] = Success(1.0).map{v => Success()}
    println(s"map Success: $a") // map Success: Success(())

    val b: Try[Unit] = Success(1.0).map{v => Failure(new Exception("fail"))}
    println(s"map Failure: $b") // map Failure: Success(())

    val c: Try[Unit] = Success(1.0).flatMap{v => Success()}
    println(s"flatMap Success: $c") // flatMap Success: Success(())

    val d: Try[Unit] = Success(1.0).flatMap{v => Failure(new Exception("fail"))}
    println(s"flatMap Failure: $d") // flatMap Failure: Failure(java.lang.Exception: fail)
```
