### PR TITLE
variance parameter for `coefficients`

### DIFF
--- a/src/main/scala/scalismo/statisticalmodel/DiscreteGaussianProcess.scala
+++ b/src/main/scala/scalismo/statisticalmodel/DiscreteGaussianProcess.scala
@@ -111,9 +111,8 @@ class DiscreteGaussianProcess[D <: Dim: NDSpace, Value] private[scalismo] (val m
    * Discrete version of [[LowRankGaussianProcess.project(IndexedSeq[(Point[D], Vector[DO])], Double)]]
    */
 
-  def project(s: DiscreteField[D, Value]): DiscreteField[D, Value] = {
-
-    val sigma2 = 1e-5 // regularization weight to avoid numerical problems
+  def project(s: DiscreteField[D, Value], sigma2: Double = DiscreteGaussianProcess.numericalNoiseVariance): DiscreteField[D, Value] = {
+    require(sigma2 >= 0.0, "noise variance cannot be negative")
     val noiseDist = MultivariateNormalDistribution(DenseVector.zeros[Double](outputDim), DenseMatrix.eye[Double](outputDim) * sigma2)
     val td = s.values.zipWithIndex.map { case (v, id) => (id, v, noiseDist) }.toIndexedSeq
     DiscreteGaussianProcess.regression(this, td).mean
@@ -171,4 +170,7 @@ object DiscreteGaussianProcess {
 
     DiscreteGaussianProcess(discreteGp.domain, gp)
   }
+
+  /** default noise variance value of data observations (independent Gaussian), to avoid numerical issues */
+  val numericalNoiseVariance: Double = 1e-5
 }

--- a/src/main/scala/scalismo/statisticalmodel/DiscreteLowRankGaussianProcess.scala
+++ b/src/main/scala/scalismo/statisticalmodel/DiscreteLowRankGaussianProcess.scala
@@ -82,14 +82,14 @@ case class DiscreteLowRankGaussianProcess[D <: Dim: NDSpace, Value] private[scal
   /**
    * Returns the probability density of the given instance
    */
-  override def pdf(instance: DiscreteField[D, Value]): Double = pdf(coefficients(instance))
+  override def pdf(instance: DiscreteField[D, Value]): Double = pdf(coefficients(instance, DiscreteLowRankGaussianProcess.numericalNoiseVariance))
 
   /**
    * Returns the log of the probability density of the instance
    *
    * If you are interested in ordinal comparisons of PDFs, use this as it is numerically more stable
    */
-  override def logpdf(instance: DiscreteField[D, Value]): Double = logpdf(coefficients(instance))
+  override def logpdf(instance: DiscreteField[D, Value]): Double = logpdf(coefficients(instance, DiscreteLowRankGaussianProcess.numericalNoiseVariance))
 
   /**
    * Discrete version of [[DiscreteLowRankGaussianProcess.sample]]
@@ -114,8 +114,8 @@ case class DiscreteLowRankGaussianProcess[D <: Dim: NDSpace, Value] private[scal
   /**
    * Discrete version of [[LowRankGaussianProcess.project(IndexedSeq[(Point[D], Vector[DO])], Double)]]
    */
-  override def project(s: DiscreteField[D, Value]): DiscreteField[D, Value] = {
-    instance(coefficients(s))
+  override def project(s: DiscreteField[D, Value], sigma2: Double = DiscreteLowRankGaussianProcess.numericalNoiseVariance): DiscreteField[D, Value] = {
+    instance(coefficients(s, sigma2))
   }
 
   /**
@@ -123,7 +123,8 @@ case class DiscreteLowRankGaussianProcess[D <: Dim: NDSpace, Value] private[scal
    *
    * @param sigma2 variance of observation uncertainty (default value avoids numerical issues)
    */
-  def coefficients(s: DiscreteField[D, Value], sigma2: Double = 1e-5): DenseVector[Double] = {
+  def coefficients(s: DiscreteField[D, Value], sigma2: Double = DiscreteLowRankGaussianProcess.numericalNoiseVariance): DenseVector[Double] = {
+    require(sigma2 >= 0.0, "noise variance cannot be negative")
     val noiseDist = MultivariateNormalDistribution(DenseVector.zeros[Double](outputDim), DenseMatrix.eye[Double](outputDim) * sigma2)
     val td = s.valuesWithIds.map { case (v, id) => (id, v, noiseDist) }.toIndexedSeq
     val (minv, qtL, yVec, mVec) = DiscreteLowRankGaussianProcess.genericRegressionComputations(this, td)
@@ -137,6 +138,7 @@ case class DiscreteLowRankGaussianProcess[D <: Dim: NDSpace, Value] private[scal
    *
    */
   def posterior(trainingData: IndexedSeq[(PointId, Value)], sigma2: Double): DiscreteLowRankGaussianProcess[D, Value] = {
+    require(sigma2 >= 0.0, "noise variance cannot be negative")
     val cov = MultivariateNormalDistribution(DenseVector.zeros[Double](outputDim), DenseMatrix.eye[Double](outputDim) * sigma2)
     val newtd = trainingData.map { case (ptId, df) => (ptId, df, cov) }
     posterior(newtd)
@@ -286,7 +288,6 @@ private[scalismo] class NearestNeighbourInterpolatedLowRankGaussianProcess[D <: 
 }
 
 object DiscreteLowRankGaussianProcess {
-
   case class Eigenpair[D <: Dim, Value](eigenvalue: Double, eigenfunction: DiscreteField[D, Value])
 
   type KLBasis[D <: Dim, Value] = Seq[Eigenpair[D, Value]]
@@ -480,6 +481,9 @@ object DiscreteLowRankGaussianProcess {
 
     DiscreteMatrixValuedPDKernel(domain, cov, outputDim)
   }
+
+  /** default noise variance value of data observations (independent Gaussian), value to avoid numerical issues */
+  val numericalNoiseVariance: Double = DiscreteGaussianProcess.numericalNoiseVariance
 
 }
 

--- a/src/main/scala/scalismo/statisticalmodel/DiscreteLowRankGaussianProcess.scala
+++ b/src/main/scala/scalismo/statisticalmodel/DiscreteLowRankGaussianProcess.scala
@@ -120,9 +120,10 @@ case class DiscreteLowRankGaussianProcess[D <: Dim: NDSpace, Value] private[scal
 
   /**
    * Discrete version of [[DiscreteLowRankGaussianProcess.coefficients(IndexedSeq[(Point[D], Vector[DO], Double)])]]
+   *
+   * @param sigma2 variance of observation uncertainty (default value avoids numerical issues)
    */
-  def coefficients(s: DiscreteField[D, Value]): DenseVector[Double] = {
-    val sigma2 = 1e-5 // regularization weight to avoid numerical problems
+  def coefficients(s: DiscreteField[D, Value], sigma2: Double = 1e-5): DenseVector[Double] = {
     val noiseDist = MultivariateNormalDistribution(DenseVector.zeros[Double](outputDim), DenseMatrix.eye[Double](outputDim) * sigma2)
     val td = s.valuesWithIds.map { case (v, id) => (id, v, noiseDist) }.toIndexedSeq
     val (minv, qtL, yVec, mVec) = DiscreteLowRankGaussianProcess.genericRegressionComputations(this, td)

--- a/src/main/scala/scalismo/statisticalmodel/LowRankGaussianProcess.scala
+++ b/src/main/scala/scalismo/statisticalmodel/LowRankGaussianProcess.scala
@@ -88,7 +88,7 @@ class LowRankGaussianProcess[D <: Dim: NDSpace, Value](mean: Field[D, Value],
    * @param trainingData Point/value pairs where that the sample should approximate.
    * @param sigma2       variance of a Gaussian noise that is assumed on every training point
    */
-  def project(trainingData: IndexedSeq[(Point[D], Value)], sigma2: Double = 1e-6): Field[D, Value] = {
+  def project(trainingData: IndexedSeq[(Point[D], Value)], sigma2: Double = LowRankGaussianProcess.numericalNoiseVariance): Field[D, Value] = {
     val cov = MultivariateNormalDistribution(DenseVector.zeros[Double](outputDim), DenseMatrix.eye[Double](outputDim) * sigma2)
     val newtd = trainingData.map { case (pt, df) => (pt, df, cov) }
     project(newtd)
@@ -119,7 +119,7 @@ class LowRankGaussianProcess[D <: Dim: NDSpace, Value](mean: Field[D, Value],
    * Returns the sample of the coefficients of the sample that best explains the given training data. It is assumed that the training data (values)
    * are subject to 0 mean Gaussian noise
    */
-  def coefficients(trainingData: IndexedSeq[(Point[D], Value)], sigma2: Double): DenseVector[Double] = {
+  def coefficients(trainingData: IndexedSeq[(Point[D], Value)], sigma2: Double = LowRankGaussianProcess.numericalNoiseVariance): DenseVector[Double] = {
     val cov = MultivariateNormalDistribution(DenseVector.zeros[Double](outputDim), DenseMatrix.eye[Double](outputDim) * sigma2)
     val newtd = trainingData.map { case (pt, df) => (pt, df, cov) }
     coefficients(newtd)
@@ -168,6 +168,9 @@ class LowRankGaussianProcess[D <: Dim: NDSpace, Value](mean: Field[D, Value],
  * Factory methods for creating Low-rank gaussian processes, as well as generic algorithms to manipulate Gaussian processes.
  */
 object LowRankGaussianProcess {
+  /** default noise variance value of data observations (independent Gaussian), to avoid numerical issues */
+  val numericalNoiseVariance: Double = 1e-5
+
 
   case class Eigenpair[D <: Dim, Value](eigenvalue: Double, eigenfunction: Field[D, Value])
 

--- a/src/main/scala/scalismo/statisticalmodel/StatisticalMeshModel.scala
+++ b/src/main/scala/scalismo/statisticalmodel/StatisticalMeshModel.scala
@@ -106,19 +106,20 @@ case class StatisticalMeshModel private (referenceMesh: TriangleMesh[_3D], gp: D
   /**
    * @see [[DiscreteLowRankGaussianProcess.project]]
    */
-  def project(mesh: TriangleMesh[_3D]) = {
+  def project(mesh: TriangleMesh[_3D], sigma2: Double = DiscreteLowRankGaussianProcess.numericalNoiseVariance) = {
     val displacements = referenceMesh.pointSet.points.zip(mesh.pointSet.points).map({ case (refPt, tgtPt) => tgtPt - refPt }).toIndexedSeq
     val dvf = DiscreteVectorField(referenceMesh.pointSet, displacements)
-    warpReference(gp.project(dvf))
+    warpReference(gp.project(dvf, sigma2))
   }
 
   /**
    * @see [[DiscreteLowRankGaussianProcess.coefficients]]
    */
-  def coefficients(mesh: TriangleMesh[_3D]): DenseVector[Double] = {
+  def coefficients(mesh: TriangleMesh[_3D], sigma2: Double = DiscreteLowRankGaussianProcess.numericalNoiseVariance): DenseVector[Double] = {
+    require(sigma2 >= 0.0, "noise variance cannot be negative")
     val displacements = referenceMesh.pointSet.points.zip(mesh.pointSet.points).map({ case (refPt, tgtPt) => tgtPt - refPt }).toIndexedSeq
     val dvf = DiscreteVectorField(referenceMesh.pointSet, displacements)
-    gp.coefficients(dvf)
+    gp.coefficients(dvf, sigma2)
   }
 
   /**


### PR DESCRIPTION
Pulled out variance parameter for `coefficients` method in `DiscreteLowRankGausianProcess`. Using the default values results in the exact same behavior. The parameter is necessary to allow the use of estimated noise parameters.