### PR TITLE
Add MCMC sampling library from scalismo-sampling

### DIFF
--- a/src/main/scala/scalismo/sampling/DistributionEvaluator.scala
+++ b/src/main/scala/scalismo/sampling/DistributionEvaluator.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2016 University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package scalismo.sampling
+
+/** a probability or density */
+trait DistributionEvaluator[A] {
+  /** log probability/density of sample */
+  def logValue(sample: A): Double
+}
+
+/** gradient evaluator, used together with DistributionEvaluator */
+trait GradientEvaluator[A] {
+  /** gradient at sample */
+  def gradient(sample: A): A
+}

--- a/src/main/scala/scalismo/sampling/MarkovChain.scala
+++ b/src/main/scala/scalismo/sampling/MarkovChain.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2016 University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package scalismo.sampling
+
+import scalismo.sampling.loggers.ChainStateLogger
+
+/** basic Markov Chain trait: provides a next sample */
+trait MarkovChain[A] {
+  /** next sample in chain */
+  def next(current: A): A
+
+  /** provide a chain starting from current as an iterator */
+  def iterator(current: A): Iterator[A] = Iterator.iterate(current)(next)
+}
+
+object MarkovChain {
+  /** fat interface with rich enhancements for Markov Chains - only implementation, not a type */
+  implicit class RichMarkovChain[A](mc: MarkovChain[A]) {
+    def loggedWith(logger: ChainStateLogger[A]): MarkovChain[A] = new LoggedMarkovChain[A](mc, logger)
+  }
+
+  class LoggedMarkovChain[A](chain: MarkovChain[A], logger: ChainStateLogger[A]) extends MarkovChain[A] {
+    /** next sample in chain */
+    override def next(current: A): A = {
+      val sample = chain.next(current)
+      logger.logState(sample)
+      sample
+    }
+
+    override def toString = chain.toString
+  }
+}

--- a/src/main/scala/scalismo/sampling/ProposalGenerator.scala
+++ b/src/main/scala/scalismo/sampling/ProposalGenerator.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2016 University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package scalismo.sampling
+
+/** proposal distribution sampler for Metropolis-Hastings MCMC */
+trait ProposalGenerator[A] {
+  /** draw a sample from this proposal distribution, may depend on current state */
+  def propose(current: A): A
+}
+
+/** ratio of forward and backwards proposal probability/density */
+trait TransitionRatio[A] {
+  /** total rate of transition from to, corrected for backwards transition (log value) */
+  def logTransitionRatio(from: A, to: A): Double
+}
+
+/** symmetric transition: equal forward and backward transition probability */
+trait SymmetricTransition[A] extends TransitionRatio[A] {
+  override def logTransitionRatio(from: A, to: A) = 0.0
+}
+
+/** expresses transition probability between two states */
+trait TransitionProbability[A] extends TransitionRatio[A] {
+  /** rate of transition from to (log value) */
+  def logTransitionProbability(from: A, to: A): Double
+
+  /** transition ratio forward probability / backward probability */
+  override def logTransitionRatio(from: A, to: A) = {
+    val fw = logTransitionProbability(from, to)
+    val bw = logTransitionProbability(to, from)
+
+    if (fw.isNaN || bw.isNaN)
+      throw new Exception("NaN transition Probability!")
+
+    if (!fw.isNegInfinity || !bw.isNegInfinity)
+      fw - bw
+    else
+      0.0
+  }
+}
+
+/** trait to express a unit transition probability (rarely appropriate) */
+trait UnitTransition[A] extends TransitionProbability[A] with SymmetricTransition[A] {
+  /** fixed unit value for transition probability - careful when in use with correction */
+  override def logTransitionProbability(from: A, to: A) = 0.0
+}

--- a/src/main/scala/scalismo/sampling/algorithms/ForwardChain.scala
+++ b/src/main/scala/scalismo/sampling/algorithms/ForwardChain.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2016 University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package scalismo.sampling.algorithms
+
+import scalismo.sampling.{ MarkovChain, ProposalGenerator }
+
+/** Markov chain which draws the next sample from a proposal distribution */
+class ForwardChain[A](proposalGenerator: ProposalGenerator[A]) extends MarkovChain[A] {
+  /** next sample in chain */
+  override def next(current: A): A = proposalGenerator.propose(current)
+}
+
+object ForwardChain {
+  def apply[A](proposalGenerator: ProposalGenerator[A]) = new ForwardChain[A](proposalGenerator)
+}

