### PR TITLE
Region search on unstructured point domains

### DIFF
--- a/src/main/scala/scalismo/common/UnstructuredPointsDomain.scala
+++ b/src/main/scala/scalismo/common/UnstructuredPointsDomain.scala
@@ -19,6 +19,7 @@ package scalismo.common
 import scalismo.common.UnstructuredPointsDomain.Create
 import scalismo.geometry._
 import scalismo.mesh.kdtree.KDTreeMap
+import scalismo.mesh.kdtree.RegionBuilder
 
 import scala.language.implicitConversions
 
@@ -47,6 +48,17 @@ sealed abstract class UnstructuredPointsDomain[D <: Dim: NDSpace: Create] privat
       case Some(id) => PointWithId(pt, id)
       case None => kdtreeLookup(pt)
     }
+  }
+
+  def findPointsInRegion(region: BoxDomain[D]): Seq[PointWithId[D]] = {
+
+    val dim = implicitly[NDSpace[D]]
+    val regionBuilder = new RegionBuilder[Point[D]]
+    val a = region.origin
+    val b = region.origin + region.extent
+    val reg = (0 until dim.dimensionality).foldLeft[RegionBuilder[Point[D]]](regionBuilder) { case (rg, dim) => rg.from(a, dim).to(b, dim) }
+    kdTreeMap.regionQuery(reg).map { case (p, id) => PointWithId(p, PointId(id)) }
+
   }
 
   override def findNClosestPoints(pt: Point[D], n: Int): Seq[PointWithId[D]] = {

--- a/src/main/scala/scalismo/registration/TransformationSpace.scala
+++ b/src/main/scala/scalismo/registration/TransformationSpace.scala
@@ -488,10 +488,10 @@ object RotationTransform {
   /**
    *  Factory method to create a 3-dimensional rotation transform around a center (default at origin) when
    *  given the Euler angles according to the x-convention
-    *  @param phi rotation around the Z axis
-    *  @param theta rotation around the Y axis
-    *  @param psi rotation around the X axis
-    *
+   *  @param phi rotation around the Z axis
+   *  @param theta rotation around the Y axis
+   *  @param psi rotation around the X axis
+   *
    */
   def apply(phi: Double, theta: Double, psi: Double, centre: Point[_3D] = Point(0.0, 0.0, 0.0)): RotationTransform[_3D] = {
     val rotMatrix = RotationSpace.eulerAnglesToRotMatrix3D(DenseVector(phi, theta, psi))

--- a/src/test/scala/scalismo/mesh/RegionQueryTest.scala
+++ b/src/test/scala/scalismo/mesh/RegionQueryTest.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2015 University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package scalismo.mesh
+import java.io.File
+
+import scalismo.ScalismoTestSuite
+import scalismo.common.{ BoxDomain, PointId, UnstructuredPointsDomain }
+import scalismo.geometry._
+import scalismo.image.{ DiscreteImageDomain, DiscreteImageDomain2D }
+import scalismo.io.MeshIO
+
+class RegionQueryTest extends ScalismoTestSuite {
+
+  val path = getClass.getResource("/facemesh.stl").getPath
+  val mesh = MeshIO.readMesh(new File(path)).get
+  val translationLength = 1.0
+  val translatedMesh = mesh.transform((pt: Point[_3D]) => pt + Vector(translationLength, 0.0, 0.0))
+
+  describe("The KD-tree region query") {
+
+    it("finds points in the 2D bounding box region") {
+
+      val img = DiscreteImageDomain(Point(0, 0), Vector(1, 1), IntVector(10, 10))
+      val bigBox = img.boundingBox
+      val dom = UnstructuredPointsDomain[_2D](img.points.toIndexedSeq)
+
+      // Smaller Region
+      val o = bigBox.origin
+      val e = bigBox.extent * 0.5
+      val nBox = BoxDomain(o, o + e)
+      val pts = dom.findPointsInRegion(nBox).map(_.point)
+      val groundTruth = dom.points.filter(p => nBox.isDefinedAt(p)).toSeq
+
+      assert(groundTruth.forall(p => pts.contains(p)))
+      assert(pts.forall(p => groundTruth.contains(p)))
+
+    }
+
+    it("finds points in the 3D bounding box region") {
+
+      val bigBox = mesh.boundingBox
+
+      //Smaller Region
+      val o = bigBox.origin
+      val e = bigBox.extent * 0.5
+      val nBox = BoxDomain(o, o + e)
+      val pts = mesh.pointSet.findPointsInRegion(nBox).map(_.point)
+      val groundTruth = mesh.pointSet.points.filter(p => nBox.isDefinedAt(p)).toSeq
+
+      assert(groundTruth.forall(p => pts.contains(p)))
+      assert(pts.forall(p => groundTruth.contains(p)))
+
+    }
+
+  }
+}


### PR DESCRIPTION
Use the KD-tree to query for points within a given BoxDomain. Implemented together with the corresponding test.