### PR TITLE
VantagePointTree: fast search in metric spaces

### DIFF
--- a/src/main/scala/scalismo/utils/VantagePointTree.scala
+++ b/src/main/scala/scalismo/utils/VantagePointTree.scala
@@ -1,0 +1,283 @@
+/*
+ * Copyright 2015 University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package scalismo.utils
+
+import scala.collection.mutable
+import scala.util.Random
+
+/** represents a metric to be used with the Vantage Point tree */
+trait Metric[A] {
+  /** calculates distance */
+  def distance(x: A, y: A): Double
+
+  /** convenience interface through apply */
+  def apply(x: A, y: A): Double = distance(x, y)
+}
+
+object Metric {
+  def apply[A](f: (A, A) => Double) = new Metric[A] {
+    override def distance(x: A, y: A) = f(x, y)
+  }
+}
+
+/**
+ * Recursive, immutable Vantage Point tree
+ * Partitions metric spaces for efficient neighbour searches
+ * Key concept: split a point set at a node into an inner and an outer set which satisfy:
+ *  - inner: all points are closer to the pivot/center than the radius
+ *  - outer: all points are further away from the the pivot than radius
+ *
+ *  WARNING: the tree only works with a metric (positive, symmetric, triangle inequality)
+ */
+sealed trait VantagePointTree[A] extends Traversable[A] {
+  /** metric of the space */
+  def metric: Metric[A]
+
+  /** find closest point in tree */
+  def findClosestPoint(point: A): A = findKNearestNeighbours(point, k = 1).head
+
+  /** return true of the tree contains the point */
+  def contains(point: A): Boolean
+
+  /** find k nearest neighbours */
+  def findKNearestNeighbours(point: A, k: Int): IndexedSeq[A] = {
+    val candidates = new CandidatesKNN[A](k)
+    findNN(point, candidates)
+    candidates.points
+  }
+
+  /** find all neighbours within an epsilon region around point */
+  def findEpsilonNeighbours(point: A, maxDistance: Double): IndexedSeq[A] = {
+    val candidates = new CandidatesEpsRegion[A](maxDistance)
+    findNN(point, candidates)
+    candidates.points
+  }
+
+  /** main implementation of neighbour searches */
+  protected[utils] def findNN(point: A, candidates: CandidateSet[A]): Unit
+}
+
+/** mutable candidate set for neighbour searches (internal use) */
+private trait CandidateSet[A] {
+  protected case class DistPoint(p: A, dist: Double) extends Ordered[DistPoint] {
+    override def compare(that: DistPoint): Int = if (dist < that.dist) -1 else if (dist > that.dist) 1 else 0
+  }
+
+  def points: IndexedSeq[A]
+
+  def addCandidate(point: A, dist: Double): Unit
+
+  def maxDistance: Double
+}
+
+/** mutable candidate set for k neighbour searches (internal use) */
+private class CandidatesKNN[A](size: Int) extends CandidateSet[A] {
+  private val q = mutable.SortedSet.empty[DistPoint]
+
+  /** all points in this candidate set */
+  override def points: IndexedSeq[A] = q.iterator.map(_.p).toIndexedSeq
+
+  /** add a new candidate to consider */
+  override def addCandidate(point: A, dist: Double): Unit = {
+    if (dist <= maxDistance || q.size < size) {
+      q.add(DistPoint(point, dist))
+      while (q.size > size) {
+        q.remove(q.last)
+      }
+    }
+  }
+
+  /** distance of candidate which is farthest */
+  override def maxDistance = {
+    if (q.size >= size)
+      q.lastOption.map(_.dist).getOrElse(Double.PositiveInfinity)
+    else
+      Double.PositiveInfinity
+  }
+}
+
+/** mutable candidate set for epsilon neighbour searches (internal use) */
+private class CandidatesEpsRegion[A](override val maxDistance: Double) extends CandidateSet[A] {
+  private val q = mutable.SortedSet.empty[DistPoint]
+
+  /** all points in this candidate set */
+  override def points: IndexedSeq[A] = q.iterator.map(_.p).toIndexedSeq
+
+  /** add a new candidate to consider */
+  override def addCandidate(point: A, dist: Double): Unit = {
+    if (dist <= maxDistance) {
+      q.add(DistPoint(point, dist))
+    }
+  }
+}
+
+object VantagePointTree {
+  /** build a Vantage Point tree with given metric (must be a metric!), uses random pivot elements */
+  def apply[A](data: Iterable[A], metric: Metric[A]): VantagePointTree[A] = recursiveTreeBuilder(data, metric, randomPivotSelector[A])
+
+  /** build a Vantage Point tree with given metric (must be a metric!) and pivot selector */
+  def apply[A](data: Iterable[A], metric: Metric[A], pivotSelector: Iterable[A] => A): VantagePointTree[A] = recursiveTreeBuilder(data, metric, pivotSelector)
+
+  /** select a random element as pivot */
+  def randomPivotSelector[A](points: Iterable[A]): A = {
+    Random.shuffle(points).head
+  }
+
+  /** select first element as pivot */
+  def firstPivotSelector[A](points: Iterable[A]): A = points.head
+
+  /** select central element as pivot */
+  def centralPivotSelector[A](metric: Metric[A], samples: Int)(points: Iterable[A]): A = points.toSeq match {
+    case Seq() => throw new RuntimeException("cannot select from empty seq!")
+    case head +: Seq() => head
+    case first +: second +: Seq() => first
+    case _ =>
+      // draw candidates, select the most central
+      val trials = Random.shuffle(points).take(math.min(samples, points.size))
+      def spread(pivot: A) = {
+        val dists = points.toSeq map { p => metric(pivot, p) }
+        val medianDistance = median(dists)
+        dists.map({ d => math.pow(d - medianDistance, 2) }).sum / dists.size
+      }
+      trials.minBy(spread)
+  }
+
+  private def median(s: Seq[Double]): Double = {
+    val (lower, upper) = s.sortWith(_ < _).splitAt(s.size / 2)
+    if (s.size % 2 == 0) (lower.last + upper.head) / 2.0 else upper.head
+  }
+
+  private def recursiveTreeBuilder[A](data: Iterable[A], metric: Metric[A], pivotSelector: Iterable[A] => A): VantagePointTree[A] = {
+    // recursive tree builder
+    def recursiveBuilder(points: Seq[A]): VantagePointTree[A] = points match {
+      // small cases
+      case Seq() => EmptyVP(metric)
+      case point +: Seq() => VPLeaf(metric, point)
+      case first +: second +: Seq() if first == second => VPLeaf[A](metric, first)
+      case first +: second +: Seq() => VPLink(metric, first, VPLeaf[A](metric, second))
+      case _ => // general case
+        assert(points.size >= 3)
+        val pivot = pivotSelector(points)
+        // find distance to each point in the set
+        val distances = points map { point => metric(point, pivot) }
+        // pick median as node radius
+        val radius = median(distances.toIndexedSeq)
+        // all <= --> left, > --> right (remember to remove the Vantage point)
+        val inside = points filter { point => metric(point, pivot) <= radius && metric(point, pivot) > 0.0 }
+        val outside = points filter { point => metric(point, pivot) > radius }
+
+        // construct the node and build the tree recursively
+        if (inside.nonEmpty && outside.nonEmpty)
+          VPNode(metric, pivot, radius,
+            recursiveBuilder(inside),
+            recursiveBuilder(outside)
+          )
+        else if (inside.nonEmpty)
+          VPLink(metric, pivot,
+            recursiveBuilder(inside)
+          )
+        else if (outside.nonEmpty)
+          VPLink(metric, pivot,
+            recursiveBuilder(outside)
+          )
+        else
+          VPLeaf(metric, pivot)
+    }
+    // build with all points
+    recursiveBuilder(data.toIndexedSeq)
+  }
+}
+
+/** empty VP tree node */
+private case class EmptyVP[A](metric: Metric[A]) extends VantagePointTree[A] {
+
+  override def contains(point: A): Boolean = false
+
+  override def foreach[U](f: (A) => U): Unit = {}
+
+  override def findNN(point: A, candidates: CandidateSet[A]): Unit = {}
+}
+
+/** leaf node of VP tree */
+private case class VPLeaf[A](metric: Metric[A], center: A) extends VantagePointTree[A] {
+
+  override def contains(point: A): Boolean = point == center
+
+  override def foreach[U](f: (A) => U): Unit = f(center)
+
+  override def findNN(point: A, candidates: CandidateSet[A]): Unit = candidates.addCandidate(center, metric(center, point))
+}
+
+/** link node: list element, only a single child - should only appear before a leaf */
+private case class VPLink[A](metric: Metric[A], center: A, next: VantagePointTree[A]) extends VantagePointTree[A] {
+
+  override def findNN(point: A, candidates: CandidateSet[A]): Unit = {
+    candidates.addCandidate(center, metric(center, point))
+    next.findNN(point, candidates)
+  }
+
+  override def contains(point: A): Boolean = point == this.center || next.contains(point)
+
+  override def foreach[U](f: (A) => U): Unit = {
+    f(center)
+    next.foreach(f)
+  }
+}
+
+/** regular VP tree node with inner and outer children, inner contains all points which are closer to center than radius (inclusive) */
+private case class VPNode[A](metric: Metric[A], center: A, radius: Double, inner: VantagePointTree[A], outer: VantagePointTree[A]) extends VantagePointTree[A] {
+  // smart part of the VP tree, space partition according to distance to current pivot element
+  override def findNN(point: A, candidates: CandidateSet[A]): Unit = {
+    // distance to center point decides on first lookup
+    val dist = metric(point, center)
+
+    // this node as candidate
+    candidates.addCandidate(center, metric(point, center))
+
+    // children
+    if (dist < radius) {
+      if (dist - candidates.maxDistance < radius) {
+        inner.findNN(point, candidates)
+      }
+      if (dist + candidates.maxDistance > radius) {
+        outer.findNN(point, candidates)
+      }
+    } else {
+      if (dist + candidates.maxDistance > radius) {
+        outer.findNN(point, candidates)
+      }
+      if (dist - candidates.maxDistance < radius) {
+        inner.findNN(point, candidates)
+      }
+    }
+  }
+
+  override def contains(point: A): Boolean = {
+    if (point == center) true
+    else {
+      val d = metric(point, center)
+      // can efficiently choose sub tree for further search, inside or outside radius
+      if (d > radius) outer.contains(point) else inner.contains(point)
+    }
+  }
+
+  /** to satisfy traversable */
+  override def foreach[U](f: (A) => U): Unit = {
+    f(center)
+    inner.foreach(f)
+    outer.foreach(f)
+  }
+}

