### PR TITLE
Method to convert NDimensionalNormalDistribution to MultivariateNorma…

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -12,7 +12,7 @@ import sbtbuildinfo.Plugin._
 
 object BuildSettings {
   val buildOrganization = "ch.unibas.cs.gravis"
-  val buildVersion = "0.13.0-RC2"
+  val buildVersion = "0.13.0-RC3"
   val buildScalaVersion = "2.10.5"
   val publishURL = Resolver.file("file", new File("/export/contrib/statismo/repo/public"))
 

--- a/src/main/scala/scalismo/common/Scalar.scala
+++ b/src/main/scala/scalismo/common/Scalar.scala
@@ -337,12 +337,12 @@ object ValueClassScalarArray {
 /** Factory for ScalarArray instances. */
 object ScalarArray {
 
-//  /**
-//   * Converts a native array of scalar values to the corresponding [[ScalarArray]] instance
-//   * @param array a native array of scalar values
-//   * @tparam T the type of the scalar data
-//   * @return the corresponding [[ScalarArray]] instance, containing the same data as <code>array</code>
-//   */
+  //  /**
+  //   * Converts a native array of scalar values to the corresponding [[ScalarArray]] instance
+  //   * @param array a native array of scalar values
+  //   * @tparam T the type of the scalar data
+  //   * @return the corresponding [[ScalarArray]] instance, containing the same data as <code>array</code>
+  //   */
   def apply[T: Scalar: ClassTag](array: Array[T]): ScalarArray[T] = {
     val scalar = implicitly[Scalar[T]]
     scalar match {

--- a/src/main/scala/scalismo/geometry/Landmark.scala
+++ b/src/main/scala/scalismo/geometry/Landmark.scala
@@ -16,7 +16,7 @@
 package scalismo.geometry
 
 import scalismo.io.LandmarkIO
-import scalismo.statisticalmodel.NDimensionalNormalDistribution
+import scalismo.statisticalmodel.MultivariateNormalDistribution
 
-case class Landmark[D <: Dim: NDSpace](id: String, point: Point[D], description: Option[String] = None, uncertainty: Option[NDimensionalNormalDistribution[D]] = None)
+case class Landmark[D <: Dim: NDSpace](id: String, point: Point[D], description: Option[String] = None, uncertainty: Option[MultivariateNormalDistribution] = None)
 

--- a/src/main/scala/scalismo/registration/TransformationSpace.scala
+++ b/src/main/scala/scalismo/registration/TransformationSpace.scala
@@ -35,11 +35,10 @@ trait Transformation[D <: Dim] extends Field[D, Point[D]] {}
 
 object Transformation {
 
-
   /**
-    * Create a transformation defined on the whole real space with the given function
-    */
-  def apply[D <: Dim](t : Point[D] => Point[D]) : Transformation[D] = {
+   * Create a transformation defined on the whole real space with the given function
+   */
+  def apply[D <: Dim](t: Point[D] => Point[D]): Transformation[D] = {
     new Transformation[D] {
       override val f: (Point[D]) => Point[D] = t
 

--- a/src/main/scala/scalismo/statisticalmodel/MultivariateNormalDistribution.scala
+++ b/src/main/scala/scalismo/statisticalmodel/MultivariateNormalDistribution.scala
@@ -208,4 +208,6 @@ case class NDimensionalNormalDistribution[D <: Dim: NDSpace](mean: Vector[D], co
   override def principalComponents: Seq[(Vector[D], Double)] = impl.principalComponents.map { case (v, d) => (Vector.fromBreezeVector(v), d) }
 
   override def mahalanobisDistance(x: Vector[D]): Double = impl.mahalanobisDistance(x.toBreezeVector)
+
+  def toMultivariateNormalDistribution: MultivariateNormalDistribution = impl
 }

--- a/src/main/scala/scalismo/statisticalmodel/MultivariateNormalDistribution.scala
+++ b/src/main/scala/scalismo/statisticalmodel/MultivariateNormalDistribution.scala
@@ -16,7 +16,8 @@
 package scalismo.statisticalmodel
 
 import breeze.linalg.svd.SVD
-import breeze.linalg.{ DenseMatrix, DenseVector, det, inv }
+import breeze.linalg._
+import scalismo.geometry.Vector
 import scalismo.geometry._
 
 import scala.util.Try
@@ -153,6 +154,25 @@ case class MultivariateNormalDistribution(mean: DenseVector[Double], cov: DenseM
 
 object MultivariateNormalDistribution {
 
+  def apply(mean: DenseVector[Double], principalComponents: Seq[(DenseVector[Double], Double)]): MultivariateNormalDistribution = {
+
+    val dim = mean.length
+    require(principalComponents.length == dim)
+
+    val cov: DenseMatrix[Double] = {
+      val d2 = diag(DenseVector[Double](principalComponents.map(_._2).toArray))
+
+      // stack pcs
+      val u = principalComponents.tail.foldLeft(principalComponents.head._1.toDenseMatrix) {
+        case (m: DenseMatrix[Double], pc: (DenseVector[Double], Double)) =>
+          DenseMatrix.vertcat(m, pc._1.toDenseMatrix)
+      }
+
+      u * d2 * u.t
+    }
+    MultivariateNormalDistribution(mean, cov)
+  }
+
   def estimateFromData(samples: Seq[DenseVector[Double]]): MultivariateNormalDistribution = {
 
     val numSamples = samples.length
@@ -174,6 +194,7 @@ object MultivariateNormalDistribution {
 
 }
 
+@deprecated("Please use MultivariateNormalDistribution instead. This object wil be removed in future versions.", "0.13.0")
 object NDimensionalNormalDistribution {
   def apply[D <: Dim: NDSpace](mean: Vector[D], principalComponents: Seq[(Vector[D], Double)]): NDimensionalNormalDistribution[D] = {
     val dim = implicitly[NDSpace[D]].dimensionality
@@ -192,6 +213,7 @@ object NDimensionalNormalDistribution {
   }
 }
 
+@deprecated("Please use MultivariateNormalDistribution instead. This class wil be removed in future versions.", "0.13.0")
 case class NDimensionalNormalDistribution[D <: Dim: NDSpace](mean: Vector[D], cov: SquareMatrix[D])
     extends MultivariateNormalDistributionLike[Vector[D], SquareMatrix[D]] {
 

--- a/src/test/scala/scalismo/io/LandmarkIOTests.scala
+++ b/src/test/scala/scalismo/io/LandmarkIOTests.scala
@@ -17,9 +17,11 @@ package scalismo.io
 
 import java.io.{ ByteArrayOutputStream, File, InputStream }
 
+import breeze.linalg.DenseVector
+import breeze.math.MutableOptimizationSpace.DenseDoubleOptimizationSpace
 import scalismo.ScalismoTestSuite
 import scalismo.geometry._
-import scalismo.statisticalmodel.NDimensionalNormalDistribution
+import scalismo.statisticalmodel.MultivariateNormalDistribution
 
 import scala.io.Source
 import scala.language.implicitConversions
@@ -94,11 +96,11 @@ class LandmarkIOTests extends ScalismoTestSuite {
      * SIMPLE JSON LANDMARKS
      */
 
-    def distWithDefaultVectors(d1: Double, d2: Double, d3: Double): NDimensionalNormalDistribution[_3D] = {
-      val axes = List(Vector(1, 0, 0), Vector(0, 1, 0), Vector(0, 0, 1))
+    def distWithDefaultVectors(d1: Double, d2: Double, d3: Double): MultivariateNormalDistribution = {
+      val axes = List(DenseVector[Double](1, 0, 0), DenseVector[Double](0, 1, 0), DenseVector[Double](0, 0, 1))
       val devs = List(d1, d2, d3)
       val data = axes zip devs
-      NDimensionalNormalDistribution(Vector(0, 0, 0), data)
+      MultivariateNormalDistribution(DenseVector[Double](0, 0, 0), data)
     }
 
     val jsonLm1 = Landmark("one", Point(1, 2, 3))

--- a/src/test/scala/scalismo/statisticalmodel/MultivariateNormalDistributionTests.scala
+++ b/src/test/scala/scalismo/statisticalmodel/MultivariateNormalDistributionTests.scala
@@ -64,13 +64,13 @@ class MultivariateNormalDistributionTests extends ScalismoTestSuite {
     }
   }
 
-  describe("An NDimensionalNormalDistribution") {
+  describe("An MultivariateNormalDistribution") {
     it("returns the same principal components it was constructed with") {
-      val axes = List(Vector(1.0, 0.0, 0.0), Vector(0.0, 1.0, 0.0), Vector(0.0, 0.0, 1.0))
+      val axes = List(DenseVector[Double](1.0, 0.0, 0.0), DenseVector[Double](0.0, 1.0, 0.0), DenseVector[Double](0.0, 0.0, 1.0))
       // these are knowingly not sorted
       val variances = List(1.0, 4.0, 3.0)
       val data = axes zip variances
-      val n = NDimensionalNormalDistribution(Vector(0.0, 0.0, 0.0), data)
+      val n = MultivariateNormalDistribution(DenseVector[Double](0.0, 0.0, 0.0), data)
       // to compare however, we must ensure that both are sorted
       n.principalComponents should equal(data.sortBy(x => x._2).reverse)
     }


### PR DESCRIPTION
…lDistribution

Currently GP.posterior method requires noise as a  MultivariateNormalDistribution, while landmark's uncertainty is an NDimensionalNormalDistribution. Hence the need for conversion.

An alternative could also be to make NDimensionalNormalDistribution a descendant of MultivariateNormalDistribution.