### PR TITLE
updated breeze dependency to 0.12 and removed spire dependency (that …

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -13,7 +13,7 @@ import sbtbuildinfo.Plugin._
 object BuildSettings {
   val buildOrganization = "ch.unibas.cs.gravis"
   val buildVersion = "develop-SNAPSHOT"
-  val buildScalaVersion = "2.10.5"
+  val buildScalaVersion = "2.11.7"
   val publishURL = Resolver.file("file", new File("/export/contrib/statismo/repo/public"))
 
   val buildSettings = Defaults.defaultSettings ++ Seq(
@@ -66,12 +66,11 @@ object Resolvers {
 object Dependencies {
   import BuildSettings.scalismoPlatform
   val scalatest = "org.scalatest" %% "scalatest" % "2.2+" % "test"
-  val breezeMath = "org.scalanlp" %% "breeze" % "0.11.2"
-  val breezeNative = "org.scalanlp" %% "breeze-natives" % "0.11.2"
+  val breezeMath = "org.scalanlp" %% "breeze" % "0.12"
+  val breezeNative = "org.scalanlp" %% "breeze-natives" % "0.12"
   val sprayJson = "io.spray" %% "spray-json" % "1.2.6"
   val scalismoNativeStub = "ch.unibas.cs.gravis" % "scalismo-native-stub" % "3.0.+"
   val scalismoNativeImpl = "ch.unibas.cs.gravis" % s"scalismo-native-$scalismoPlatform" % "3.0.+" % "test"
-  val spire = "org.spire-math" %% "spire" % "0.9.0"
   val slf4jNop = "org.slf4j" % "slf4j-nop" % "1.6.0" // this silences slf4j complaints in registration classes
 }
 
@@ -113,7 +112,6 @@ object STKBuild extends Build {
     scalismoNativeStub,
     scalismoNativeImpl,
     sprayJson,
-    spire,
     slf4jNop
   )
 }

--- a/src/main/scala/scalismo/statisticalmodel/DiscreteLowRankGaussianProcess.scala
+++ b/src/main/scala/scalismo/statisticalmodel/DiscreteLowRankGaussianProcess.scala
@@ -405,8 +405,8 @@ object DiscreteLowRankGaussianProcess {
     }
 
     def demean(X: DenseMatrix[Double]): (DenseMatrix[Double], DenseVector[Double]) = {
-      val X0 = X.map(_.toDouble) // will be the demeaned result matrix
-      val m: DenseVector[Double] = breeze.stats.mean(X0(::, *)).toDenseVector
+      val X0 = X // will be the demeaned result matrix
+      val m: DenseVector[Double] = breeze.stats.mean(X0(::, *)).inner
       for (i <- 0 until X0.rows) {
         X0(i, ::) := X0(i, ::) - m.t
       }


### PR DESCRIPTION
My initial goal was to get rid of the annoying warning in intelliJ when refreshing the sbt project (these cascade to user projects and confuse new comers). But apparently there isn't much we can do about the netlib warnings https://github.com/scalanlp/breeze/issues/248#issuecomment-43465854

Still removed an eviction warning and upgraded to breeze 0.12.

This should be merged after PR 143 that fixes the build (sorry for that :/).