--- a/src/test/scala/scalismo/utils/VantagePointTreeTests.scala
+++ b/src/test/scala/scalismo/utils/VantagePointTreeTests.scala
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2015 University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package scalismo.utils
+
+import scalismo.ScalismoTestSuite
+import scalismo.geometry.{ Point, _3D }
+
+import scala.collection.immutable.IndexedSeq
+import scala.util.Random
+
+class VantagePointTreeTests extends ScalismoTestSuite {
+
+  // seeded random generator
+  implicit val rnd = new Random(1024L)
+  def randomPoint()(implicit rnd: Random): Point[_3D] = Point(rnd.nextDouble(), rnd.nextDouble(), rnd.nextDouble())
+
+  // test size, VP size, lookup size
+  val n = 50
+  val nQuery = 10
+  val points = {
+    var s = IndexedSeq.fill(n)(randomPoint)
+    while (s.distinct.length < s.length) s = IndexedSeq.fill(n)(randomPoint)
+    s
+  }
+  val metric = Metric[Point[_3D]]((p, q) => (p - q).norm)
+
+  describe("A VantagePointTree") {
+    // build the tree
+    val t = VantagePointTree(points, metric, VantagePointTree.randomPivotSelector[Point[_3D]])
+
+    it("linearizes to points of construction") {
+      val tseq = t.toIndexedSeq
+      tseq should contain theSameElementsAs points
+    }
+
+    it("contains all points of construction") {
+      points.foreach { p =>
+        t.contains(p) shouldBe true
+      }
+    }
+
+    it("does not contain points which it does not have") {
+      var p = randomPoint()
+      var i = 0 // timeout
+      while (points.contains(p) && i < 10) {
+        p = randomPoint()
+        i += 1
+      }
+      if (i == 10) fail("could not find points which are not in the tree!")
+      t.contains(p) shouldBe false
+    }
+
+    it("is a set") {
+      val seq = t.toIndexedSeq
+      seq.distinct should contain theSameElementsAs seq
+    }
+
+    it("finds all own points as closest points to themselves") {
+      val closest = points.map(p => t.findClosestPoint(p))
+      closest shouldBe points
+    }
+
+    it("finds the correct closest points using a few random points as query") {
+      val rpoints = IndexedSeq.fill(nQuery)(randomPoint)
+      val vpClosest = rpoints.map(p => t.findClosestPoint(p))
+      // find closest points in list, linear, known result, as reference
+      val listClosest = rpoints.map(p => points.minBy(metric(_, p)))
+      vpClosest should contain theSameElementsAs listClosest
+    }
+
+    it("finds the k nearest neighbours to random points") {
+      val k = 6
+      val rpoints = IndexedSeq.fill(nQuery)(randomPoint)
+      val vpClosest = rpoints.map(p => t.findKNearestNeighbours(p, k))
+      val listClosest = rpoints.map(p => points.sortBy(metric(_, p)).take(k))
+      vpClosest should contain theSameElementsAs listClosest
+    }
+
+    it("finds all neighbours within an epsilon region around random points") {
+      val eps = 0.2
+      val rpoints = IndexedSeq.fill(nQuery)(randomPoint)
+      val vpClosest = rpoints.map(p => t.findEpsilonNeighbours(p, eps))
+      val listClosest = rpoints.map(p => points.zip(points.map(metric(_, p))).sortBy(_._2).takeWhile(_._2 <= eps).map(_._1))
+      vpClosest.zip(listClosest).foreach {
+        case (vpLookUp, linLookUp) => vpLookUp should contain theSameElementsAs linLookUp
+      }
+    }
+
+    it("finding 1 nearest neighbour is equivalent to findClosestPoint") {
+      val k = 1
+      val rpoints = IndexedSeq.fill(nQuery)(randomPoint)
+      val kClosest = rpoints.map(p => t.findKNearestNeighbours(p, k)).map(_.head)
+      val closest = rpoints.map(p => t.findClosestPoint(p))
+      kClosest should contain theSameElementsAs closest
+    }
+  }
+}


### PR DESCRIPTION
Added a [Vantage-Point Tree](https://en.wikipedia.org/wiki/Vantage-point_tree) for fast neighbour searches in metric spaces. The tree builds a binary space partition using the provided metric (which is exchangeable).

**WARNING:** this only works for a metric (positive, symmetric and triangle inequality), see [Wikipedia](https://en.wikipedia.org/wiki/Metric_(mathematics))

Key concept: at each node store a point and a radius, then split remaining points into an *inner* and *outer* set:

- inner: all points which are closer to the node's point (=pivot) than radius
- outer: all points which are farther away from the pivot than radius

- Added to `scalismo.utils`
- Recursive tree implementation for building and traversal
- includes tests