--- a/src/main/scala/scalismo/sampling/algorithms/Metropolis.scala
+++ b/src/main/scala/scalismo/sampling/algorithms/Metropolis.scala
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2016 University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package scalismo.sampling.algorithms
+
+import scalismo.sampling._
+import scalismo.sampling.loggers.{ AcceptRejectLogger, SilentLogger }
+
+import scala.math.exp
+import scala.util.Random
+
+/**
+ * Metropolis algorithm (MCMC), provides samples from the evaluator distribution by drawing from generator and stochastic accept/reject decisions
+ * generator needs to be symmetric
+ */
+class Metropolis[A] protected (val generator: ProposalGenerator[A] with SymmetricTransition[A],
+    val evaluator: DistributionEvaluator[A],
+    val logger: AcceptRejectLogger[A])(implicit val random: Random) extends MarkovChain[A] {
+  // next sample
+  override def next(current: A): A = {
+    // reference p value
+    val currentP = evaluator.logValue(current)
+    // proposal
+    val proposal = generator.propose(current)
+    val proposalP = evaluator.logValue(proposal)
+    // acceptance probability
+    val a = proposalP - currentP
+    // accept or reject
+    if (a > 0.0 || random.nextDouble() < exp(a)) {
+      logger.accept(current, proposal, generator, evaluator)
+      proposal
+    } else {
+      logger.reject(current, proposal, generator, evaluator)
+      current
+    }
+  }
+}
+
+object Metropolis {
+  /** create a Metropolis MCMC chain, needs a symmetric proposal distribution, with logger attached */
+  def apply[A](generator: ProposalGenerator[A] with SymmetricTransition[A],
+    evaluator: DistributionEvaluator[A],
+    logger: AcceptRejectLogger[A])(implicit random: Random) = new Metropolis[A](generator, evaluator, logger)
+
+  /** create a Metropolis MCMC chain without a logger */
+  def apply[A](generator: ProposalGenerator[A] with SymmetricTransition[A],
+    evaluator: DistributionEvaluator[A])(implicit random: Random) = new Metropolis[A](generator, evaluator, new SilentLogger[A]())
+}
+
+/** Metropolis-Hastings algorithm - generates random samples from a target distribution using only samples from a proposal distribution */
+class MetropolisHastings[A] protected (val generator: ProposalGenerator[A] with TransitionRatio[A],
+    val evaluator: DistributionEvaluator[A],
+    val logger: AcceptRejectLogger[A])(implicit val random: Random) extends MarkovChain[A] {
+  /** next sample in Markov Chain */
+  override def next(current: A): A = {
+    // reference p value
+    val currentP = evaluator.logValue(current)
+    // proposal
+    val proposal = generator.propose(current)
+    val proposalP = evaluator.logValue(proposal)
+    // transition ratio
+    val t = generator.logTransitionRatio(current, proposal)
+    // acceptance probability
+    val a = proposalP - currentP - t
+
+    // accept or reject
+    if (a > 0.0 || random.nextDouble() < exp(a)) {
+      logger.accept(current, proposal, generator, evaluator)
+      proposal
+    } else {
+      logger.reject(current, proposal, generator, evaluator)
+      current
+    }
+  }
+}
+
+object MetropolisHastings {
+  def apply[A](generator: ProposalGenerator[A] with TransitionRatio[A],
+    evaluator: DistributionEvaluator[A],
+    logger: AcceptRejectLogger[A])(implicit random: Random) = new MetropolisHastings[A](generator, evaluator, logger)
+
+  def apply[A](generator: ProposalGenerator[A] with TransitionRatio[A],
+    evaluator: DistributionEvaluator[A])(implicit random: Random) = new MetropolisHastings[A](generator, evaluator, new SilentLogger[A]())
+}
+

--- a/src/main/scala/scalismo/sampling/evaluators/GaussianEvaluator.scala
+++ b/src/main/scala/scalismo/sampling/evaluators/GaussianEvaluator.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2016 University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package scalismo.sampling.evaluators
+
+import scalismo.sampling.DistributionEvaluator
+
+/** 1D Gaussian distribution */
+case class GaussianEvaluator(mean: Double, sdev: Double) extends DistributionEvaluator[Double] {
+  val normalizer = -0.5 * math.log(2 * math.Pi) - math.log(sdev)
+
+  /** log probability/density of sample */
+  override def logValue(sample: Double): Double = -0.5 * (sample - mean) * (sample - mean) / sdev / sdev + normalizer
+}
+
+object GaussianEvaluator {
+  /** probability density of 1D Gaussian distribution */
+  def probability(x: Double, mean: Double, sdev: Double): Double = {
+    -0.5 * math.log(2 * math.Pi) - math.log(sdev) - 0.5 * (x - mean) * (x - mean) / sdev / sdev
+  }
+}

