### PR TITLE
Bugfix: Handle special case when triangle list is empty

### DIFF
--- a/src/main/scala/scalismo/mesh/TriangleList.scala
+++ b/src/main/scala/scalismo/mesh/TriangleList.scala
@@ -84,9 +84,14 @@ case class TriangleList(triangles: IndexedSeq[TriangleCell]) {
   }
 
   private[this] def extractRange(triangles: IndexedSeq[TriangleCell]): IndexedSeq[PointId] = {
-    val min = triangles.flatMap(t => t.pointIds).minBy(_.id)
-    val max = triangles.flatMap(t => t.pointIds).maxBy(_.id)
-    (min.id to max.id).map(id => PointId(id))
+    if (triangles.isEmpty) {
+      IndexedSeq[PointId]()
+    }
+    else {
+      val min = triangles.flatMap(t => t.pointIds).minBy(_.id)
+      val max = triangles.flatMap(t => t.pointIds).maxBy(_.id)
+      (min.id to max.id).map(id => PointId(id))
+    }
   }
 }
 

--- a/src/test/scala/scalismo/mesh/MeshTests.scala
+++ b/src/test/scala/scalismo/mesh/MeshTests.scala
@@ -77,5 +77,13 @@ class MeshTests extends ScalismoTestSuite {
       binaryImg(Point(0, 0, 0)) should be(1)
       binaryImg(Point(2, 0, 0)) should be(0)
     }
+
+    it("can be defined with an empty triangle list") {
+      val pts = IndexedSeq(Point(0.0, 0.0, 0.0), Point(1.0, 1.0, 1.0), Point(1.0, 1.0, 5.0))
+      val cells = IndexedSeq()
+      val mesh = TriangleMesh3D(UnstructuredPointsDomain(pts), TriangleList(cells))
+
+    }
+
   }
 }


### PR DESCRIPTION
Sometimes it is useful to define a mesh that has an empty list of triangles. For example, when we crop a mesh it may happen that one part does not contain any triangles any more. The current implementation crashes in such a case. 

This PR handles this special case. 