### PR TITLE
renamed SymmetricTransition to SymmetricTransitionRatio

### DIFF
--- a/src/main/scala/scalismo/sampling/ProposalGenerator.scala
+++ b/src/main/scala/scalismo/sampling/ProposalGenerator.scala
@@ -28,7 +28,7 @@ trait TransitionRatio[A] {
 }
 
 /** symmetric transition: equal forward and backward transition probability */
-trait SymmetricTransition[A] extends TransitionRatio[A] {
+trait SymmetricTransitionRatio[A] extends TransitionRatio[A] {
   override def logTransitionRatio(from: A, to: A) = 0.0
 }
 
@@ -53,7 +53,10 @@ trait TransitionProbability[A] extends TransitionRatio[A] {
 }
 
 /** trait to express a unit transition probability (rarely appropriate) */
-trait UnitTransition[A] extends TransitionProbability[A] with SymmetricTransition[A] {
+trait UnitTransition[A] extends TransitionProbability[A] with SymmetricTransitionRatio[A] {
   /** fixed unit value for transition probability - careful when in use with correction */
   override def logTransitionProbability(from: A, to: A) = 0.0
 }
+
+/** trait to express a symmetric transition probability (normal perturbation for example)*/
+trait SymmetricTransition[A] extends TransitionProbability[A] with SymmetricTransitionRatio[A]

--- a/src/main/scala/scalismo/sampling/algorithms/Metropolis.scala
+++ b/src/main/scala/scalismo/sampling/algorithms/Metropolis.scala
@@ -25,7 +25,7 @@ import scala.util.Random
  * Metropolis algorithm (MCMC), provides samples from the evaluator distribution by drawing from generator and stochastic accept/reject decisions
  * generator needs to be symmetric
  */
-class Metropolis[A] protected (val generator: ProposalGenerator[A] with SymmetricTransition[A],
+class Metropolis[A] protected (val generator: ProposalGenerator[A] with SymmetricTransitionRatio[A],
     val evaluator: DistributionEvaluator[A],
     val logger: AcceptRejectLogger[A])(implicit val random: Random) extends MarkovChain[A] {
   // next sample
@@ -50,12 +50,12 @@ class Metropolis[A] protected (val generator: ProposalGenerator[A] with Symmetri
 
 object Metropolis {
   /** create a Metropolis MCMC chain, needs a symmetric proposal distribution, with logger attached */
-  def apply[A](generator: ProposalGenerator[A] with SymmetricTransition[A],
+  def apply[A](generator: ProposalGenerator[A] with SymmetricTransitionRatio[A],
     evaluator: DistributionEvaluator[A],
     logger: AcceptRejectLogger[A])(implicit random: Random) = new Metropolis[A](generator, evaluator, logger)
 
   /** create a Metropolis MCMC chain without a logger */
-  def apply[A](generator: ProposalGenerator[A] with SymmetricTransition[A],
+  def apply[A](generator: ProposalGenerator[A] with SymmetricTransitionRatio[A],
     evaluator: DistributionEvaluator[A])(implicit random: Random) = new Metropolis[A](generator, evaluator, new SilentLogger[A]())
 }
 

--- a/src/main/scala/scalismo/sampling/proposals/MixtureProposal.scala
+++ b/src/main/scala/scalismo/sampling/proposals/MixtureProposal.scala
@@ -15,7 +15,7 @@
  */
 package scalismo.sampling.proposals
 
-import scalismo.sampling.{ ProposalGenerator, SymmetricTransitionRatio, TransitionProbability }
+import scalismo.sampling.{ ProposalGenerator, SymmetricTransition, SymmetricTransitionRatio, TransitionProbability }
 
 import scala.util.Random
 
@@ -78,7 +78,7 @@ object MixtureProposal {
   def fromSymmetricProposals[A](proposals: (Double, ProposalGenerator[A] with SymmetricTransitionRatio[A])*)(implicit rnd: Random): MixtureProposal[A] with SymmetricTransitionRatio[A] = new MixtureProposal[A](proposals.toIndexedSeq) with SymmetricTransitionRatio[A]
 
   /** mixture of symmetric proposals (mixture distribution) with a transition probability */
-  def fromSymmetricProposalsWithTransition[A](proposals: (Double, ProposalGenerator[A] with TransitionProbability[A] with SymmetricTransitionRatio[A])*)(implicit rnd: Random): MixtureProposal[A] with TransitionProbability[A] with SymmetricTransitionRatio[A] = new MixtureProposalWithTransition[A](proposals.toIndexedSeq) with SymmetricTransitionRatio[A]
+  def fromSymmetricProposalsWithTransition[A](proposals: (Double, ProposalGenerator[A] with SymmetricTransition[A])*)(implicit rnd: Random): MixtureProposal[A] with SymmetricTransition[A] = new MixtureProposalWithTransition[A](proposals.toIndexedSeq) with SymmetricTransition[A]
 
   /** create a mixture proposal using the simplified operator syntax: 0.4 *: prop1 + 0.6 *: prop2 */
   def apply[A](builder: implicits.MixtureBuilder[A])(implicit rnd: Random): MixtureProposal[A] with TransitionProbability[A] = builder.toMixtureProposal

--- a/src/main/scala/scalismo/sampling/proposals/MixtureProposal.scala
+++ b/src/main/scala/scalismo/sampling/proposals/MixtureProposal.scala
@@ -15,7 +15,7 @@
  */
 package scalismo.sampling.proposals
 
-import scalismo.sampling.{ ProposalGenerator, SymmetricTransition, TransitionProbability }
+import scalismo.sampling.{ ProposalGenerator, SymmetricTransitionRatio, TransitionProbability }
 
 import scala.util.Random
 
@@ -75,10 +75,10 @@ object MixtureProposal {
   def fromProposalsWithTransition[A](proposals: (Double, ProposalGenerator[A] with TransitionProbability[A])*)(implicit rnd: Random): MixtureProposal[A] with TransitionProbability[A] = new MixtureProposalWithTransition[A](proposals.toIndexedSeq)
 
   /** mixture of symmetric proposals (mixture distribution) */
-  def fromSymmetricProposals[A](proposals: (Double, ProposalGenerator[A] with SymmetricTransition[A])*)(implicit rnd: Random): MixtureProposal[A] with SymmetricTransition[A] = new MixtureProposal[A](proposals.toIndexedSeq) with SymmetricTransition[A]
+  def fromSymmetricProposals[A](proposals: (Double, ProposalGenerator[A] with SymmetricTransitionRatio[A])*)(implicit rnd: Random): MixtureProposal[A] with SymmetricTransitionRatio[A] = new MixtureProposal[A](proposals.toIndexedSeq) with SymmetricTransitionRatio[A]
 
   /** mixture of symmetric proposals (mixture distribution) with a transition probability */
-  def fromSymmetricProposalsWithTransition[A](proposals: (Double, ProposalGenerator[A] with TransitionProbability[A] with SymmetricTransition[A])*)(implicit rnd: Random): MixtureProposal[A] with TransitionProbability[A] with SymmetricTransition[A] = new MixtureProposalWithTransition[A](proposals.toIndexedSeq) with SymmetricTransition[A]
+  def fromSymmetricProposalsWithTransition[A](proposals: (Double, ProposalGenerator[A] with TransitionProbability[A] with SymmetricTransitionRatio[A])*)(implicit rnd: Random): MixtureProposal[A] with TransitionProbability[A] with SymmetricTransitionRatio[A] = new MixtureProposalWithTransition[A](proposals.toIndexedSeq) with SymmetricTransitionRatio[A]
 
   /** create a mixture proposal using the simplified operator syntax: 0.4 *: prop1 + 0.6 *: prop2 */
   def apply[A](builder: implicits.MixtureBuilder[A])(implicit rnd: Random): MixtureProposal[A] with TransitionProbability[A] = builder.toMixtureProposal


### PR DESCRIPTION
Currently one can define a proposal with UnitTransition as such:

case class Proposal(..) extends ProposalGenerator[A] with UnitTransition[A] 

while for a symmetric one :

case class Proposal(..) extends ProposalGenerator[A] with TransitionProbability[A] with SymmetricTransition[A]

since SymmetricTransition is in fact a TransitionRatio and not a TransitionProbability. 

This PR hopefully harmonizes the naming.