--- a/src/main/scala/scalismo/sampling/evaluators/PairEvaluator.scala
+++ b/src/main/scala/scalismo/sampling/evaluators/PairEvaluator.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2016 University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package scalismo.sampling.evaluators
+
+import scalismo.sampling.DistributionEvaluator
+
+/** probability density based on pairs, e.g. Gaussian centered on first evaluated at second */
+trait PairEvaluator[A] {
+  self =>
+  /** probability/density value for a pair (log value) */
+  def logValue(first: A, second: A): Double
+
+  /** make a distribution evaluator, centered at first */
+  def toDistributionEvaluator(first: A): DistributionEvaluator[A] = new DistributionEvaluator[A] {
+    override def logValue(sample: A): Double = self.logValue(first, sample)
+
+    override def toString = self.toString
+  }
+
+  /** make a distribution evaluator for tuples to encode pairs */
+  def tupled = new DistributionEvaluator[(A, A)] {
+    override def logValue(sample: (A, A)): Double = self.logValue(sample._1, sample._2)
+
+    override def toString = self.toString
+  }
+}

--- a/src/main/scala/scalismo/sampling/evaluators/ProductEvaluator.scala
+++ b/src/main/scala/scalismo/sampling/evaluators/ProductEvaluator.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2016 University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package scalismo.sampling.evaluators
+
+import scalismo.sampling.DistributionEvaluator
+
+import scala.language.implicitConversions
+
+/**
+ * evaluate a product of distributions
+ *
+ * @param evaluators Sequence of distributions to evaluate
+ */
+class ProductEvaluator[A](evaluators: Seq[DistributionEvaluator[A]]) extends DistributionEvaluator[A] {
+  override def logValue(sample: A): Double = {
+    evaluators.iterator.map(e => e.logValue(sample)).sum
+  }
+}
+
+object ProductEvaluator {
+  def apply[A](evaluators: DistributionEvaluator[A]*) = new ProductEvaluator[A](evaluators.toSeq)
+
+  def apply[A](builder: implicits.ProductBuilder[A]) = builder.toProductEvaluator
+
+  /** implicit builder for ProductEvaluator */
+  object implicits {
+    implicit def toProductBuilder[A](eval: DistributionEvaluator[A]): ProductBuilder[A] = new ProductBuilder[A](eval)
+
+    implicit def toProductEvaluator[A](builder: ProductBuilder[A]): ProductEvaluator[A] = builder.toProductEvaluator
+
+    class ProductBuilder[A](evals: DistributionEvaluator[A]*) {
+      def toProductEvaluator: ProductEvaluator[A] = new ProductEvaluator[A](evals.toSeq)
+
+      def *(other: DistributionEvaluator[A]): ProductBuilder[A] = new ProductBuilder[A](evals :+ other: _*)
+    }
+
+  }
+
+}

--- a/src/main/scala/scalismo/sampling/loggers/AcceptRejectLogger.scala
+++ b/src/main/scala/scalismo/sampling/loggers/AcceptRejectLogger.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2016 University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package scalismo.sampling.loggers
+
+import scalismo.sampling.{ DistributionEvaluator, ProposalGenerator }
+
+import scala.language.implicitConversions
+
+trait AcceptRejectLogger[A] {
+  def accept(current: A, sample: A, generator: ProposalGenerator[A], evaluator: DistributionEvaluator[A]): Unit
+
+  def reject(current: A, sample: A, generator: ProposalGenerator[A], evaluator: DistributionEvaluator[A]): Unit
+}
+
+object AcceptRejectLogger {
+
+  // Rich logger to attach various others
+
+  object implicits {
+    implicit def richLogger[A](logger: AcceptRejectLogger[A]): RichLogger[A] = new RichLogger[A](logger)
+
+    class RichLogger[A](logger: AcceptRejectLogger[A]) {
+      def subSampled(stepping: Int) = SteppedAcceptRejectLogger(stepping, logger)
+    }
+
+  }
+
+}

