### PR TITLE
Rigid transform with public rotation (and rotation center) and translation

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -12,7 +12,7 @@ import sbtbuildinfo.Plugin._
 
 object BuildSettings {
   val buildOrganization = "ch.unibas.cs.gravis"
-  val buildVersion = "0.12.0-RC2"
+  val buildVersion = "0.12.0-RC3"
   val buildScalaVersion = "2.10.5"
   val publishURL = Resolver.file("file", new File("/export/contrib/statismo/repo/public"))
 


### PR DESCRIPTION
So far there is no way to access the rotation center used in a rigid transformation. This makes the parameters of a rotation meaningless (cf Issue #83). This fix resolve this issue.

Furthermore, by exposing rotation and translations in the Rigid Transform we make it possible to access their parameters individually.