### PR TITLE
Interpolator as implicit field in SurfacePointProperty

### DIFF
--- a/src/main/scala/scalismo/mesh/MeshSurfaceProperty.scala
+++ b/src/main/scala/scalismo/mesh/MeshSurfaceProperty.scala
@@ -46,7 +46,7 @@ case class ConstantProperty[@specialized(Double, Float, Int, Boolean) A](overrid
 }
 
 /** property per vertex, with interpolation */
-case class SurfacePointProperty[@specialized(Double, Float, Int, Boolean) A](override val triangulation: TriangleList, pointData: PointId => A)(implicit ops: Interpolator[A])
+case class SurfacePointProperty[@specialized(Double, Float, Int, Boolean) A](override val triangulation: TriangleList, pointData: PointId => A)(implicit val ops: Interpolator[A])
     extends MeshSurfaceProperty[A] {
 
   def atPoint(pointId: PointId): A = pointData(pointId)

--- a/src/main/scala/scalismo/mesh/MeshSurfaceProperty.scala
+++ b/src/main/scala/scalismo/mesh/MeshSurfaceProperty.scala
@@ -46,7 +46,7 @@ case class ConstantProperty[@specialized(Double, Float, Int, Boolean) A](overrid
 }
 
 /** property per vertex, with interpolation */
-case class SurfacePointProperty[@specialized(Double, Float, Int, Boolean) A](override val triangulation: TriangleList, pointData: PointId => A)(implicit val ops: Interpolator[A])
+case class SurfacePointProperty[@specialized(Double, Float, Int, Boolean) A](override val triangulation: TriangleList, pointData: PointId => A)(implicit val interpolator: Interpolator[A])
     extends MeshSurfaceProperty[A] {
 
   def atPoint(pointId: PointId): A = pointData(pointId)


### PR DESCRIPTION
Interpolator as implicit `val`: `implicit val ops: Interpolator[A]`

- easier copying: no own context of `Interpolator[A]` required at copying site since it can be accessed through the `val`