### PR TITLE
Simplify MeshSurfaceProperty: buffered data, no specialization

### DIFF
--- a/src/main/scala/scalismo/mesh/MeshSurfaceProperty.scala
+++ b/src/main/scala/scalismo/mesh/MeshSurfaceProperty.scala
@@ -20,7 +20,7 @@ import scalismo.common.PointId
 import scala.reflect.ClassTag
 
 /** general property defined on the surface of a mesh */
-trait MeshSurfaceProperty[@specialized(Double, Float, Int, Boolean) A] {
+trait MeshSurfaceProperty[A] {
   /** access via triangle coordinates */
   def onSurface(triangleId: TriangleId, bcc: BarycentricCoordinates): A
 
@@ -28,71 +28,44 @@ trait MeshSurfaceProperty[@specialized(Double, Float, Int, Boolean) A] {
   def apply(triangleId: TriangleId, bcc: BarycentricCoordinates): A = onSurface(triangleId, bcc)
 
   /** map a surface property through a function */
-  def map[@specialized(Double, Float, Int, Boolean) B](f: A => B): MeshSurfaceProperty[B] = MappedSurfaceProperty(this, f)
+  def map[B](f: A => B): MeshSurfaceProperty[B] = MappedSurfaceProperty(this, f)
 
   /** triangulation: domain of surface property */
   def triangulation: TriangleList
 }
 
 /** constant property value on complete surface */
-case class ConstantProperty[@specialized(Double, Float, Int, Boolean) A](override val triangulation: TriangleList, value: A)
+case class ConstantProperty[A](triangulation: TriangleList, value: A)
     extends MeshSurfaceProperty[A] {
 
   def atPoint(pointId: PointId): A = value
 
   override def onSurface(triangleId: TriangleId, bcc: BarycentricCoordinates): A = value
 
-  override def map[@specialized(Double, Float, Int, Boolean) B](f: A => B): ConstantProperty[B] = ConstantProperty(triangulation, f(value))
+  override def map[B](f: A => B): ConstantProperty[B] = ConstantProperty(triangulation, f(value))
 }
 
 /** property per vertex, with interpolation */
-case class SurfacePointProperty[@specialized(Double, Float, Int, Boolean) A](override val triangulation: TriangleList, pointData: PointId => A)(implicit val interpolator: Interpolator[A])
+case class SurfacePointProperty[A](triangulation: TriangleList, pointData: IndexedSeq[A])(implicit val interpolator: Interpolator[A])
     extends MeshSurfaceProperty[A] {
 
-  def atPoint(pointId: PointId): A = pointData(pointId)
+  def atPoint(pointId: PointId): A = pointData(pointId.id)
 
-  def apply(pointId: PointId): A = pointData(pointId)
+  def apply(pointId: PointId): A = pointData(pointId.id)
 
   override def onSurface(triangleId: TriangleId, bcc: BarycentricCoordinates): A = {
     val t = triangulation.triangles(triangleId.id)
-    val v1 = pointData(t.ptId1)
-    val v2 = pointData(t.ptId2)
-    val v3 = pointData(t.ptId3)
+    val v1 = pointData(t.ptId1.id)
+    val v2 = pointData(t.ptId2.id)
+    val v3 = pointData(t.ptId3.id)
     bcc.interpolateProperty(v1, v2, v3)
   }
 
-  def toIndexedSeq: IndexedSeq[A] = triangulation.pointIds.map(pointData)
-
-  def toArray(implicit tag: ClassTag[A]): Array[A] = {
-    val data = new Array[A](triangulation.pointIds.size)
-    triangulation.pointIds.foreach { ptId =>
-      data(ptId.id) = pointData(ptId)
-    }
-    data
-  }
-
-  def buffer(implicit tag: ClassTag[A]): SurfacePointProperty[A] = {
-    val data = toArray
-    val t = triangulation
-    SurfacePointProperty(t, data)
-  }
-
-  /** equality: same value for each triangle (explicit, not handled by case class) */
-  override def equals(other: Any) = other match {
-    case spp: SurfacePointProperty[A] => triangulation == spp.triangulation && triangulation.pointIds.forall(id => atPoint(id) == spp.atPoint(id))
-    case _ => false
-  }
-
-  /** hashCode for each triangle value (explicit, not handled by case class) */
-  override def hashCode(): Int = triangulation.hashCode() + triangulation.pointIds.foldLeft(0)((hc, id) => 41 * hc + atPoint(id).hashCode())
+  def mapPoints[B](f: A => B)(implicit interpolator: Interpolator[B]) = SurfacePointProperty(triangulation, pointData.map(f))
 }
 
 object SurfacePointProperty {
-  def apply[A](triangulation: TriangleList, pointData: IndexedSeq[A])(implicit interpolator: Interpolator[A]) = new SurfacePointProperty[A](triangulation, id => pointData(id.id))
-
-  def apply[@specialized(Double, Float, Int, Boolean) A](triangulation: TriangleList, pointData: Array[A])(implicit interpolator: Interpolator[A]) = new SurfacePointProperty[A](triangulation, id => pointData(id.id))
-
-  def averagedPointProperty[A](triangulation: TriangleList, property: MeshSurfaceProperty[A])(implicit ops: Interpolator[A]): SurfacePointProperty[A] = {
+  def averagedPointProperty[A](property: MeshSurfaceProperty[A])(implicit ops: Interpolator[A]): SurfacePointProperty[A] = {
     def averager(data: IndexedSeq[A]): A = {
       data.size match {
         case 0 => throw new Exception("averaging over empty set")
@@ -100,10 +73,11 @@ object SurfacePointProperty {
           ops.average(data.head, data.tail: _*)
       }
     }
-    sampleSurfaceProperty(triangulation, property, averager)
+    sampleSurfaceProperty(property, averager)
   }
 
-  def sampleSurfaceProperty[A](triangulation: TriangleList, property: MeshSurfaceProperty[A], reducer: IndexedSeq[A] => A)(implicit blender: Interpolator[A]): SurfacePointProperty[A] = {
+  def sampleSurfaceProperty[A](property: MeshSurfaceProperty[A], reducer: IndexedSeq[A] => A)(implicit blender: Interpolator[A]): SurfacePointProperty[A] = {
+    val triangulation = property.triangulation
     // get all data for a single vertex:
     def getVertex(pointId: PointId): A = {
       val triangles = triangulation.adjacentTrianglesForPoint(pointId)
@@ -116,45 +90,32 @@ object SurfacePointProperty {
     }
     // do for each vertex
     val data = for (v <- triangulation.pointIds) yield getVertex(v)
-    SurfacePointProperty(triangulation, id => data(id.id))
+    SurfacePointProperty(triangulation, data)
   }
 }
 
 /** property constant per triangle */
-case class TriangleProperty[@specialized(Double, Float, Int, Boolean) A](override val triangulation: TriangleList, triangleData: TriangleId => A)
+case class TriangleProperty[A](triangulation: TriangleList, triangleData: IndexedSeq[A])
     extends MeshSurfaceProperty[A] {
 
-  def apply(triangleId: TriangleId): A = triangleData(triangleId)
+  def apply(triangleId: TriangleId): A = onTriangle(triangleId)
 
-  override def onSurface(triangleId: TriangleId, bcc: BarycentricCoordinates): A = triangleData(triangleId)
+  override def onSurface(triangleId: TriangleId, bcc: BarycentricCoordinates): A = triangleData(triangleId.id)
 
-  def toIndexedSeq: IndexedSeq[A] = triangulation.triangleIds.map(id => triangleData(id))
+  def onTriangle(triangleId: TriangleId): A = triangleData(triangleId.id)
 
-  def toArray(implicit tag: ClassTag[A]): Array[A] = triangulation.triangleIds.toArray.map(triangleData)
-
-  /** equality: same value for each triangle (explicit, not handled by case class) */
-  override def equals(other: Any) = other match {
-    case tp: TriangleProperty[A] => triangulation == tp.triangulation && triangulation.triangleIds.forall(id => this(id) == tp(id))
-    case _ => false
-  }
-
-  /** hashCode for each triangle value (explicit, not handled by case class) */
-  override def hashCode(): Int = triangulation.hashCode() + triangulation.triangleIds.foldLeft(0)((hc, id) => 41 * hc + this(id).hashCode())
+  override def map[B](f: A => B): TriangleProperty[B] = TriangleProperty(triangulation, triangleData.map(f))
 }
 
 object TriangleProperty {
-  def apply[A](triangulation: TriangleList, triangleData: IndexedSeq[A]) = new TriangleProperty[A](triangulation, id => triangleData(id.id))
-
-  def apply[@specialized(Double, Float, Int, Boolean) A](triangulation: TriangleList, triangleData: Array[A]) = new TriangleProperty[A](triangulation, id => triangleData(id.id))
-
-  def fromAveragedPoints[A](triangulation: TriangleList, property: MeshSurfaceProperty[A])(implicit blender: Interpolator[A]): TriangleProperty[A] = {
-    val triangleData = for (t <- triangulation.triangleIds) yield {
+  def fromAveragedPoints[A](property: MeshSurfaceProperty[A])(implicit blender: Interpolator[A]): TriangleProperty[A] = {
+    val triangleData = for (t <- property.triangulation.triangleIds) yield {
       val v1 = property(t, BarycentricCoordinates.v0)
       val v2 = property(t, BarycentricCoordinates.v1)
       val v3 = property(t, BarycentricCoordinates.v2)
       blender.convexCombination((v1, 1f), (v2, 1f), (v3, 1f))
     }
-    TriangleProperty(triangulation, triangleData)
+    TriangleProperty(property.triangulation, triangleData)
   }
 
   def fromTriangleCenters[A](triangulation: TriangleList, property: MeshSurfaceProperty[A]) = {
@@ -164,11 +125,13 @@ object TriangleProperty {
 }
 
 /** function indirection for surface access */
-case class MappedSurfaceProperty[@specialized(Double, Float, Int, Boolean) A, @specialized(Double, Float, Int, Boolean) B](values: MeshSurfaceProperty[A], f: A => B)
+case class MappedSurfaceProperty[A, B](values: MeshSurfaceProperty[A], f: A => B)
     extends MeshSurfaceProperty[B] {
   /// access via triangle coordinates
   override def onSurface(triangleId: TriangleId, bcc: BarycentricCoordinates): B = f(values.onSurface(triangleId, bcc))
 
   override def triangulation: TriangleList = values.triangulation
+
+  override def map[C](g: B => C): MappedSurfaceProperty[A, C] = MappedSurfaceProperty(values, g compose f)
 }
 

--- a/src/main/scala/scalismo/mesh/TriangleMesh.scala
+++ b/src/main/scala/scalismo/mesh/TriangleMesh.scala
@@ -80,7 +80,7 @@ object TriangleMesh {
 
 case class TriangleMesh3D(pointSet: UnstructuredPointsDomain[_3D], triangulation: TriangleList) extends TriangleMesh[_3D] {
 
-  val position = SurfacePointProperty(triangulation, pointSet.point _)
+  val position = SurfacePointProperty(triangulation, pointSet.points.toIndexedSeq)
   val triangles = triangulation.triangles
   val cells = triangles
 
@@ -198,7 +198,7 @@ object TriangleMesh3D {
 }
 
 case class TriangleMesh2D(pointSet: UnstructuredPointsDomain[_2D], triangulation: TriangleList) extends TriangleMesh[_2D] {
-  val position = SurfacePointProperty(triangulation, pointSet.point _)
+  val position = SurfacePointProperty(triangulation, pointSet.points.toIndexedSeq)
 
   override def transform(transform: Point[_2D] => Point[_2D]): TriangleMesh2D = {
     TriangleMesh2D(UnstructuredPointsDomain(pointSet.points.map(transform).toIndexedSeq), triangulation)

--- a/src/test/scala/scalismo/mesh/MeshSurfacePropertyTests.scala
+++ b/src/test/scala/scalismo/mesh/MeshSurfacePropertyTests.scala
@@ -34,10 +34,6 @@ class MeshSurfacePropertyTests extends ScalismoTestSuite {
       pointProperty(TriangleId(0), BarycentricCoordinates.center) shouldBe (values(0) + values(1) + values(2)) / 3.0
       pointProperty(TriangleId(1), BarycentricCoordinates.center) shouldBe (values(2) + values(1) + values(3)) / 3.0
     }
-
-    it("returns the same values used at construction") {
-      pointProperty.toIndexedSeq shouldBe values
-    }
   }
 
   describe("A MappedMeshSurfaceProperty") {


### PR DESCRIPTION
Simplification of `MeshSurfaceProperty`:

- Removed type-specialization from all definitions
- Data of most concrete properties is supplied as a `IndexedSeq[A]`
- Added some documentation strings

Especially the buffered data enables a much cleaner case class code, e.g. they have proper equality and hash code methods out of the box.

We lose a tiny bit of flexibility through this: supplying data through the functional `PointId => A` or `TriangleId => A` enabled adhoc solutions without the need the compute a property for each vertex/triangle in advance. But having these functions made a complicated equality test necessary (sample all values first).

If the functionality is really needed now, the way to go would be to define your own `MeshSurfaceProperty` where you need it. It is just a two-methods interface.