### PR TITLE
bugfix: creating mesh with empty cell list failed

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -12,7 +12,7 @@ import sbtbuildinfo.Plugin._
 
 object BuildSettings {
   val buildOrganization = "ch.unibas.cs.gravis"
-  val buildVersion = "0.12.0-RC3"
+  val buildVersion = "0.12.0-RC4"
   val buildScalaVersion = "2.10.5"
   val publishURL = Resolver.file("file", new File("/export/contrib/statismo/repo/public"))
 

--- a/src/main/scala/scalismo/mesh/TriangleList.scala
+++ b/src/main/scala/scalismo/mesh/TriangleList.scala
@@ -84,9 +84,13 @@ case class TriangleList(triangles: IndexedSeq[TriangleCell]) {
   }
 
   private[this] def extractRange(triangles: IndexedSeq[TriangleCell]): IndexedSeq[PointId] = {
-    val min = triangles.flatMap(t => t.pointIds).minBy(_.id)
-    val max = triangles.flatMap(t => t.pointIds).maxBy(_.id)
-    (min.id to max.id).map(id => PointId(id))
+    if(triangles.isEmpty){
+      IndexedSeq[PointId]()
+    } else {
+      val min = triangles.flatMap(t => t.pointIds).minBy(_.id)
+      val max = triangles.flatMap(t => t.pointIds).maxBy(_.id)
+      (min.id to max.id).map(id => PointId(id))
+    }
   }
 }
 

--- a/src/test/scala/scalismo/mesh/MeshTests.scala
+++ b/src/test/scala/scalismo/mesh/MeshTests.scala
@@ -77,5 +77,11 @@ class MeshTests extends ScalismoTestSuite {
       binaryImg(Point(0, 0, 0)) should be(1)
       binaryImg(Point(2, 0, 0)) should be(0)
     }
+
+    it("can have an empty cell list"){
+      val pts = IndexedSeq(Point(0.0, 0.0, 0.0), Point(1.0, 1.0, 1.0), Point(1.0, 1.0, 5.0))
+      val cells = IndexedSeq[TriangleCell]()
+      val mesh = TriangleMesh3D(UnstructuredPointsDomain(pts), TriangleList(cells)) // would throw exception on fail
+    }
   }
 }


### PR DESCRIPTION
minBy throws exception on empty list