### PR TITLE
MeshBoundary class

### DIFF
--- a/src/main/scala/scalismo/mesh/MeshBoundary.scala
+++ b/src/main/scala/scalismo/mesh/MeshBoundary.scala
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2015 University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package scalismo.mesh
+
+import breeze.linalg.CSCMatrix
+import scalismo.geometry.Dim
+
+
+/**
+  * MeshBoundary is a property to test if points or a line between two points is on the boundary of the mesh.
+  */
+trait MeshBoundary {
+
+  /**
+    * Check if the point with given index is on the boundary of the underlaying mesh.
+    *
+    * @return True if point is part of the boundary.
+    */
+  def pointIsOnBoundary(id: Int): Boolean
+
+  /**
+    * Check if the line between the two points with given indices is on the boundary of the underlaying mesh.
+    * @note This method does not check weather there exists a line between the two points. You will get false for all
+    *       lines not in the mesh.
+    *
+    * @return True if the line is part of the boundary.
+    */
+  def lineIsOnBoundary(id1: Int, id2: Int): Boolean
+
+}
+
+
+
+/**
+  * The TriangularMeshBoundary can be queried if a triangle has one side in common with the mesh boundary.
+  */
+trait TriangularMeshBoundary extends MeshBoundary {
+
+  /**
+    * Check if the triangle with given index is on the boundary of the underlaying mesh.
+    *
+    * @return True if the triangle has at least one border in common with the boundary.
+    */
+  def triangleIsOnBoundary(id: Int): Boolean
+}
+
+
+
+/**
+  * Implementation of a TriangularMeshBoundary
+  */
+private class BoundaryOfATriangleMesh(private var vertexIsOnBorder: IndexedSeq[Boolean],
+                                      private var lineIsOnBorder: CSCMatrix[Boolean], // NOTE: CSCMatrix is a yet experimental sparse matrix in breeze
+                                      private var triangleIsOnBorder: IndexedSeq[Boolean]) extends TriangularMeshBoundary {
+
+  override def pointIsOnBoundary(id: Int) : Boolean = {
+    return vertexIsOnBorder(id)
+  }
+
+  override def lineIsOnBoundary(id1: Int, id2: Int): Boolean = {
+    return lineIsOnBorder(id1,id2);
+  }
+
+  override def triangleIsOnBoundary(id: Int ) : Boolean = {
+    return triangleIsOnBorder(id)
+  }
+}
+
+
+
+/**
+  * Factory for mesh boundaries.
+  */
+object MeshBoundaryFactory {
+
+  /**
+    * Build boundary index for triangle mesh.
+    *
+    * @param mesh Incoming triangle mesh.
+    * @return Boundary that can be queried for by index for points, lines, and triangles.
+    */
+  def triangularMeshBoundary[D <: Dim](mesh: TriangleMesh[D]): TriangularMeshBoundary = {
+
+    val points = mesh.pointSet.points.toIndexedSeq
+    val nPts = points.length
+
+    val triangles = mesh.triangulation.triangles
+    val nTriangles = triangles.length
+    val linesOfATriangle = Seq((0,1),(1,2),(2,0))
+
+    val pointOnBorder = new Array[Boolean](nPts)
+    val lineOnBorder = new CSCMatrix.Builder[Boolean](nPts,nPts).result()
+    val triangleOnBorder = new Array[Boolean](nTriangles)
+
+    // lines in only a single triangle lie on the border,
+    // lines contained in two triangles are not on a border
+    triangles.map{ triangle =>
+      linesOfATriangle.map{ line =>
+        val v1 = triangle.pointIds(line._1).id
+        val v2 = triangle.pointIds(line._2).id
+        lineOnBorder(v1,v2) = ! lineOnBorder(v1,v2)
+        lineOnBorder(v2,v1) = ! lineOnBorder(v2,v1)
+      }
+    }
+
+    // points at one end of a border line are also on the border,
+    // triangles with one side on the border are also on the border
+    triangles.zipWithIndex.map{ t =>
+      val triangle = t._1
+      val tIdx = t._2
+      linesOfATriangle.map{ line =>
+        val v1 = triangle.pointIds(line._1).id
+        val v2 = triangle.pointIds(line._2).id
+        if( lineOnBorder(v1,v2) ) {
+          pointOnBorder(v1) = true
+          pointOnBorder(v2) = true
+          triangleOnBorder(tIdx) = true
+        }
+      }
+    }
+
+    new BoundaryOfATriangleMesh(
+      pointOnBorder.toIndexedSeq,
+      lineOnBorder,
+      triangleOnBorder.toIndexedSeq
+    )
+  }
+
+}

--- a/src/main/scala/scalismo/mesh/MeshBoundary.scala
+++ b/src/main/scala/scalismo/mesh/MeshBoundary.scala
@@ -18,80 +18,78 @@ package scalismo.mesh
 import breeze.linalg.CSCMatrix
 import scalismo.geometry.Dim
 
