### PR TITLE
 Allow construction of DiscreteScalarXXX objects from a Traversable

### DIFF
--- a/src/main/scala/scalismo/common/DiscreteField.scala
+++ b/src/main/scala/scalismo/common/DiscreteField.scala
@@ -138,6 +138,10 @@ object DiscreteScalarField {
   def apply[D <: Dim: NDSpace, A: Scalar: ClassTag](domain: DiscreteDomain[D], data: ScalarArray[A]): DiscreteScalarField[D, A] = {
     new DiscreteScalarField[D, A](domain, data)
   }
+
+  def apply[D <: Dim: NDSpace, A: Scalar: ClassTag](domain: DiscreteDomain[D], data: Traversable[A]): DiscreteScalarField[D, A] = {
+    new DiscreteScalarField[D, A](domain, ScalarArray(data.toArray))
+  }
 }
 
 /**

--- a/src/main/scala/scalismo/common/Scalar.scala
+++ b/src/main/scala/scalismo/common/Scalar.scala
@@ -337,12 +337,12 @@ object ValueClassScalarArray {
 /** Factory for ScalarArray instances. */
 object ScalarArray {
 
-  /**
-   * Converts a native array of scalar values to the corresponding [[ScalarArray]] instance
-   * @param array a native array of scalar values
-   * @tparam T the type of the scalar data
-   * @return the corresponding [[ScalarArray]] instance, containing the same data as <code>array</code>
-   */
+//  /**
+//   * Converts a native array of scalar values to the corresponding [[ScalarArray]] instance
+//   * @param array a native array of scalar values
+//   * @tparam T the type of the scalar data
+//   * @return the corresponding [[ScalarArray]] instance, containing the same data as <code>array</code>
+//   */
   def apply[T: Scalar: ClassTag](array: Array[T]): ScalarArray[T] = {
     val scalar = implicitly[Scalar[T]]
     scalar match {
@@ -351,13 +351,4 @@ object ScalarArray {
     }
   }
 
-  object implicits {
-    import Scalar._
-    import scala.language.implicitConversions
-    implicit def scalarArrayFromByteArray(data: Array[Byte]): ScalarArray[Byte] = ByteIsScalar.createArray(data)
-    implicit def scalarArrayFromShortArray(data: Array[Short]): ScalarArray[Short] = ShortIsScalar.createArray(data)
-    implicit def scalarArrayFromIntArray(data: Array[Int]): ScalarArray[Int] = IntIsScalar.createArray(data)
-    implicit def scalarArrayFromFloatArray(data: Array[Float]): ScalarArray[Float] = FloatIsScalar.createArray(data)
-    implicit def scalarArrayFromDoubleArray(data: Array[Double]): ScalarArray[Double] = DoubleIsScalar.createArray(data)
-  }
 }

--- a/src/main/scala/scalismo/image/DiscreteScalarImage.scala
+++ b/src/main/scala/scalismo/image/DiscreteScalarImage.scala
@@ -94,6 +94,11 @@ object DiscreteScalarImage {
     create.create(domain, values)
   }
 
+  /** create a new DiscreteScalarImage with given domain and values */
+  def apply[D <: Dim: NDSpace, A: Scalar: ClassTag](domain: DiscreteImageDomain[D], values: Traversable[A])(implicit create: Create[D]) = {
+    create.create(domain, ScalarArray(values.toArray))
+  }
+
   /** create a new DiscreteScalarImage with given domain and values which are defined by the given function f */
   def apply[D <: Dim: NDSpace, A: Scalar: ClassTag](domain: DiscreteImageDomain[D], f: Point[D] => A)(implicit create: Create[D]) = {
     create.create(domain, ScalarArray(domain.points.map(f).toArray))

--- a/src/main/scala/scalismo/mesh/ScalarMeshField.scala
+++ b/src/main/scala/scalismo/mesh/ScalarMeshField.scala
@@ -40,3 +40,9 @@ case class ScalarMeshField[S: Scalar: ClassTag](mesh: TriangleMesh[_3D], overrid
     ScalarMeshField(mesh, data.map(f))
   }
 }
+
+object ScalarMeshField {
+  def apply[S: Scalar: ClassTag](mesh: TriangleMesh[_3D], data: Traversable[S]): ScalarMeshField[S] = {
+    ScalarMeshField(mesh, ScalarArray(data.toArray))
+  }
+}

--- a/src/main/scala/scalismo/mesh/TriangleList.scala
+++ b/src/main/scala/scalismo/mesh/TriangleList.scala
@@ -84,9 +84,13 @@ case class TriangleList(triangles: IndexedSeq[TriangleCell]) {
   }
 
   private[this] def extractRange(triangles: IndexedSeq[TriangleCell]): IndexedSeq[PointId] = {
-    val min = triangles.flatMap(t => t.pointIds).minBy(_.id)
-    val max = triangles.flatMap(t => t.pointIds).maxBy(_.id)
-    (min.id to max.id).map(id => PointId(id))
+    if (triangles.isEmpty) {
+      IndexedSeq[PointId]()
+    } else {
+      val min = triangles.flatMap(t => t.pointIds).minBy(_.id)
+      val max = triangles.flatMap(t => t.pointIds).maxBy(_.id)
+      (min.id to max.id).map(id => PointId(id))
+    }
   }
 }
 