--- a/src/main/scala/scalismo/sampling/loggers/AcceptRejectLoggerContainer.scala
+++ b/src/main/scala/scalismo/sampling/loggers/AcceptRejectLoggerContainer.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2016 University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package scalismo.sampling.loggers
+
+import scalismo.sampling.{ DistributionEvaluator, ProposalGenerator }
+
+import scala.language.implicitConversions
+
+/** container for multiple AcceptRejectLoggers */
+class AcceptRejectLoggerContainer[A](loggers: Seq[AcceptRejectLogger[A]]) extends AcceptRejectLogger[A] {
+  override def accept(current: A, sample: A, generator: ProposalGenerator[A], evaluator: DistributionEvaluator[A]): Unit = {
+    loggers.foreach(_.accept(current, sample, generator, evaluator))
+  }
+
+  override def reject(current: A, sample: A, generator: ProposalGenerator[A], evaluator: DistributionEvaluator[A]): Unit = {
+    loggers.foreach(_.reject(current, sample, generator, evaluator))
+  }
+}
+
+object AcceptRejectLoggerContainer {
+  def apply[A](loggers: Seq[AcceptRejectLogger[A]]) = new AcceptRejectLoggerContainer[A](loggers)
+
+  /** implicit building DSL: logger1 :+ logger2 -> LoggerContainer */
+  object implicits {
+    implicit def promoteLoggerToContainerBuilder[A](logger: AcceptRejectLogger[A]): ContainerBuilder[A] = new ContainerBuilder[A](Seq(logger))
+
+    implicit def buildContainer[A](containerBuilder: ContainerBuilder[A]): AcceptRejectLoggerContainer[A] = containerBuilder.toContainer
+
+    class ContainerBuilder[A](logger: Seq[AcceptRejectLogger[A]]) {
+      def :+(other: AcceptRejectLogger[A]): ContainerBuilder[A] = new ContainerBuilder[A](logger :+ other)
+
+      def toContainer: AcceptRejectLoggerContainer[A] = new AcceptRejectLoggerContainer[A](logger)
+    }
+
+  }
+
+}
+
+/** container to keep multiple ChainStateLoggers active */
+class ChainStateLoggerContainer[A](loggers: Seq[ChainStateLogger[A]]) extends ChainStateLogger[A] {
+  override def logState(sample: A): Unit = {
+    loggers.foreach(_.logState(sample))
+  }
+}
+
+object ChainStateLoggerContainer {
+  def apply[A](loggers: Seq[ChainStateLogger[A]]) = new ChainStateLoggerContainer[A](loggers)
+
+  /** implicit construction with "logger :+ other" */
+  object implicits {
+    implicit def promoteToLoggerBuilder[A](logger: ChainStateLogger[A]): ContainerBuilder[A] = new ContainerBuilder[A](Seq(logger))
+
+    implicit def buildContainer[A](builder: ContainerBuilder[A]): ChainStateLoggerContainer[A] = builder.toContainer
+
+    class ContainerBuilder[A](loggers: Seq[ChainStateLogger[A]]) {
+      def :+(other: ChainStateLogger[A]): ContainerBuilder[A] = new ContainerBuilder[A](loggers :+ other)
+
+      def toContainer: ChainStateLoggerContainer[A] = new ChainStateLoggerContainer[A](loggers)
+    }
+
+  }
+
+}

--- a/src/main/scala/scalismo/sampling/loggers/AllProposalsLogger.scala
+++ b/src/main/scala/scalismo/sampling/loggers/AllProposalsLogger.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2016 University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package scalismo.sampling.loggers
+
+import scalismo.sampling.{ DistributionEvaluator, ProposalGenerator }
+
+class AllProposalsLogger[A](logger: ChainStateLogger[A]) extends AcceptRejectLogger[A] {
+  override def accept(current: A, sample: A, generator: ProposalGenerator[A], evaluator: DistributionEvaluator[A]): Unit = logger.logState(sample)
+
+  override def reject(current: A, sample: A, generator: ProposalGenerator[A], evaluator: DistributionEvaluator[A]): Unit = logger.logState(sample)
+}
+
+class AcceptedProposalLogger[A](logger: ChainStateLogger[A]) extends AcceptRejectLogger[A] {
+  private var state: Option[A] = None // keep track of last accepted proposal -> this is the state
+
+  override def accept(current: A, sample: A, generator: ProposalGenerator[A], evaluator: DistributionEvaluator[A]): Unit = {
+    state = Some(sample)
+    logger.logState(sample)
+  }
+
+  override def reject(current: A, sample: A, generator: ProposalGenerator[A], evaluator: DistributionEvaluator[A]): Unit = {
+    if (state.isDefined) logger.logState(state.get)
+  }
+}
+
+object AllProposalsLogger {
+  // implicit attachment to a chain logger
+  implicit def stateLoggerOnAllProposals[A](logger: ChainStateLogger[A]): RichChainStateLogger[A] = new RichChainStateLogger[A](logger)
+
+  class RichChainStateLogger[A](logger: ChainStateLogger[A]) {
+    def onAllProposals: AcceptRejectLogger[A] = new AllProposalsLogger[A](logger)
+    def onAccepted: AcceptRejectLogger[A] = new AcceptedProposalLogger[A](logger)
+  }
+}

