### PR TITLE
Asm transform fix

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -12,7 +12,7 @@ import sbtbuildinfo.Plugin._
 
 object BuildSettings {
   val buildOrganization = "ch.unibas.cs.gravis"
-  val buildVersion = "0.12.0-RC4"
+  val buildVersion = "0.12.0-RC5"
   val buildScalaVersion = "2.10.5"
   val publishURL = Resolver.file("file", new File("/export/contrib/statismo/repo/public"))
 

--- a/src/main/scala/scalismo/mesh/TriangleList.scala
+++ b/src/main/scala/scalismo/mesh/TriangleList.scala
@@ -84,7 +84,7 @@ case class TriangleList(triangles: IndexedSeq[TriangleCell]) {
   }
 
   private[this] def extractRange(triangles: IndexedSeq[TriangleCell]): IndexedSeq[PointId] = {
-    if(triangles.isEmpty){
+    if (triangles.isEmpty) {
       IndexedSeq[PointId]()
     } else {
       val min = triangles.flatMap(t => t.pointIds).minBy(_.id)

--- a/src/main/scala/scalismo/registration/TransformationSpace.scala
+++ b/src/main/scala/scalismo/registration/TransformationSpace.scala
@@ -381,7 +381,7 @@ object CreateRotationSpace {
  */
 abstract class RotationTransform[D <: Dim: NDSpace] extends ParametricTransformation[D] with CanInvert[D] with CanDifferentiate[D] {
   override def inverse: RotationTransform[D]
-  def center : Point[D]
+  def center: Point[D]
 }
 
 private case class RotationTransform3D(rotMatrix: SquareMatrix[_3D], val center: Point[_3D] = Point(0, 0, 0)) extends RotationTransform[_3D] {
@@ -567,8 +567,8 @@ object ScalingTransformation {
 class RigidTransformationSpace[D <: Dim: NDSpace: CreateRotationSpace] private (center: Point[D])
     extends ProductTransformationSpace[D, TranslationTransform[D], RotationTransform[D]](TranslationSpace[D], RotationSpace[D](center)) {
 
-  def translationSpace : TransformationSpace[D] = TranslationSpace[D]
-  def rotationSpace : RotationSpace[D] = RotationSpace[D](center)
+  def translationSpace: TransformationSpace[D] = TranslationSpace[D]
+  def rotationSpace: RotationSpace[D] = RotationSpace[D](center)
 
   /**
    * Returns a rigid transform that rotates first then translates.
@@ -604,8 +604,8 @@ object RigidTransformationSpace {
  * Instances of this trait exist only for [[_2D]] and [[_3D]] as [[RotationTransform]] is not defined for [[_1D]]
  */
 trait RigidTransformation[D <: Dim] extends ProductTransformation[D] with CanInvert[D] {
-  def translation : TranslationTransform[D]
-  def rotation : RotationTransform[D]
+  def translation: TranslationTransform[D]
+  def rotation: RotationTransform[D]
 }
 
 /** Factory for [[RigidTransformation]] instances. */
@@ -619,8 +619,6 @@ object RigidTransformation {
 
 private class RigidTransformationRotThenTrans[D <: Dim: NDSpace](val translation: TranslationTransform[D], val rotation: RotationTransform[D])
     extends ProductTransformation[D](translation, rotation) with RigidTransformation[D] {
-
-
 
   def inverse = new RigidTransformationTransThenRot[D](rotation.inverse, translation.inverse)
 }

--- a/src/main/scala/scalismo/statisticalmodel/asm/ActiveShapeModel.scala
+++ b/src/main/scala/scalismo/statisticalmodel/asm/ActiveShapeModel.scala
@@ -174,7 +174,7 @@ case class ActiveShapeModel(statisticalModel: StatisticalMeshModel, profiles: Pr
     }
   }
 
-  private def fitOnce(image: PreprocessedImage, sampler: SearchPointSampler, config: FittingConfiguration, mesh: TriangleMesh[_3D], inverseTransform : RigidTransformation[_3D]): Try[FittingResult] = {
+  private def fitOnce(image: PreprocessedImage, sampler: SearchPointSampler, config: FittingConfiguration, mesh: TriangleMesh[_3D], inverseTransform: RigidTransformation[_3D]): Try[FittingResult] = {
     val refPtIdsWithTargetPt = findBestCorrespondingPoints(image, mesh, sampler, config, inverseTransform)
 
     if (refPtIdsWithTargetPt.isEmpty) {
@@ -197,7 +197,7 @@ case class ActiveShapeModel(statisticalModel: StatisticalMeshModel, profiles: Pr
 
   private def refPoint(profileId: ProfileId): Point[_3D] = statisticalModel.referenceMesh.pointSet.point(profiles(profileId).pointId)
 
-  private def findBestCorrespondingPoints(img: PreprocessedImage, mesh: TriangleMesh[_3D], sampler: SearchPointSampler, config: FittingConfiguration, inverseTransform : RigidTransformation[_3D]): IndexedSeq[(PointId, Point[_3D])] = {
+  private def findBestCorrespondingPoints(img: PreprocessedImage, mesh: TriangleMesh[_3D], sampler: SearchPointSampler, config: FittingConfiguration, inverseTransform: RigidTransformation[_3D]): IndexedSeq[(PointId, Point[_3D])] = {
 
     val matchingPts = profiles.ids.par.map { index =>
       (profiles(index).pointId, findBestMatchingPointAtPoint(img, mesh, index, sampler, config, profiles(index).pointId, inverseTransform))
@@ -208,7 +208,7 @@ case class ActiveShapeModel(statisticalModel: StatisticalMeshModel, profiles: Pr
 
   }
 
-  private def findBestMatchingPointAtPoint(image: PreprocessedImage, mesh: TriangleMesh[_3D], profileId: ProfileId, searchPointSampler: SearchPointSampler, config: FittingConfiguration, pointId: PointId, inverseTransform : RigidTransformation[_3D]): Option[Point[_3D]] = {
+  private def findBestMatchingPointAtPoint(image: PreprocessedImage, mesh: TriangleMesh[_3D], profileId: ProfileId, searchPointSampler: SearchPointSampler, config: FittingConfiguration, pointId: PointId, inverseTransform: RigidTransformation[_3D]): Option[Point[_3D]] = {
     val sampledPoints = searchPointSampler(mesh, pointId)
 
     val pointsWithFeatureDistances = (for (point <- sampledPoints) yield {

--- a/src/test/scala/scalismo/mesh/MeshTests.scala
+++ b/src/test/scala/scalismo/mesh/MeshTests.scala
@@ -78,7 +78,7 @@ class MeshTests extends ScalismoTestSuite {
       binaryImg(Point(2, 0, 0)) should be(0)
     }
 
-    it("can have an empty cell list"){
+    it("can have an empty cell list") {
       val pts = IndexedSeq(Point(0.0, 0.0, 0.0), Point(1.0, 1.0, 1.0), Point(1.0, 1.0, 5.0))
       val cells = IndexedSeq[TriangleCell]()
       val mesh = TriangleMesh3D(UnstructuredPointsDomain(pts), TriangleList(cells)) // would throw exception on fail

--- a/src/test/scala/scalismo/statisticalmodel/ActiveShapeModelTests.scala
+++ b/src/test/scala/scalismo/statisticalmodel/ActiveShapeModelTests.scala
@@ -8,10 +8,9 @@ import scalismo.geometry._3D
 import scalismo.io.{ ImageIO, MeshIO, StatismoIO }
 import scalismo.mesh.{ MeshMetrics, TriangleMesh }
 import scalismo.numerics.{ Sampler, UniformMeshSampler3D }
-import scalismo.registration.{RigidTransformationSpace, LandmarkRegistration}
+import scalismo.registration.{ RigidTransformationSpace, LandmarkRegistration }
 import scalismo.statisticalmodel.asm._
 import scalismo.statisticalmodel.dataset.DataCollection
-
 
 class ActiveShapeModelTests extends ScalismoTestSuite {
 
@@ -55,7 +54,7 @@ class ActiveShapeModelTests extends ScalismoTestSuite {
     it("Can be transformed correctly from within the fitting") {
 
       val nullInitialParameters = DenseVector.zeros[Double](Fixture.asm.statisticalModel.rank)
-      val fit = Fixture.asm.fit(Fixture.targetImage, Fixture.searchMethod, 20, Fixture.fittingConfig, ModelTransformations(nullInitialParameters,Fixture.alignment)).get.mesh
+      val fit = Fixture.asm.fit(Fixture.targetImage, Fixture.searchMethod, 20, Fixture.fittingConfig, ModelTransformations(nullInitialParameters, Fixture.alignment)).get.mesh
       assert(MeshMetrics.diceCoefficient(fit, Fixture.targetMesh) > 0.95)
     }
   }


### PR DESCRIPTION
ASF fitting failed when provided an initial Rigid Transformation.

The reason is that the logpdf of the candidate deformation vectors was not evaluated in the model space, therefore leading to all of the candidates being rejected. 