### PR TITLE
Default center argument only in one method. Also, ASM fitting updates…

### DIFF
--- a/src/main/scala/scalismo/io/ImageIO.scala
+++ b/src/main/scala/scalismo/io/ImageIO.scala
@@ -372,7 +372,7 @@ object ImageIO {
       val scaledPS = origPs.map(anisotropicScaling)
       val imgPs = origPs.map(transVoxelToWorld)
 
-      val rigidReg = LandmarkRegistration.rigid3DLandmarkRegistration((scaledPS zip imgPs).toIndexedSeq)
+      val rigidReg = LandmarkRegistration.rigid3DLandmarkRegistration((scaledPS zip imgPs).toIndexedSeq, Point(0, 0, 0))
       val transform = AnisotropicSimilarityTransformationSpace[_3D](Point(0, 0, 0)).transformForParameters(DenseVector(rigidReg.parameters.data ++ spacing.data))
 
       val rotationResiduals = rigidReg.parameters(3 to 5).toArray.map { a =>

--- a/src/main/scala/scalismo/mesh/MeshMetrics.scala
+++ b/src/main/scala/scalismo/mesh/MeshMetrics.scala
@@ -48,7 +48,7 @@ object MeshMetrics {
     require(m1.pointSet.numberOfPoints == m2.pointSet.numberOfPoints)
 
     val landmarks = m1.pointSet.points.toIndexedSeq zip m2.pointSet.points.toIndexedSeq
-    val t = LandmarkRegistration.rigid3DLandmarkRegistration(landmarks)
+    val t = LandmarkRegistration.rigid3DLandmarkRegistration(landmarks, Point(0, 0, 0))
     val m1w = m1.transform(t)
     avgDistance(m1w, m2)
   }

--- a/src/main/scala/scalismo/registration/LandmarkRegistration.scala
+++ b/src/main/scala/scalismo/registration/LandmarkRegistration.scala
@@ -76,12 +76,31 @@ object LandmarkRegistration {
     LandmarkRegistration.rigid3DLandmarkRegistration(landmarksPairs.toIndexedSeq, center)
   }
 
+  /**
+   * Returns a rigid transformation mapping the original landmarks  (first elements of the tuples) into the corresponding target points (second elements of the tuples).
+   *
+   * @param landmarks sequence of corresponding landmarks
+   * @param center center of rotation to be used for the rigid transformation
+   */
+
   def rigid3DLandmarkRegistration(landmarks: IndexedSeq[(Point[_3D], Point[_3D])], center: Point[_3D]): RigidTransformation[_3D] = {
     val (t, rotparams, _) = rigidSimilarity3DCommon(landmarks, center)
     val optimalParameters = DenseVector.vertcat(t, rotparams)
     val rigidSpace = RigidTransformationSpace[_3D](center)
     rigidSpace.transformForParameters(optimalParameters)
   }
+
+  /**
+   * Returns a rigid transformation mapping the original landmarks (first elements of the tuples) into the corresponding target points (second elements of the tuples).
+   *
+   * Attention: the center of rotation used for the rigid transformation here is the origin of the 3D space
+   *
+   * @param landmarks sequence of corresponding landmarks
+   */
+
+  def rigid3DLandmarkRegistration(landmarks: IndexedSeq[(Point[_3D], Point[_3D])]): RigidTransformation[_3D] = rigid3DLandmarkRegistration(landmarks, origin3D)
+
+  def similarity3DLandmarkRegistration(landmarks: IndexedSeq[(Point[_3D], Point[_3D])]): ParametricTransformation[_3D] = similarity3DLandmarkRegistration(landmarks, origin3D)
 
   def similarity3DLandmarkRegistration(landmarks: IndexedSeq[(Point[_3D], Point[_3D])], center: Point[_3D]): ParametricTransformation[_3D] = {
     val (t, rotparams, s) = rigidSimilarity3DCommon(landmarks, center, similarityFlag = true)

--- a/src/main/scala/scalismo/registration/LandmarkRegistration.scala
+++ b/src/main/scala/scalismo/registration/LandmarkRegistration.scala
@@ -76,14 +76,14 @@ object LandmarkRegistration {
     LandmarkRegistration.rigid3DLandmarkRegistration(landmarksPairs.toIndexedSeq, center)
   }
 
-  def rigid3DLandmarkRegistration(landmarks: IndexedSeq[(Point[_3D], Point[_3D])], center: Point[_3D] = origin3D): RigidTransformation[_3D] = {
+  def rigid3DLandmarkRegistration(landmarks: IndexedSeq[(Point[_3D], Point[_3D])], center: Point[_3D]): RigidTransformation[_3D] = {
     val (t, rotparams, _) = rigidSimilarity3DCommon(landmarks, center)
     val optimalParameters = DenseVector.vertcat(t, rotparams)
     val rigidSpace = RigidTransformationSpace[_3D](center)
     rigidSpace.transformForParameters(optimalParameters)
   }
 
-  def similarity3DLandmarkRegistration(landmarks: IndexedSeq[(Point[_3D], Point[_3D])], center: Point[_3D] = origin3D): ParametricTransformation[_3D] = {
+  def similarity3DLandmarkRegistration(landmarks: IndexedSeq[(Point[_3D], Point[_3D])], center: Point[_3D]): ParametricTransformation[_3D] = {
     val (t, rotparams, s) = rigidSimilarity3DCommon(landmarks, center, similarityFlag = true)
     val optimalParameters = DenseVector.vertcat(DenseVector.vertcat(t, rotparams), DenseVector(s))
     val similaritySpace = RigidTransformationSpace[_3D](center).product(ScalingSpace[_3D])

--- a/src/main/scala/scalismo/statisticalmodel/asm/ActiveShapeModel.scala
+++ b/src/main/scala/scalismo/statisticalmodel/asm/ActiveShapeModel.scala
@@ -182,7 +182,7 @@ case class ActiveShapeModel(statisticalModel: StatisticalMeshModel, profiles: Pr
     } else Try {
 
       val refPtsWithTargetPts = refPtIdsWithTargetPt.map { case (refPtId, tgtPt) => (statisticalModel.referenceMesh.pointSet.point(refPtId), tgtPt) }
-      val bestRigidTransform = LandmarkRegistration.rigid3DLandmarkRegistration(refPtsWithTargetPts)
+      val bestRigidTransform = LandmarkRegistration.rigid3DLandmarkRegistration(refPtsWithTargetPts, poseTransform.rotation.center)
 
       val refPtIdsWithTargetPtAtModelSpace = refPtIdsWithTargetPt.map { case (refPtId, tgtPt) => (refPtId, bestRigidTransform.inverse(tgtPt)) }
       val bestReconstruction = statisticalModel.posterior(refPtIdsWithTargetPtAtModelSpace, 1e-5).mean

--- a/src/main/scala/scalismo/statisticalmodel/dataset/DataCollection.scala
+++ b/src/main/scala/scalismo/statisticalmodel/dataset/DataCollection.scala
@@ -134,7 +134,7 @@ object DataCollection {
       // align all shape to it and create a transformation from the mean to the aligned shape 
       val alignedShapesTransformations = dc.dataItems.zip(allShapesPoints).par.map {
         case (item, points) =>
-          val transform = LandmarkRegistration.rigid3DLandmarkRegistration(points.zip(meanShapePoints))
+          val transform = LandmarkRegistration.rigid3DLandmarkRegistration(points.zip(meanShapePoints), Point(0, 0, 0))
           val alignedPoints = points.map(transform)
 
           val t = meanShapePoints.zip(alignedPoints).toMap

--- a/src/test/scala/scalismo/registration/RegistrationTests.scala
+++ b/src/test/scala/scalismo/registration/RegistrationTests.scala
@@ -70,7 +70,7 @@ class RegistrationTests extends ScalismoTestSuite {
 
     val rigidTransformed = mesh transform trans
 
-    val regResult = LandmarkRegistration.rigid3DLandmarkRegistration(mesh.pointSet.points.zip(rigidTransformed.pointSet.points).toIndexedSeq)
+    val regResult = LandmarkRegistration.rigid3DLandmarkRegistration(mesh.pointSet.points.zip(rigidTransformed.pointSet.points).toIndexedSeq, Point(0, 0, 0))
 
     //should not test on parameters here since many euler angles can lead to the same rotation matrix
     val rigidRegTransformed = mesh transform regResult
@@ -152,7 +152,7 @@ class RegistrationTests extends ScalismoTestSuite {
 
       val translatedRotatedScaled = mesh transform trans
 
-      val regResult = LandmarkRegistration.similarity3DLandmarkRegistration(mesh.pointSet.points.zip(translatedRotatedScaled.pointSet.points).toIndexedSeq)
+      val regResult = LandmarkRegistration.similarity3DLandmarkRegistration(mesh.pointSet.points.zip(translatedRotatedScaled.pointSet.points).toIndexedSeq, Point(0, 0, 0))
 
       //should not test on parameters here since many euler angles can lead to the same rotation matrix
       val regSim = mesh transform regResult

--- a/src/test/scala/scalismo/statisticalmodel/ActiveShapeModelTests.scala
+++ b/src/test/scala/scalismo/statisticalmodel/ActiveShapeModelTests.scala
@@ -4,11 +4,11 @@ import java.io.File
 
 import breeze.linalg.DenseVector
 import scalismo.ScalismoTestSuite
-import scalismo.geometry._3D
+import scalismo.geometry.{ Point, _3D }
 import scalismo.io.{ ImageIO, MeshIO, StatismoIO }
 import scalismo.mesh.{ MeshMetrics, TriangleMesh }
 import scalismo.numerics.{ Sampler, UniformMeshSampler3D }
-import scalismo.registration.{ RigidTransformationSpace, LandmarkRegistration }
+import scalismo.registration.{ LandmarkRegistration, RigidTransformationSpace }
 import scalismo.statisticalmodel.asm._
 import scalismo.statisticalmodel.dataset.DataCollection
 
@@ -41,7 +41,7 @@ class ActiveShapeModelTests extends ScalismoTestSuite {
       val asm = ActiveShapeModel.trainModel(shapeModel, trainingData, imagePreprocessor, featureExtractor, samplerPerMesh)
 
       // align the model
-      val alignment = LandmarkRegistration.rigid3DLandmarkRegistration((asm.statisticalModel.mean.pointSet.points zip targetMesh.pointSet.points).toIndexedSeq)
+      val alignment = LandmarkRegistration.rigid3DLandmarkRegistration((asm.statisticalModel.mean.pointSet.points zip targetMesh.pointSet.points).toIndexedSeq, Point(0, 0, 0))
       val alignedASM = asm.transform(alignment)
 
     }

--- a/src/test/scala/scalismo/statisticalmodel/dataset/DataCollectionTests.scala
+++ b/src/test/scala/scalismo/statisticalmodel/dataset/DataCollectionTests.scala
@@ -84,7 +84,7 @@ class DataCollectionTests extends ScalismoTestSuite {
     val dataset = nonAlignedFaces.tail
 
     val aligendDataset = dataset.map { d =>
-      val trans = LandmarkRegistration.rigid3DLandmarkRegistration((d.pointSet.points zip ref.pointSet.points).toIndexedSeq)
+      val trans = LandmarkRegistration.rigid3DLandmarkRegistration((d.pointSet.points zip ref.pointSet.points).toIndexedSeq, Point(0, 0, 0))
       d.transform(trans)
     }
 


### PR DESCRIPTION
… pose using the same center

The center can be default"ed" either in rigid3DLandmarkRegistration(IndexedSeq[(Point[_3D], Point[_3D])]) or rigid3DLandmarkRegistration(Seq[Landmark[_3D]],  Seq[Landmark[_3D]]) .. not in both (compiler error). Favored the latter as it is most user friendly.