### PR TITLE
Harmonize creation of UnstructuredPointsDomain (with other ND objects)

### DIFF
--- a/src/main/scala/scalismo/common/Scalar.scala
+++ b/src/main/scala/scalismo/common/Scalar.scala
@@ -337,12 +337,12 @@ object ValueClassScalarArray {
 /** Factory for ScalarArray instances. */
 object ScalarArray {
 
-//  /**
-//   * Converts a native array of scalar values to the corresponding [[ScalarArray]] instance
-//   * @param array a native array of scalar values
-//   * @tparam T the type of the scalar data
-//   * @return the corresponding [[ScalarArray]] instance, containing the same data as <code>array</code>
-//   */
+  //  /**
+  //   * Converts a native array of scalar values to the corresponding [[ScalarArray]] instance
+  //   * @param array a native array of scalar values
+  //   * @tparam T the type of the scalar data
+  //   * @return the corresponding [[ScalarArray]] instance, containing the same data as <code>array</code>
+  //   */
   def apply[T: Scalar: ClassTag](array: Array[T]): ScalarArray[T] = {
     val scalar = implicitly[Scalar[T]]
     scalar match {

--- a/src/main/scala/scalismo/mesh/TriangleMesh.scala
+++ b/src/main/scala/scalismo/mesh/TriangleMesh.scala
@@ -50,7 +50,7 @@ object TriangleMesh {
   }
 
   /** Typeclass for creating domains of arbitrary dimensionality */
-  trait Create[D <: Dim] extends CreateUnstructuredPointsDomain[D] {
+  trait Create[D <: Dim] extends UnstructuredPointsDomain.Create[D] {
     def createTriangleMesh(pointSet: UnstructuredPointsDomain[D], topology: TriangleList): TriangleMesh[D]
   }
 

--- a/src/main/scala/scalismo/registration/TransformationSpace.scala
+++ b/src/main/scala/scalismo/registration/TransformationSpace.scala
@@ -35,11 +35,10 @@ trait Transformation[D <: Dim] extends Field[D, Point[D]] {}
 
 object Transformation {
 
-
   /**
-    * Create a transformation defined on the whole real space with the given function
-    */
-  def apply[D <: Dim](t : Point[D] => Point[D]) : Transformation[D] = {
+   * Create a transformation defined on the whole real space with the given function
+   */
+  def apply[D <: Dim](t: Point[D] => Point[D]): Transformation[D] = {
     new Transformation[D] {
       override val f: (Point[D]) => Point[D] = t
 

--- a/src/main/scala/scalismo/statisticalmodel/DiscreteGaussianProcess.scala
+++ b/src/main/scala/scalismo/statisticalmodel/DiscreteGaussianProcess.scala
@@ -62,7 +62,7 @@ class DiscreteGaussianProcess[D <: Dim: NDSpace, Value] private[scalismo] (val m
    * The marginal distribution for the points specified by the given point ids.
    * Note that this is again a DiscreteGaussianProcess.
    */
-  def marginal(pointIds: Seq[PointId])(implicit domainCreator: CreateUnstructuredPointsDomain[D]): DiscreteGaussianProcess[D, Value] = {
+  def marginal(pointIds: Seq[PointId])(implicit domainCreator: UnstructuredPointsDomain.Create[D]): DiscreteGaussianProcess[D, Value] = {
     val domainPts = domain.points.toIndexedSeq
 
     val newPts = pointIds.map(pointId => domainPts(pointId.id)).toIndexedSeq

--- a/src/main/scala/scalismo/statisticalmodel/DiscreteLowRankGaussianProcess.scala
+++ b/src/main/scala/scalismo/statisticalmodel/DiscreteLowRankGaussianProcess.scala
@@ -158,7 +158,7 @@ case class DiscreteLowRankGaussianProcess[D <: Dim: NDSpace, Value] private[scal
     DiscreteLowRankGaussianProcess.regression(this, trainingData)
   }
 
-  override def marginal(pointIds: Seq[PointId])(implicit domainCreator: CreateUnstructuredPointsDomain[D]): DiscreteLowRankGaussianProcess[D, Value] = {
+  override def marginal(pointIds: Seq[PointId])(implicit domainCreator: UnstructuredPointsDomain.Create[D]): DiscreteLowRankGaussianProcess[D, Value] = {
     val domainPts = domain.points.toIndexedSeq
 
     val newPts = pointIds.map(pointId => domainPts(pointId.id)).toIndexedSeq

--- a/src/main/scala/scalismo/statisticalmodel/StatisticalMeshModel.scala
+++ b/src/main/scala/scalismo/statisticalmodel/StatisticalMeshModel.scala
@@ -19,7 +19,6 @@ import breeze.linalg.svd.SVD
 import breeze.linalg.{ DenseMatrix, DenseVector }
 import breeze.numerics.sqrt
 import scalismo.common._
-import scalismo.common.CreateUnstructuredPointsDomain._
 import scalismo.geometry.Vector._
 import scalismo.geometry._
 import scalismo.mesh._


### PR DESCRIPTION
The creation of the ```UnstructuredPointsDomain``` class with a generic dimension was using a slightly different mechanism. This PR harmonizes it with other classes. 

* The changes are only internal, and have no effect on any user code. 