+import scala.collection.mutable
+import scala.collection.Map
 
 /**
-  * MeshBoundary is a property to test if points or a line between two points is on the boundary of the mesh.
-  */
+ * MeshBoundary is a property to test if points or an edge between two points is on the boundary of the mesh.
+ */
 trait MeshBoundary {
 
   /**
-    * Check if the point with given index is on the boundary of the underlaying mesh.
-    *
-    * @return True if point is part of the boundary.
-    */
+   * Check if the point with given index is on the boundary of the underlaying mesh.
+   *
+   * @return True if point is part of the boundary.
+   */
   def pointIsOnBoundary(id: Int): Boolean
 
   /**
-    * Check if the line between the two points with given indices is on the boundary of the underlaying mesh.
-    * @note This method does not check weather there exists a line between the two points. You will get false for all
-    *       lines not in the mesh.
-    *
-    * @return True if the line is part of the boundary.
-    */
-  def lineIsOnBoundary(id1: Int, id2: Int): Boolean
+   * Check if the edge between the two points with given indices is on the boundary of the underlaying mesh.
+   *
+   * @note This method does not check weather there exists a nedge between the two points. You will get false for all
+   *       edges not in the mesh.
+   * @return True if the edge is part of the boundary.
+   */
+  def edgeIsOnBoundary(id1: Int, id2: Int): Boolean
 
 }
 
-
-
 /**
-  * The TriangularMeshBoundary can be queried if a triangle has one side in common with the mesh boundary.
-  */
+ * The TriangularMeshBoundary can be queried if a triangle has one side in common with the mesh boundary.
+ */
 trait TriangularMeshBoundary extends MeshBoundary {
 
   /**
-    * Check if the triangle with given index is on the boundary of the underlaying mesh.
-    *
-    * @return True if the triangle has at least one border in common with the boundary.
-    */
+   * Check if the triangle with given index is on the boundary of the underlaying mesh.
+   *
+   * @return True if the triangle has at least one border in common with the boundary.
+   */
   def triangleIsOnBoundary(id: Int): Boolean
 }
 