--- a/src/test/scala/scalismo/image/ImageTests.scala
+++ b/src/test/scala/scalismo/image/ImageTests.scala
@@ -34,7 +34,7 @@ class ImageTests extends ScalismoTestSuite {
   describe("A discrete 1D image") {
     it("returns the same points for a 1d index and a coordinate index") {
       val domain = DiscreteImageDomain[_1D](0.0, 1.0, 5)
-      val discreteImage = DiscreteScalarImage(domain, Array(3.0, 2.0, 1.5, 1, 0))
+      val discreteImage = DiscreteScalarImage(domain, Seq(3.0, 2.0, 1.5, 1, 0))
 
       for (i <- 0 until domain.size(0)) {
         assert(discreteImage(i) == discreteImage(i))
@@ -45,7 +45,7 @@ class ImageTests extends ScalismoTestSuite {
   describe("A discrete 2D image") {
     it("returns the same points for a 1d index and a (2d) coordinate index") {
       val domain = DiscreteImageDomain[_2D]((0.0, 0.0), (1.0, 2.0), (3, 2))
-      val discreteImage = DiscreteScalarImage(domain, Array(3.0, 2.0, 1.5, 1.0, 0.0, 4.0))
+      val discreteImage = DiscreteScalarImage(domain, Seq(3.0, 2.0, 1.5, 1.0, 0.0, 4.0))
 
       for (
         y <- 0 until domain.size(1);

--- a/src/test/scala/scalismo/image/InterpolationTest.scala
+++ b/src/test/scala/scalismo/image/InterpolationTest.scala
@@ -20,7 +20,6 @@ import java.io.File
 import org.scalatest.PrivateMethodTester
 import scalismo.ScalismoTestSuite
 import scalismo.common.PointId
-import scalismo.common.ScalarArray.implicits._
 import scalismo.geometry.IntVector.implicits._
 import scalismo.geometry.Point.implicits._
 import scalismo.geometry.Vector.implicits._
@@ -37,7 +36,7 @@ class InterpolationTest extends ScalismoTestSuite with PrivateMethodTester {
 
     it("interpolates the values for origin 2.3 and spacing 1.5") {
       val domain = DiscreteImageDomain[_1D](2.3, 1.5, 7)
-      val discreteImage = DiscreteScalarImage(domain, Array[Float](1.4, 2.1, 7.5, 9.0, 8.0, 0.0, 2.1))
+      val discreteImage = DiscreteScalarImage(domain, Seq[Float](1.4, 2.1, 7.5, 9.0, 8.0, 0.0, 2.1))
       val continuousImg = discreteImage.interpolate(0)
       for ((pt, idx) <- discreteImage.domain.points.zipWithIndex) {
         continuousImg(pt) should be(discreteImage(idx) +- 0.0001f)
@@ -49,7 +48,7 @@ class InterpolationTest extends ScalismoTestSuite with PrivateMethodTester {
 
     it("interpolates the values for origin 2.3 and spacing 1.5") {
       val domain = DiscreteImageDomain[_1D](2.3, 1.5, 7)
-      val discreteImage = DiscreteScalarImage[_1D, Float](domain, Array[Float](1.4, 2.1, 7.5, 9, 8, 0, 2.1))
+      val discreteImage = DiscreteScalarImage[_1D, Float](domain, Seq[Float](1.4, 2.1, 7.5, 9, 8, 0, 2.1))
       val continuousImg = discreteImage.interpolate(1)
       for ((pt, idx) <- discreteImage.domain.points.zipWithIndex) {
         continuousImg(pt) should be(discreteImage(idx) +- 0.0001f)
@@ -58,7 +57,7 @@ class InterpolationTest extends ScalismoTestSuite with PrivateMethodTester {
 
     it("interpolates the values for origin 0 and spacing 1") {
       val domain = DiscreteImageDomain[_1D](0.0, 1.0, 5)
-      val discreteImage = DiscreteScalarImage(domain, Array(3.0, 2.0, 1.5, 1.0, 0.0))
+      val discreteImage = DiscreteScalarImage(domain, Seq(3.0, 2.0, 1.5, 1.0, 0.0))
       val continuousImg = discreteImage.interpolate(0)
       for ((pt, idx) <- discreteImage.domain.points.zipWithIndex) {
         assert(continuousImg(pt) === discreteImage(idx))
@@ -70,11 +69,11 @@ class InterpolationTest extends ScalismoTestSuite with PrivateMethodTester {
       it("Derivative of interpolated Sine function is the Cosine") {
         val domain = DiscreteImageDomain[_1D](-2.0, 0.01, 400)
 
-        val discreteSinImage = DiscreteScalarImage(domain, domain.points.map(x => math.sin(x * math.Pi)).toArray)
+        val discreteSinImage = DiscreteScalarImage(domain, domain.points.map(x => math.sin(x * math.Pi)).toIndexedSeq)
         val interpolatedSinImage = discreteSinImage.interpolate(3)
         val derivativeImage = interpolatedSinImage.differentiate
 
-        val discreteCosImage = DiscreteScalarImage(domain, domain.points.map(x => math.Pi * math.cos(x * math.Pi)).toArray)
+        val discreteCosImage = DiscreteScalarImage(domain, domain.points.map(x => math.Pi * math.cos(x * math.Pi)).toIndexedSeq)
 
         for ((pt, idx) <- domain.points.zipWithIndex.filter(x => math.abs(x._1) < 1.90)) {
           derivativeImage(pt)(0).toDouble should be(discreteCosImage(idx) +- 0.0001f)
@@ -89,7 +88,7 @@ class InterpolationTest extends ScalismoTestSuite with PrivateMethodTester {
 
       it("Interpolates the values for a simple domain") {
         val domain = DiscreteImageDomain[_2D]((0.0, 0.0), (1.0, 1.0), (2, 3))
-        val discreteImage = DiscreteScalarImage(domain, Array(1f, 2f, 3f, 4f, 5f, 6f))
+        val discreteImage = DiscreteScalarImage(domain, Seq(1f, 2f, 3f, 4f, 5f, 6f))
 
         val continuousImg = discreteImage.interpolate(0)
 
@@ -100,7 +99,7 @@ class InterpolationTest extends ScalismoTestSuite with PrivateMethodTester {
 
       it("Interpolates the values for origin (2,3) and spacing (1.5, 2.3)") {
         val domain = DiscreteImageDomain[_2D]((2.0, 3.0), (1.5, 0.1), (2, 3))
-        val discreteImage = DiscreteScalarImage(domain, Array(1.4f, 2.1f, 7.5f, 9f, 8f, 0f))
+        val discreteImage = DiscreteScalarImage(domain, Seq(1.4f, 2.1f, 7.5f, 9f, 8f, 0f))
 
         val continuousImg = discreteImage.interpolate(0)
 

--- a/src/test/scala/scalismo/io/ImageIOTests.scala
+++ b/src/test/scala/scalismo/io/ImageIOTests.scala
@@ -153,7 +153,6 @@ class ImageIOTests extends ScalismoTestSuite {
     }
 
     it("can be stored to VTK and re-read in right precision") {
-      import scalismo.common.ScalarArray.implicits._
       val domain = DiscreteImageDomain[_3D](Point(-72.85742f, -72.85742f, -273.0f), Vector(0.85546875f, 0.85546875f, 1.5f), IntVector(15, 15, 15))
       val values = DenseVector.zeros[Short](15 * 15 * 15).data
       val discreteImage = DiscreteScalarImage(domain, values)


### PR DESCRIPTION
So far only ScalarArrays could be chosen to define DiscreteScalar objects. It is often more convenient (especially for light objects) to use the output of a sequence directly.