--- a/src/main/scala/scalismo/sampling/loggers/BestSampleLogger.scala
+++ b/src/main/scala/scalismo/sampling/loggers/BestSampleLogger.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2016 University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package scalismo.sampling.loggers
+
+import scalismo.sampling.DistributionEvaluator
+
+/** keep the best sample so far, warning: changes state */
+class BestSampleLogger[A](evaluator: DistributionEvaluator[A]) extends ChainStateLogger[A] {
+
+  private case class EvaluatedSample(sample: A, value: Double)
+
+  private var bestState: Option[EvaluatedSample] = None
+
+  override def logState(sample: A): Unit = {
+    val value = evaluator.logValue(sample)
+    if (bestState.isEmpty || value > bestState.get.value) {
+      bestState = Some(EvaluatedSample(sample, value))
+    }
+  }
+
+  def currentBestSample() = bestState.map(_.sample)
+
+  def currentBestValue() = bestState.map(_.value)
+}
+
+object BestSampleLogger {
+  def apply[A](evaluator: DistributionEvaluator[A]) = new BestSampleLogger[A](evaluator)
+}

--- a/src/main/scala/scalismo/sampling/loggers/ChainStateLogger.scala
+++ b/src/main/scala/scalismo/sampling/loggers/ChainStateLogger.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2016 University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package scalismo.sampling.loggers
+
+import scala.language.implicitConversions
+
+/* side-effects-based logging facility, be careful when doing something advanced with Markov Chains (such as parallel chains on a single object) */
+
+trait ChainStateLogger[A] extends RichLogger[A] {
+  def logState(sample: A): Unit
+}
+
+trait RichLogger[A] {
+  self: ChainStateLogger[A] =>
+  def subSampled(stepping: Int): ChainStateLogger[A] = SteppedChainStateLogger(stepping, self)
+}
+
+object ChainStateLogger {
+
+  // implicit enrichment of others loggers
+  object implicits {
+    implicit def richLogger[A](logger: ChainStateLogger[A]): RichLogger[A] = new RichLogger[A](logger)
+
+    class RichLogger[A](logger: ChainStateLogger[A]) {
+      def subSampled(stepping: Int) = SteppedChainStateLogger(stepping, logger)
+    }
+  }
+}

--- a/src/main/scala/scalismo/sampling/loggers/SilentLogger.scala
+++ b/src/main/scala/scalismo/sampling/loggers/SilentLogger.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2016 University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package scalismo.sampling.loggers
+
+import scalismo.sampling.{ DistributionEvaluator, ProposalGenerator }
+
+object SilentLogger {
+  def apply[A] = new SilentLogger[A]()
+}
+
+/** silent logger, does nothing */
+class SilentLogger[A] extends AcceptRejectLogger[A] {
+  override def accept(current: A, sample: A, generator: ProposalGenerator[A], evaluator: DistributionEvaluator[A]): Unit = {}
+
+  override def reject(current: A, sample: A, generator: ProposalGenerator[A], evaluator: DistributionEvaluator[A]): Unit = {}
+}

--- a/src/main/scala/scalismo/sampling/loggers/SteppedAcceptRejectLogger.scala
+++ b/src/main/scala/scalismo/sampling/loggers/SteppedAcceptRejectLogger.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2016 University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package scalismo.sampling.loggers
+
+import scalismo.sampling.{ DistributionEvaluator, ProposalGenerator }
+
+class SteppedAcceptRejectLogger[A](stepping: Int, logger: AcceptRejectLogger[A]) extends AcceptRejectLogger[A] {
+  private var counter = 0
+
+  override def accept(current: A, sample: A, generator: ProposalGenerator[A], evaluator: DistributionEvaluator[A]): Unit = {
+    if (counter % stepping == 0)
+      logger.accept(current, sample, generator, evaluator)
+    counter += 1
+  }
+
+  override def reject(current: A, sample: A, generator: ProposalGenerator[A], evaluator: DistributionEvaluator[A]): Unit = {
+    if (counter % stepping == 0)
+      logger.reject(current, sample, generator, evaluator)
+    counter += 1
+  }
+}
+
+object SteppedAcceptRejectLogger {
+  def apply[A](stepping: Int, logger: AcceptRejectLogger[A]) = new SteppedAcceptRejectLogger[A](stepping, logger)
+}
+
+class SteppedChainStateLogger[A](stepping: Int, logger: ChainStateLogger[A]) extends ChainStateLogger[A] {
+  private var counter = 0
+
+  override def logState(sample: A): Unit = {
+    if (counter % stepping == 0)
+      logger.logState(sample)
+    counter += 1
+  }
+}
+
+object SteppedChainStateLogger {
+  def apply[A](stepping: Int, logger: ChainStateLogger[A]) = new SteppedChainStateLogger[A](stepping, logger)
+}