-
-
 /**
-  * Implementation of a TriangularMeshBoundary
-  */
+ * Implementation of a TriangularMeshBoundary
+ *
+ * @note the implementation with a Map instead of a CSCMatrix was three times slower using our test mesh.
+ */
 private class BoundaryOfATriangleMesh(private var vertexIsOnBorder: IndexedSeq[Boolean],
-                                      private var lineIsOnBorder: CSCMatrix[Boolean], // NOTE: CSCMatrix is a yet experimental sparse matrix in breeze
-                                      private var triangleIsOnBorder: IndexedSeq[Boolean]) extends TriangularMeshBoundary {
+    private var edgeIsOnBorder: CSCMatrix[Boolean],
+    private var triangleIsOnBorder: IndexedSeq[Boolean]) extends TriangularMeshBoundary {
 
-  override def pointIsOnBoundary(id: Int) : Boolean = {
+  override def pointIsOnBoundary(id: Int): Boolean = {
     return vertexIsOnBorder(id)
   }
 
-  override def lineIsOnBoundary(id1: Int, id2: Int): Boolean = {
-    return lineIsOnBorder(id1,id2);
+  override def edgeIsOnBoundary(id1: Int, id2: Int): Boolean = {
+    return edgeIsOnBorder(id1, id2);
   }
 
-  override def triangleIsOnBoundary(id: Int ) : Boolean = {
+  override def triangleIsOnBoundary(id: Int): Boolean = {
     return triangleIsOnBorder(id)
   }
 }
 
-
-
 /**
-  * Factory for mesh boundaries.
-  */
+ * Factory for mesh boundaries.
+ */
 object MeshBoundaryFactory {
 
   /**
-    * Build boundary index for triangle mesh.
-    *
-    * @param mesh Incoming triangle mesh.
-    * @return Boundary that can be queried for by index for points, lines, and triangles.
-    */
+   * Build boundary index for triangle mesh.
+   *
+   * @param mesh Incoming triangle mesh.
+   * @return Boundary that can be queried for by index for points, edges, and triangles.
+   */
   def triangularMeshBoundary[D <: Dim](mesh: TriangleMesh[D]): TriangularMeshBoundary = {
 
     val points = mesh.pointSet.points.toIndexedSeq
@@ -99,32 +97,45 @@ object MeshBoundaryFactory {
 
     val triangles = mesh.triangulation.triangles
     val nTriangles = triangles.length
-    val linesOfATriangle = Seq((0,1),(1,2),(2,0))
+    val edgesOfATriangle = Seq((0, 1), (1, 2), (2, 0))
 
     val pointOnBorder = new Array[Boolean](nPts)
-    val lineOnBorder = new CSCMatrix.Builder[Boolean](nPts,nPts).result()
     val triangleOnBorder = new Array[Boolean](nTriangles)
 
-    // lines in only a single triangle lie on the border,
-    // lines contained in two triangles are not on a border
-    triangles.map{ triangle =>
-      linesOfATriangle.map{ line =>
-        val v1 = triangle.pointIds(line._1).id
-        val v2 = triangle.pointIds(line._2).id
-        lineOnBorder(v1,v2) = ! lineOnBorder(v1,v2)
-        lineOnBorder(v2,v1) = ! lineOnBorder(v2,v1)
+    val edgeOnBorderBuilder = new CSCMatrix.Builder[Boolean](nPts, nPts)
+    triangles.map { triangle =>
+      edgesOfATriangle.map { edge =>
+        val v1 = triangle.pointIds(edge._1).id
+        val v2 = triangle.pointIds(edge._2).id
+        edgeOnBorderBuilder.add(v1, v2, false)
+        edgeOnBorderBuilder.add(v2, v1, false)
+      }
+    }
+    val edgeOnBorderTmp = edgeOnBorderBuilder.result()
+
+    // edges from only a single triangle lie on the border,
+    // edges contained in two triangles are not on a border
+    triangles.map { triangle =>
+      edgesOfATriangle.map { edge =>
+        val v1 = triangle.pointIds(edge._1).id
+        val v2 = triangle.pointIds(edge._2).id
+        edgeOnBorderTmp(v1, v2) = !edgeOnBorderTmp(v1, v2)
+        edgeOnBorderTmp(v2, v1) = !edgeOnBorderTmp(v2, v1)
       }
     }
 
-    // points at one end of a border line are also on the border,
+    // optimization : we do not need values corresponding to false in the sparse representation
+    val edgeOnBorder = reduceCSCMatrixBooleansToTrueEntries(edgeOnBorderTmp)
+
+    // points at one end of a border edge are also on the border,
     // triangles with one side on the border are also on the border
-    triangles.zipWithIndex.map{ t =>
+    triangles.zipWithIndex.map { t =>
       val triangle = t._1
       val tIdx = t._2
-      linesOfATriangle.map{ line =>
-        val v1 = triangle.pointIds(line._1).id
-        val v2 = triangle.pointIds(line._2).id
-        if( lineOnBorder(v1,v2) ) {
+      edgesOfATriangle.map { edge =>
+        val v1 = triangle.pointIds(edge._1).id
+        val v2 = triangle.pointIds(edge._2).id
+        if (edgeOnBorder(v1, v2)) {
           pointOnBorder(v1) = true
           pointOnBorder(v2) = true
           triangleOnBorder(tIdx) = true
@@ -134,9 +145,25 @@ object MeshBoundaryFactory {
 
     new BoundaryOfATriangleMesh(
       pointOnBorder.toIndexedSeq,
-      lineOnBorder,
+      edgeOnBorder,
       triangleOnBorder.toIndexedSeq
     )
+  }
+
+  /**
+   * Reduces a boolean CSCMatrix so that only the true entries are contained. Everything else is false anyway.
+   */
+  private def reduceCSCMatrixBooleansToTrueEntries(m: CSCMatrix[Boolean]): CSCMatrix[Boolean] = {
+    val reduced = new CSCMatrix.Builder[Boolean](m.cols, m.rows)
+
+    val it = m.activeIterator
+    it.foreach { e =>
+      val value = e._2
+      val idx = e._1
+      if (value)
+        reduced.add(idx._1, idx._2, value)
+    }
+    reduced.result
   }
 
 }

--- a/src/test/scala/scalismo/mesh/MeshBoundaryTests.scala
+++ b/src/test/scala/scalismo/mesh/MeshBoundaryTests.scala
@@ -1,0 +1,300 @@
+/*
+ * Copyright 2015 University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package scalismo.mesh
+
+import scalismo.ScalismoTestSuite
+import scalismo.common.PointId
+import scalismo.geometry.Point
+
+class MeshBoundaryTests extends ScalismoTestSuite {
+
+
+  describe("a mesh boundary") {
+
+    object Fixture {
+      implicit def toPointId(i: Int) = PointId(i)
+
+      val singleTriangleMesh = TriangleMesh3D(IndexedSeq(
+        Point(0, 0, 0),
+        Point(0, 0, 1),
+        Point(1, 0, 0)
+      ),
+        TriangleList(IndexedSeq(
+          TriangleCell(0, 1, 2)
+        ))
+      )
+
+      val twoTraingesMesh = TriangleMesh3D(IndexedSeq(
+        Point(0, 0, 0),
+        Point(0, 0, 1),
+        Point(1, 0, 0),
+        Point(0, 1, 1)
+      ),
+        TriangleList(IndexedSeq(
+          TriangleCell(0, 1, 2),
+          TriangleCell(0, 2, 3)
+        ))
+      )
+
+
+      val traingesMeshWithOneCompletelySouroundedTriangle = {
+        val points = for( x <- 0 until 4; y <- 0 until 4) yield Point(x,y,0)
+        val trianglesV = for( x <- 0 until 3; y <- 0 until 3) yield TriangleCell(x+y*4,(x+1)+y*4,x+(y+1)*4)
+        val trianglesA = for( x <- 0 until 3; y <- 0 until 3) yield TriangleCell(x+1+y*4,x+(y+1)*4,(x+1)+(y+1)*4)
+        TriangleMesh3D(
+          points,
+          TriangleList(
+            trianglesV ++ trianglesA
+          )
+        )
+      }
+    }
+
+
+
+    it("should have all elements on the boundary for a single triangle mesh") {
+      val mesh = Fixture.singleTriangleMesh
+      val b = MeshBoundaryFactory.triangularMeshBoundary(mesh)
+
+      b.pointIsOnBoundary(0) shouldBe true
+      b.pointIsOnBoundary(1) shouldBe true
+      b.pointIsOnBoundary(2) shouldBe true
+
+      b.lineIsOnBoundary(0, 1) shouldBe true
+      b.lineIsOnBoundary(1, 2) shouldBe true
+      b.lineIsOnBoundary(2, 0) shouldBe true
+      b.lineIsOnBoundary(1, 0) shouldBe true
+      b.lineIsOnBoundary(2, 1) shouldBe true
+      b.lineIsOnBoundary(0, 2) shouldBe true
+
+      b.triangleIsOnBoundary(0) shouldBe true
+    }
+
+    it("the line between two triangles should not be on the boundary") {
+      val mesh = Fixture.twoTraingesMesh
+      val b = MeshBoundaryFactory.triangularMeshBoundary(mesh)
+
+      b.lineIsOnBoundary(0, 2) shouldBe false
+    }
+
+    it("lines not existing in the mesh should not be on the boundary") {
+      val mesh = Fixture.twoTraingesMesh
+      val b = MeshBoundaryFactory.triangularMeshBoundary(mesh)
+
+      b.lineIsOnBoundary(1, 3) shouldBe false
+    }
+
+    it("all elements of internal triangles should not be on the boundary") {
+      val mesh = Fixture.traingesMeshWithOneCompletelySouroundedTriangle
+      val b = MeshBoundaryFactory.triangularMeshBoundary(mesh)
+      /*
+      ----------
+      |0/|1/|2/|
+      |/9|/.|/.|
+      ----------
+      |3/|4/|5/|
+      |/.|/.|/.|
+      ----------
+      |6/|7/|8/|
+      |/.|/.|/.|
+      ----------
+       */
+
+      def testTriangle(id: Int) : Unit = {
+        val t4 = mesh.triangles(id)
+        val p0 = t4.ptId1.id
+        val p1 = t4.ptId2.id
+        val p2 = t4.ptId3.id
+
+        b.pointIsOnBoundary(p0) shouldBe false
+        b.pointIsOnBoundary(p1) shouldBe false
+        b.pointIsOnBoundary(p2) shouldBe false
+
+        b.lineIsOnBoundary(p0, p1) shouldBe false
+        b.lineIsOnBoundary(p1, p2) shouldBe false
+        b.lineIsOnBoundary(p2, p0) shouldBe false
+        b.lineIsOnBoundary(p1, p0) shouldBe false
+        b.lineIsOnBoundary(p2, p1) shouldBe false
+        b.lineIsOnBoundary(p0, p2) shouldBe false
+
+        b.triangleIsOnBoundary(id) shouldBe false
+      }
+
+      testTriangle(4)
+      testTriangle(13)
+
+    }
+
+
+    it("test some border triangles") {
+      val mesh = Fixture.traingesMeshWithOneCompletelySouroundedTriangle
+      val b = MeshBoundaryFactory.triangularMeshBoundary(mesh)
+      /*
+      ----------
+      |0/|1/|2/|
+      |/9|/.|/.|
+      ----------
+      |3/|4/|5/|
+      |/.|/.|/.|
+      ----------
+      |6/|7/|8/|
+      |/.|/.|/.|
+      ----------
+      */
+      def testTriangle17() : Unit = {
+        val t4 = mesh.triangles(0)
+        val p0 = t4.ptId1.id
+        val p1 = t4.ptId2.id
+        val p2 = t4.ptId3.id
+
+        b.pointIsOnBoundary(p0) shouldBe true
+        b.pointIsOnBoundary(p1) shouldBe true
+        b.pointIsOnBoundary(p2) shouldBe true
+
+        b.lineIsOnBoundary(p0, p1) shouldBe false
+        b.lineIsOnBoundary(p1, p2) shouldBe true
+        b.lineIsOnBoundary(p2, p0) shouldBe true
+        b.lineIsOnBoundary(p1, p0) shouldBe false
+        b.lineIsOnBoundary(p2, p1) shouldBe true
+        b.lineIsOnBoundary(p0, p2) shouldBe true
+
+        b.triangleIsOnBoundary(0) shouldBe true
+      }
+
+      def testTriangle16() : Unit = {
+        val t4 = mesh.triangles(0)
+        val p0 = t4.ptId1.id
+        val p1 = t4.ptId2.id
+        val p2 = t4.ptId3.id
+
+        b.pointIsOnBoundary(p0) shouldBe false
+        b.pointIsOnBoundary(p1) shouldBe true
+        b.pointIsOnBoundary(p2) shouldBe true
+
+        b.lineIsOnBoundary(p0, p1) shouldBe false
+        b.lineIsOnBoundary(p1, p2) shouldBe true
+        b.lineIsOnBoundary(p2, p0) shouldBe false
+        b.lineIsOnBoundary(p1, p0) shouldBe false
+        b.lineIsOnBoundary(p2, p1) shouldBe true
+        b.lineIsOnBoundary(p0, p2) shouldBe false
+
+        b.triangleIsOnBoundary(0) shouldBe true
+      }
+
+      def testTriangle10() : Unit = {
+        val t4 = mesh.triangles(0)
+        val p0 = t4.ptId1.id
+        val p1 = t4.ptId2.id
+        val p2 = t4.ptId3.id
+
+        b.pointIsOnBoundary(p0) shouldBe true
+        b.pointIsOnBoundary(p1) shouldBe false
+        b.pointIsOnBoundary(p2) shouldBe false
+
+        b.lineIsOnBoundary(p0, p1) shouldBe false
+        b.lineIsOnBoundary(p1, p2) shouldBe false
+        b.lineIsOnBoundary(p2, p0) shouldBe false
+        b.lineIsOnBoundary(p1, p0) shouldBe false
+        b.lineIsOnBoundary(p2, p1) shouldBe false
+        b.lineIsOnBoundary(p0, p2) shouldBe false
+
+        b.triangleIsOnBoundary(0) shouldBe false
+      }
+
+      def testTriangle9() : Unit = {
+        val t4 = mesh.triangles(0)
+        val p0 = t4.ptId1.id
+        val p1 = t4.ptId2.id
+        val p2 = t4.ptId3.id
+
+        b.pointIsOnBoundary(p0) shouldBe true
+        b.pointIsOnBoundary(p1) shouldBe true
+        b.pointIsOnBoundary(p2) shouldBe false
+
+        b.lineIsOnBoundary(p0, p1) shouldBe false
+        b.lineIsOnBoundary(p1, p2) shouldBe false
+        b.lineIsOnBoundary(p2, p0) shouldBe false
+        b.lineIsOnBoundary(p1, p0) shouldBe false
+        b.lineIsOnBoundary(p2, p1) shouldBe false
+        b.lineIsOnBoundary(p0, p2) shouldBe false
+
+        b.triangleIsOnBoundary(0) shouldBe false
+      }
+
+      def testTriangle7() : Unit = {
+        val t4 = mesh.triangles(0)
+        val p0 = t4.ptId1.id
+        val p1 = t4.ptId2.id
+        val p2 = t4.ptId3.id
+
+        b.pointIsOnBoundary(p0) shouldBe false
+        b.pointIsOnBoundary(p1) shouldBe false
+        b.pointIsOnBoundary(p2) shouldBe true
+
+        b.lineIsOnBoundary(p0, p1) shouldBe false
+        b.lineIsOnBoundary(p1, p2) shouldBe false
+        b.lineIsOnBoundary(p2, p0) shouldBe false
+        b.lineIsOnBoundary(p1, p0) shouldBe false
+        b.lineIsOnBoundary(p2, p1) shouldBe false
+        b.lineIsOnBoundary(p0, p2) shouldBe false
+
+        b.triangleIsOnBoundary(0) shouldBe false
+      }
+
+      def testTriangle1() : Unit = {
+        val t4 = mesh.triangles(1)
+        val p0 = t4.ptId1.id
+        val p1 = t4.ptId2.id
+        val p2 = t4.ptId3.id
+
+        b.pointIsOnBoundary(p0) shouldBe true
+        b.pointIsOnBoundary(p1) shouldBe true
+        b.pointIsOnBoundary(p2) shouldBe false
+
+        b.lineIsOnBoundary(p0, p1) shouldBe true
+        b.lineIsOnBoundary(p1, p2) shouldBe false
+        b.lineIsOnBoundary(p2, p0) shouldBe false
+        b.lineIsOnBoundary(p1, p0) shouldBe true
+        b.lineIsOnBoundary(p2, p1) shouldBe false
+        b.lineIsOnBoundary(p0, p2) shouldBe false
+
+        b.triangleIsOnBoundary(1) shouldBe true
+      }
+
+      def testTriangle0() : Unit = {
+        val t4 = mesh.triangles(0)
+        val p0 = t4.ptId1.id
+        val p1 = t4.ptId2.id
+        val p2 = t4.ptId3.id
+
+        b.pointIsOnBoundary(p0) shouldBe true
+        b.pointIsOnBoundary(p1) shouldBe true
+        b.pointIsOnBoundary(p2) shouldBe true
+
+        b.lineIsOnBoundary(p0, p1) shouldBe true
+        b.lineIsOnBoundary(p1, p2) shouldBe false
+        b.lineIsOnBoundary(p2, p0) shouldBe true
+        b.lineIsOnBoundary(p1, p0) shouldBe true
+        b.lineIsOnBoundary(p2, p1) shouldBe false
+        b.lineIsOnBoundary(p0, p2) shouldBe true
+
+        b.triangleIsOnBoundary(0) shouldBe true
+      }
+
+    }
+
+  }
+}

--- a/src/test/scala/scalismo/mesh/MeshBoundaryTests.scala
+++ b/src/test/scala/scalismo/mesh/MeshBoundaryTests.scala
@@ -21,7 +21,6 @@ import scalismo.geometry.Point
 
 class MeshBoundaryTests extends ScalismoTestSuite {
 
-
   describe("a mesh boundary") {
 
     object Fixture {
@@ -49,11 +48,10 @@ class MeshBoundaryTests extends ScalismoTestSuite {
         ))
       )
 
-
       val traingesMeshWithOneCompletelySouroundedTriangle = {
-        val points = for( x <- 0 until 4; y <- 0 until 4) yield Point(x,y,0)
-        val trianglesV = for( x <- 0 until 3; y <- 0 until 3) yield TriangleCell(x+y*4,(x+1)+y*4,x+(y+1)*4)
-        val trianglesA = for( x <- 0 until 3; y <- 0 until 3) yield TriangleCell(x+1+y*4,x+(y+1)*4,(x+1)+(y+1)*4)
+        val points = for (x <- 0 until 4; y <- 0 until 4) yield Point(x, y, 0)
+        val trianglesV = for (x <- 0 until 3; y <- 0 until 3) yield TriangleCell(x + y * 4, (x + 1) + y * 4, x + (y + 1) * 4)
+        val trianglesA = for (x <- 0 until 3; y <- 0 until 3) yield TriangleCell(x + 1 + y * 4, x + (y + 1) * 4, (x + 1) + (y + 1) * 4)
         TriangleMesh3D(
           points,
           TriangleList(
@@ -63,9 +61,7 @@ class MeshBoundaryTests extends ScalismoTestSuite {
       }
     }
 
-
-
-    it("should have all elements on the boundary for a single triangle mesh") {
+    it("should have all elements on the boundary for a single-triangle mesh") {
       val mesh = Fixture.singleTriangleMesh
       val b = MeshBoundaryFactory.triangularMeshBoundary(mesh)
 
@@ -73,28 +69,28 @@ class MeshBoundaryTests extends ScalismoTestSuite {
       b.pointIsOnBoundary(1) shouldBe true
       b.pointIsOnBoundary(2) shouldBe true
 
-      b.lineIsOnBoundary(0, 1) shouldBe true
-      b.lineIsOnBoundary(1, 2) shouldBe true
-      b.lineIsOnBoundary(2, 0) shouldBe true
-      b.lineIsOnBoundary(1, 0) shouldBe true
-      b.lineIsOnBoundary(2, 1) shouldBe true
-      b.lineIsOnBoundary(0, 2) shouldBe true
+      b.edgeIsOnBoundary(0, 1) shouldBe true
+      b.edgeIsOnBoundary(1, 2) shouldBe true
+      b.edgeIsOnBoundary(2, 0) shouldBe true
+      b.edgeIsOnBoundary(1, 0) shouldBe true
+      b.edgeIsOnBoundary(2, 1) shouldBe true
+      b.edgeIsOnBoundary(0, 2) shouldBe true
 
       b.triangleIsOnBoundary(0) shouldBe true
     }
 
-    it("the line between two triangles should not be on the boundary") {
+    it("the edge between two triangles should not be on the boundary") {
       val mesh = Fixture.twoTraingesMesh
       val b = MeshBoundaryFactory.triangularMeshBoundary(mesh)
 
-      b.lineIsOnBoundary(0, 2) shouldBe false
+      b.edgeIsOnBoundary(0, 2) shouldBe false
     }
 
-    it("lines not existing in the mesh should not be on the boundary") {
+    it("edges not existing in the mesh should not be on the boundary") {
       val mesh = Fixture.twoTraingesMesh
       val b = MeshBoundaryFactory.triangularMeshBoundary(mesh)
 
-      b.lineIsOnBoundary(1, 3) shouldBe false
+      b.edgeIsOnBoundary(1, 3) shouldBe false
     }
 
     it("all elements of internal triangles should not be on the boundary") {
@@ -113,7 +109,7 @@ class MeshBoundaryTests extends ScalismoTestSuite {
       ----------
        */
 
-      def testTriangle(id: Int) : Unit = {
+      def testTriangle(id: Int): Unit = {
         val t4 = mesh.triangles(id)
         val p0 = t4.ptId1.id
         val p1 = t4.ptId2.id
@@ -123,12 +119,12 @@ class MeshBoundaryTests extends ScalismoTestSuite {
         b.pointIsOnBoundary(p1) shouldBe false
         b.pointIsOnBoundary(p2) shouldBe false
 
-        b.lineIsOnBoundary(p0, p1) shouldBe false
-        b.lineIsOnBoundary(p1, p2) shouldBe false
-        b.lineIsOnBoundary(p2, p0) shouldBe false
-        b.lineIsOnBoundary(p1, p0) shouldBe false
-        b.lineIsOnBoundary(p2, p1) shouldBe false
-        b.lineIsOnBoundary(p0, p2) shouldBe false
+        b.edgeIsOnBoundary(p0, p1) shouldBe false
+        b.edgeIsOnBoundary(p1, p2) shouldBe false
+        b.edgeIsOnBoundary(p2, p0) shouldBe false
+        b.edgeIsOnBoundary(p1, p0) shouldBe false
+        b.edgeIsOnBoundary(p2, p1) shouldBe false
+        b.edgeIsOnBoundary(p0, p2) shouldBe false
 
         b.triangleIsOnBoundary(id) shouldBe false
       }
@@ -137,7 +133,6 @@ class MeshBoundaryTests extends ScalismoTestSuite {
       testTriangle(13)
 
     }
-
 
     it("test some border triangles") {
       val mesh = Fixture.traingesMeshWithOneCompletelySouroundedTriangle
@@ -154,7 +149,7 @@ class MeshBoundaryTests extends ScalismoTestSuite {
       |/.|/.|/.|
       ----------
       */
-      def testTriangle17() : Unit = {
+      def testTriangle17(): Unit = {
         val t4 = mesh.triangles(0)
         val p0 = t4.ptId1.id
         val p1 = t4.ptId2.id
@@ -164,17 +159,17 @@ class MeshBoundaryTests extends ScalismoTestSuite {
         b.pointIsOnBoundary(p1) shouldBe true
         b.pointIsOnBoundary(p2) shouldBe true
 
-        b.lineIsOnBoundary(p0, p1) shouldBe false
-        b.lineIsOnBoundary(p1, p2) shouldBe true
-        b.lineIsOnBoundary(p2, p0) shouldBe true
-        b.lineIsOnBoundary(p1, p0) shouldBe false
-        b.lineIsOnBoundary(p2, p1) shouldBe true
-        b.lineIsOnBoundary(p0, p2) shouldBe true
+        b.edgeIsOnBoundary(p0, p1) shouldBe false
+        b.edgeIsOnBoundary(p1, p2) shouldBe true
+        b.edgeIsOnBoundary(p2, p0) shouldBe true
+        b.edgeIsOnBoundary(p1, p0) shouldBe false
+        b.edgeIsOnBoundary(p2, p1) shouldBe true
+        b.edgeIsOnBoundary(p0, p2) shouldBe true
 
         b.triangleIsOnBoundary(0) shouldBe true
       }
 
-      def testTriangle16() : Unit = {
+      def testTriangle16(): Unit = {
         val t4 = mesh.triangles(0)
         val p0 = t4.ptId1.id
         val p1 = t4.ptId2.id
@@ -184,17 +179,17 @@ class MeshBoundaryTests extends ScalismoTestSuite {
         b.pointIsOnBoundary(p1) shouldBe true
         b.pointIsOnBoundary(p2) shouldBe true
 
-        b.lineIsOnBoundary(p0, p1) shouldBe false
-        b.lineIsOnBoundary(p1, p2) shouldBe true
-        b.lineIsOnBoundary(p2, p0) shouldBe false
-        b.lineIsOnBoundary(p1, p0) shouldBe false
-        b.lineIsOnBoundary(p2, p1) shouldBe true
-        b.lineIsOnBoundary(p0, p2) shouldBe false
+        b.edgeIsOnBoundary(p0, p1) shouldBe false
+        b.edgeIsOnBoundary(p1, p2) shouldBe true
+        b.edgeIsOnBoundary(p2, p0) shouldBe false
+        b.edgeIsOnBoundary(p1, p0) shouldBe false
+        b.edgeIsOnBoundary(p2, p1) shouldBe true
+        b.edgeIsOnBoundary(p0, p2) shouldBe false
 
         b.triangleIsOnBoundary(0) shouldBe true
       }
 
-      def testTriangle10() : Unit = {
+      def testTriangle10(): Unit = {
         val t4 = mesh.triangles(0)
         val p0 = t4.ptId1.id
         val p1 = t4.ptId2.id
@@ -204,17 +199,17 @@ class MeshBoundaryTests extends ScalismoTestSuite {
         b.pointIsOnBoundary(p1) shouldBe false
         b.pointIsOnBoundary(p2) shouldBe false
 
-        b.lineIsOnBoundary(p0, p1) shouldBe false
-        b.lineIsOnBoundary(p1, p2) shouldBe false
-        b.lineIsOnBoundary(p2, p0) shouldBe false
-        b.lineIsOnBoundary(p1, p0) shouldBe false
-        b.lineIsOnBoundary(p2, p1) shouldBe false
-        b.lineIsOnBoundary(p0, p2) shouldBe false
+        b.edgeIsOnBoundary(p0, p1) shouldBe false
+        b.edgeIsOnBoundary(p1, p2) shouldBe false
+        b.edgeIsOnBoundary(p2, p0) shouldBe false
+        b.edgeIsOnBoundary(p1, p0) shouldBe false
+        b.edgeIsOnBoundary(p2, p1) shouldBe false
+        b.edgeIsOnBoundary(p0, p2) shouldBe false
 
         b.triangleIsOnBoundary(0) shouldBe false
       }
 
-      def testTriangle9() : Unit = {
+      def testTriangle9(): Unit = {
         val t4 = mesh.triangles(0)
         val p0 = t4.ptId1.id
         val p1 = t4.ptId2.id
@@ -224,17 +219,17 @@ class MeshBoundaryTests extends ScalismoTestSuite {
         b.pointIsOnBoundary(p1) shouldBe true
         b.pointIsOnBoundary(p2) shouldBe false
 
-        b.lineIsOnBoundary(p0, p1) shouldBe false
-        b.lineIsOnBoundary(p1, p2) shouldBe false
-        b.lineIsOnBoundary(p2, p0) shouldBe false
-        b.lineIsOnBoundary(p1, p0) shouldBe false
-        b.lineIsOnBoundary(p2, p1) shouldBe false
-        b.lineIsOnBoundary(p0, p2) shouldBe false
+        b.edgeIsOnBoundary(p0, p1) shouldBe false
+        b.edgeIsOnBoundary(p1, p2) shouldBe false
+        b.edgeIsOnBoundary(p2, p0) shouldBe false
+        b.edgeIsOnBoundary(p1, p0) shouldBe false
+        b.edgeIsOnBoundary(p2, p1) shouldBe false
+        b.edgeIsOnBoundary(p0, p2) shouldBe false
 
         b.triangleIsOnBoundary(0) shouldBe false
       }
 
-      def testTriangle7() : Unit = {
+      def testTriangle7(): Unit = {
         val t4 = mesh.triangles(0)
         val p0 = t4.ptId1.id
         val p1 = t4.ptId2.id
@@ -244,17 +239,17 @@ class MeshBoundaryTests extends ScalismoTestSuite {
         b.pointIsOnBoundary(p1) shouldBe false
         b.pointIsOnBoundary(p2) shouldBe true
 
-        b.lineIsOnBoundary(p0, p1) shouldBe false
-        b.lineIsOnBoundary(p1, p2) shouldBe false
-        b.lineIsOnBoundary(p2, p0) shouldBe false
-        b.lineIsOnBoundary(p1, p0) shouldBe false
-        b.lineIsOnBoundary(p2, p1) shouldBe false
-        b.lineIsOnBoundary(p0, p2) shouldBe false
+        b.edgeIsOnBoundary(p0, p1) shouldBe false
+        b.edgeIsOnBoundary(p1, p2) shouldBe false
+        b.edgeIsOnBoundary(p2, p0) shouldBe false
+        b.edgeIsOnBoundary(p1, p0) shouldBe false
+        b.edgeIsOnBoundary(p2, p1) shouldBe false
+        b.edgeIsOnBoundary(p0, p2) shouldBe false
 
         b.triangleIsOnBoundary(0) shouldBe false
       }
 
-      def testTriangle1() : Unit = {
+      def testTriangle1(): Unit = {
         val t4 = mesh.triangles(1)
         val p0 = t4.ptId1.id
         val p1 = t4.ptId2.id
@@ -264,17 +259,17 @@ class MeshBoundaryTests extends ScalismoTestSuite {
         b.pointIsOnBoundary(p1) shouldBe true
         b.pointIsOnBoundary(p2) shouldBe false
 
-        b.lineIsOnBoundary(p0, p1) shouldBe true
-        b.lineIsOnBoundary(p1, p2) shouldBe false
-        b.lineIsOnBoundary(p2, p0) shouldBe false
-        b.lineIsOnBoundary(p1, p0) shouldBe true
-        b.lineIsOnBoundary(p2, p1) shouldBe false
-        b.lineIsOnBoundary(p0, p2) shouldBe false
+        b.edgeIsOnBoundary(p0, p1) shouldBe true
+        b.edgeIsOnBoundary(p1, p2) shouldBe false
+        b.edgeIsOnBoundary(p2, p0) shouldBe false
+        b.edgeIsOnBoundary(p1, p0) shouldBe true
+        b.edgeIsOnBoundary(p2, p1) shouldBe false
+        b.edgeIsOnBoundary(p0, p2) shouldBe false
 
         b.triangleIsOnBoundary(1) shouldBe true
       }
 
-      def testTriangle0() : Unit = {
+      def testTriangle0(): Unit = {
         val t4 = mesh.triangles(0)
         val p0 = t4.ptId1.id
         val p1 = t4.ptId2.id
@@ -284,12 +279,12 @@ class MeshBoundaryTests extends ScalismoTestSuite {
         b.pointIsOnBoundary(p1) shouldBe true
         b.pointIsOnBoundary(p2) shouldBe true
 
-        b.lineIsOnBoundary(p0, p1) shouldBe true
-        b.lineIsOnBoundary(p1, p2) shouldBe false
-        b.lineIsOnBoundary(p2, p0) shouldBe true
-        b.lineIsOnBoundary(p1, p0) shouldBe true
-        b.lineIsOnBoundary(p2, p1) shouldBe false
-        b.lineIsOnBoundary(p0, p2) shouldBe true
+        b.edgeIsOnBoundary(p0, p1) shouldBe true
+        b.edgeIsOnBoundary(p1, p2) shouldBe false
+        b.edgeIsOnBoundary(p2, p0) shouldBe true
+        b.edgeIsOnBoundary(p1, p0) shouldBe true
+        b.edgeIsOnBoundary(p2, p1) shouldBe false
+        b.edgeIsOnBoundary(p0, p2) shouldBe true
 
         b.triangleIsOnBoundary(0) shouldBe true
       }


### PR DESCRIPTION
Added two a mesh boundary interface with implementation for TriangularMesh. The class provides function to check if points, lines or triangles lie on the mesh boundary given their indices. The behaviour is:

- A line connection two points contained in only one triangle lies on the mesh boundary.
- A line connection two points contained in either none or two triangles lies on the boundary.

- Both points of a line which lies on the boundary, are part of the boundary.

- Triangles with one of the sides lying on the boundary is part of the boundary.
- A triangle with only one point on the boundary is not part of the boundary.

Tests are provided and may help to get started.