--- a/src/main/scala/scalismo/sampling/proposals/CombinedProposal.scala
+++ b/src/main/scala/scalismo/sampling/proposals/CombinedProposal.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2016 University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package scalismo.sampling.proposals
+
+import scalismo.sampling.{ ProposalGenerator, TransitionProbability }
+
+import scala.util.Random
+
+/**
+ * Container for multiple ProposalGenerators stacked together, applied one after the other
+ */
+class CombinedProposal[A](val proposals: IndexedSeq[ProposalGenerator[A] with TransitionProbability[A]])(implicit rnd: Random)
+    extends ProposalGenerator[A] with TransitionProbability[A] {
+
+  override def propose(current: A): A = {
+    proposals.foldLeft(current) { (z: A, g: ProposalGenerator[A]) => g.propose(z) }
+  }
+
+  /** transition from to */
+  override def logTransitionProbability(from: A, to: A): Double = {
+    proposals.foldLeft(0.0) { (z, g) => z + g.logTransitionProbability(from, to) }
+  }
+
+  override def toString = {
+    val s = new StringBuilder("CombinedProposal(")
+    val firstNames = proposals.iterator.slice(0, 2).map(_.toString).mkString(",")
+    s.append(firstNames)
+    if (proposals.length > 2)
+      s.append(",...")
+    s.append(")")
+    s.toString()
+  }
+}
+
+object CombinedProposal {
+  def apply[A](proposals: IndexedSeq[(ProposalGenerator[A] with TransitionProbability[A])])(implicit rnd: Random) = new CombinedProposal[A](proposals)
+}

--- a/src/main/scala/scalismo/sampling/proposals/MetropolisFilterProposals.scala
+++ b/src/main/scala/scalismo/sampling/proposals/MetropolisFilterProposals.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2016 University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package scalismo.sampling.proposals
+
+import scalismo.sampling._
+import scalismo.sampling.algorithms.MetropolisHastings
+import scalismo.sampling.loggers.{ AcceptRejectLogger, SilentLogger }
+
+import scala.util.Random
+
+/** Metropolis Filter Proposal with no correction */
+class MetropolisFilterProposal[A](val generator: ProposalGenerator[A] with TransitionRatio[A],
+  val evaluator: DistributionEvaluator[A],
+  val logger: AcceptRejectLogger[A])(implicit random: Random)
+    extends ProposalGenerator[A] with UnitTransition[A] {
+
+  private val mH = MetropolisHastings(generator, evaluator, logger)
+
+  override def propose(current: A): A = mH.next(current)
+
+  override def toString = s"MetropolisFilterProposal($generator,$evaluator)"
+}
+
+object MetropolisFilterProposal {
+  def apply[A](generator: ProposalGenerator[A] with TransitionRatio[A],
+    evaluator: DistributionEvaluator[A],
+    logger: AcceptRejectLogger[A])(implicit random: Random) = new MetropolisFilterProposal[A](generator, evaluator, logger)
+
+  def apply[A](generator: ProposalGenerator[A] with TransitionRatio[A],
+    evaluator: DistributionEvaluator[A])(implicit random: Random) = new MetropolisFilterProposal[A](generator, evaluator, new SilentLogger[A])
+
+}
+
+/** Metropolis Filter Proposal corrected with transition probability */
+class CorrectedMetropolisFilterProposal[A](val generator: ProposalGenerator[A] with TransitionRatio[A],
+  val evaluator: DistributionEvaluator[A],
+  val logger: AcceptRejectLogger[A])(implicit random: Random)
+    extends ProposalGenerator[A] with TransitionProbability[A] {
+
+  private val mH = MetropolisHastings(generator, evaluator, logger)
+
+  override def propose(current: A): A = mH.next(current)
+
+  override def logTransitionRatio(from: A, to: A): Double = {
+    evaluator.logValue(to) - evaluator.logValue(from)
+  }
+
+  override def logTransitionProbability(from: A, to: A): Double = {
+    evaluator.logValue(to)
+  }
+
+  override def toString = s"MetropolisHastingsFilterProposal($generator,$evaluator)"
+
+}
+
+object CorrectedMetropolisFilterProposal {
+  def apply[A](generator: ProposalGenerator[A] with TransitionRatio[A],
+    evaluator: DistributionEvaluator[A],
+    logger: AcceptRejectLogger[A])(implicit random: Random) = new CorrectedMetropolisFilterProposal[A](generator, evaluator, logger)
+
+  def apply[A](generator: ProposalGenerator[A] with TransitionRatio[A],
+    evaluator: DistributionEvaluator[A])(implicit random: Random) = new CorrectedMetropolisFilterProposal[A](generator, evaluator, new SilentLogger[A])
+
+}

--- a/src/main/scala/scalismo/sampling/proposals/MixtureProposal.scala
+++ b/src/main/scala/scalismo/sampling/proposals/MixtureProposal.scala
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2016 University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package scalismo.sampling.proposals
+
+import scalismo.sampling.{ ProposalGenerator, SymmetricTransition, TransitionProbability }
+
+import scala.util.Random
+
+/** mixture of proposals: mixture distribution of multiple proposal distributions */
+class MixtureProposal[A](proposals: IndexedSeq[(Double, ProposalGenerator[A])])(implicit rnd: Random)
+    extends ProposalGenerator[A] {
+
+  /** mixture components */
+  val generators = proposals.map(_._2)
+
+  val mixtureFactors = {
+    val f = proposals.map(_._1)
+    val totalP = f.sum
+    f.map(c => c / totalP)
+  }
+
+  // cumsum
+  protected val p = mixtureFactors.scanLeft(0.0)((t, p) => t + p).tail
+  // keep state: last active proposal, useful for printing only
+  private var lastActive = 0
+
+  override def propose(current: A): A = {
+    val r = rnd.nextDouble()
+    val i = p.indexWhere(p => p >= r) // find first element larger than random, use l
+    lastActive = i
+    generators(i).propose(current)
+  }
+
+  override def toString = generators(lastActive).toString
+}
+
+/** mixture with transition probabilities */
+private class MixtureProposalWithTransition[A](proposals: IndexedSeq[(Double, ProposalGenerator[A] with TransitionProbability[A])])(implicit rnd: Random)
+    extends MixtureProposal[A](proposals) with TransitionProbability[A] {
+
+  override val generators = proposals.map(_._2)
+
+  override def logTransitionProbability(from: A, to: A): Double = {
+    val transitions = generators.map(g => g.logTransitionProbability(from, to))
+    if (transitions.exists(_.isNaN))
+      throw new Exception("NaN transition probability encountered!")
+    if (transitions.exists(!_.isInfinite)) {
+      val maxExpo = transitions.max
+      val sum = mixtureFactors.zip(transitions).map { case (f, t) => f * math.exp(t - maxExpo) }.sum
+      val fwd = math.log(sum) + maxExpo
+      fwd
+    } else
+      Double.NegativeInfinity
+  }
+}
+
+object MixtureProposal {
+  /** generate a mixture proposal */
+  def fromProposals[A](proposals: (Double, ProposalGenerator[A])*)(implicit rnd: Random): MixtureProposal[A] = new MixtureProposal[A](proposals.toIndexedSeq)
+
+  /** mixture distribution of proposals with a transition probability */
+  def fromProposalsWithTransition[A](proposals: (Double, ProposalGenerator[A] with TransitionProbability[A])*)(implicit rnd: Random): MixtureProposal[A] with TransitionProbability[A] = new MixtureProposalWithTransition[A](proposals.toIndexedSeq)
+
+  /** mixture of symmetric proposals (mixture distribution) */
+  def fromSymmetricProposals[A](proposals: (Double, ProposalGenerator[A] with SymmetricTransition[A])*)(implicit rnd: Random): MixtureProposal[A] with SymmetricTransition[A] = new MixtureProposal[A](proposals.toIndexedSeq) with SymmetricTransition[A]
+
+  /** mixture of symmetric proposals (mixture distribution) with a transition probability */
+  def fromSymmetricProposalsWithTransition[A](proposals: (Double, ProposalGenerator[A] with TransitionProbability[A] with SymmetricTransition[A])*)(implicit rnd: Random): MixtureProposal[A] with TransitionProbability[A] with SymmetricTransition[A] = new MixtureProposalWithTransition[A](proposals.toIndexedSeq) with SymmetricTransition[A]
+
+  /** create a mixture proposal using the simplified operator syntax: 0.4 *: prop1 + 0.6 *: prop2 */
+  def apply[A](builder: implicits.MixtureBuilder[A])(implicit rnd: Random): MixtureProposal[A] with TransitionProbability[A] = builder.toMixtureProposal
+
+  /** implicit conversions for simple building: MixtureProposal(0.5 *: prop1 + 0.25 *: prop2 + 0.25 *: prop3) - only for ProposalGenerator[A] with TransitionProbability[A] */
+  object implicits {
+
+    import scala.language.implicitConversions
+
+    implicit def toComponent[A](proposal: ProposalGenerator[A] with TransitionProbability[A]): MixtureComponent[A] = new MixtureComponent[A](proposal, 1)
+
+    implicit def toBuilder[A](comp: MixtureComponent[A]): MixtureBuilder[A] = new MixtureBuilder[A](comp)
+
+    implicit def toProposal[A](builder: MixtureBuilder[A])(implicit rnd: Random): MixtureProposal[A] with TransitionProbability[A] = builder.toMixtureProposal
+
+    case class MixtureComponent[A](proposal: ProposalGenerator[A] with TransitionProbability[A], factor: Double = 1.0) {
+      def *:(f: Float) = MixtureComponent(proposal, factor * f)
+
+      def *:(f: Double) = MixtureComponent(proposal, factor * f)
+
+      def :*(f: Float) = MixtureComponent(proposal, factor * f)
+
+      def :*(f: Double) = MixtureComponent(proposal, factor * f)
+
+      def +(other: MixtureComponent[A]) = new MixtureBuilder[A](this, other)
+
+      def +(other: ProposalGenerator[A] with TransitionProbability[A]) = new MixtureBuilder[A](this, other)
+
+      def tupled = (factor, proposal)
+    }
+
+    class MixtureBuilder[A](comps: MixtureComponent[A]*) {
+      def +(other: MixtureComponent[A]): MixtureBuilder[A] = new MixtureBuilder[A](comps :+ other: _*)
+
+      def +(other: ProposalGenerator[A] with TransitionProbability[A]): MixtureBuilder[A] = this + MixtureComponent(other)
+
+      def toMixtureProposal(implicit rnd: Random): MixtureProposal[A] with TransitionProbability[A] = MixtureProposal.fromProposalsWithTransition(comps.map(_.tupled): _*)
+    }
+  }
+}

--- a/src/main/scala/scalismo/sampling/proposals/UnitTransitionProposal.scala
+++ b/src/main/scala/scalismo/sampling/proposals/UnitTransitionProposal.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2016 University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package scalismo.sampling.proposals
+
+import scalismo.sampling.{ ProposalGenerator, UnitTransition }
+
+import scala.language.implicitConversions
+
+/** wraps an arbitrary proposal in a symmetric one with unit transition ratio and probabilities - use with care! */
+class UnitTransitionProposal[A](proposal: ProposalGenerator[A]) extends ProposalGenerator[A] with UnitTransition[A] {
+  /** draw a sample from this proposal distribution, may depend on current state */
+  override def propose(current: A): A = proposal.propose(current)
+}
+
+object UnitTransitionProposal {
+  def apply[A](proposal: ProposalGenerator[A]) = new UnitTransitionProposal[A](proposal)
+
+  /** implicit attachment of "withUnitTransition" to each proposal */
+  object implicits {
+    implicit def toUTProposal[A](proposal: ProposalGenerator[A]): UTProposal[A] = new UTProposal[A](proposal)
+
+    class UTProposal[A](proposal: ProposalGenerator[A]) {
+      def withUnitTransition: ProposalGenerator[A] with UnitTransition[A] = UnitTransitionProposal(proposal)
+    }
+  }
+}


### PR DESCRIPTION
# MCMC sampling library `scalismo-sampling`

Do approximate inference with the Metropolis-Hastings algorithm:

- Bayesian fitting: find the posterior distribution rather than only a single optimum, probabilistic problem view with likelihoods and priors
- Propose-and-Verify architecture: split inference into proposing new parameters and a separate verification => can integrate unreliable proposals
- Filtering: step-by-step integration with likelihoods, allows you to build fitters with complex targets, expressed through individual, independent likelihoods, e.g. landmarks and image

Software contains: 

- Markov chain interfaces, parametrized over sample type
- Metropolis(-Hastings) algorithm with interfaces for `ProposalGenerator` and `DistributionEvaluator`
- `MixtureProposal` to combine different proposals
- Logging functionality for the chains
- Some implicit constructors for easier access