### PR TITLE
Introduce new random object that acts as a default source of randomness

### DIFF
--- a/src/main/scala/scalismo/mesh/BarycentricCoordinates.scala
+++ b/src/main/scala/scalismo/mesh/BarycentricCoordinates.scala
@@ -16,9 +16,9 @@
 package scalismo.mesh
 
 import scalismo.geometry.{ Point, _2D, _3D, Vector }
+import scalismo.utils.Random
 
 import scala.annotation.switch
-import scala.util.Random
 
 /** barycentric coordinates: localization within triangles */
 case class BarycentricCoordinates(a: Double, b: Double, c: Double) {
@@ -101,12 +101,9 @@ object BarycentricCoordinates {
   }
 
   /** Generate random barycentric coordinates, guaranteed to lie within the triangle, uniform distribution */
-  def randomUniform(seed: Int): BarycentricCoordinates = randomUniform(new Random(seed))
-
-  /** Generate random barycentric coordinates, guaranteed to lie within the triangle, uniform distribution */
-  def randomUniform(generator: Random): BarycentricCoordinates = {
-    val s = generator.nextDouble()
-    val t = generator.nextDouble()
+  def randomUniform(implicit random: Random): BarycentricCoordinates = {
+    val s = random.scalaRandom.nextDouble()
+    val t = random.scalaRandom.nextDouble()
     if (s + t < 1.0)
       new BarycentricCoordinates(s, t, 1.0 - s - t)
     else

--- a/src/main/scala/scalismo/mesh/LineMesh.scala
+++ b/src/main/scala/scalismo/mesh/LineMesh.scala
@@ -19,8 +19,6 @@ package scalismo.mesh
 import scalismo.common.{ PointId, UnstructuredPointsDomain, Cell }
 import scalismo.geometry._
 
-import scala.util.Random
-
 /**
  * Represents a line segment defined by two points.
  */

--- a/src/main/scala/scalismo/mesh/TriangleMesh.scala
+++ b/src/main/scala/scalismo/mesh/TriangleMesh.scala
@@ -18,6 +18,7 @@ package scalismo.mesh
 import scalismo.common._
 import scalismo.geometry._
 import scalismo.geometry.Vector._
+import scalismo.utils.Random
 
 import scala.language.implicitConversions
 
@@ -175,14 +176,13 @@ case class TriangleMesh3D(pointSet: UnstructuredPointsDomain[_3D], triangulation
    *  @param t Triangle cell in which to draw a random point
    *  @param seed Seed value for the random generator
    */
-  def samplePointInTriangleCell(t: TriangleCell, seed: Int): Point[_3D] = {
+  def samplePointInTriangleCell(t: TriangleCell)(implicit rnd: Random): Point[_3D] = {
     val A = pointSet.point(t.ptId1).toVector
     val B = pointSet.point(t.ptId2).toVector
     val C = pointSet.point(t.ptId3).toVector
 
-    val rand = new scala.util.Random(seed)
-    val u = rand.nextDouble()
-    val d = rand.nextDouble()
+    val u = rnd.scalaRandom.nextDouble()
+    val d = rnd.scalaRandom.nextDouble()
     val v = if (d + u <= 1.0) d else 1.0 - u
 
     val s = A * u + B * v + C * (1.0 - (u + v))

--- a/src/main/scala/scalismo/numerics/RandomSVD.scala
+++ b/src/main/scala/scalismo/numerics/RandomSVD.scala
@@ -18,7 +18,7 @@ package scalismo.numerics
 import breeze.linalg.qr.QR
 import breeze.linalg.svd.SVD
 import breeze.linalg.{ diag, DenseMatrix, DenseVector, norm }
-import scalismo.utils.Benchmark
+import scalismo.utils.{ Random, Benchmark }
 
 /**
  * Implementation of a Randomized approach for SVD,
@@ -28,7 +28,7 @@ import scalismo.utils.Benchmark
  */
 object RandomSVD {
 
-  def computeSVD(A: DenseMatrix[Double], k: Int): (DenseMatrix[Double], DenseVector[Double], DenseMatrix[Double]) = {
+  def computeSVD(A: DenseMatrix[Double], k: Int)(implicit rand: Random): (DenseMatrix[Double], DenseVector[Double], DenseMatrix[Double]) = {
 
     require(A.rows == A.cols) // might be removed later (check in Halko paper)
 
@@ -36,7 +36,7 @@ object RandomSVD {
     val l = k + 5
     val m = A.rows
 
-    val standardNormal = breeze.stats.distributions.Gaussian(0, 1)
+    val standardNormal = rand.breezeRandomGaussian(0, 1)
 
     // create a gaussian random matrix
     val Omega = DenseMatrix.zeros[Double](m, l).map(_ => standardNormal.draw())

--- a/src/main/scala/scalismo/numerics/Sampler.scala
+++ b/src/main/scala/scalismo/numerics/Sampler.scala
@@ -33,7 +33,7 @@ trait Sampler[D <: Dim] {
    * sample n points (x_1, ... x_n), yielding an sequence of (x_i, p(x_i)), i=1..n , p is the probability density function
    * according to which the points are sampled
    */
-  def sample: IndexedSeq[(Point[D], Double)]
+  def sample()(implicit rand: Random): IndexedSeq[(Point[D], Double)]
 
   def volumeOfSampleRegion: Double
 }
@@ -43,35 +43,33 @@ case class GridSampler[D <: Dim: NDSpace](domain: DiscreteImageDomain[D]) extend
   override val numberOfPoints = domain.numberOfPoints
 
   val p = 1.0 / volumeOfSampleRegion
-  override def sample = {
+  override def sample()(implicit rand: Random) = {
     domain.points.toIndexedSeq.map(pt => (pt, p))
   }
 }
 
-case class UniformSampler[D <: Dim: NDSpace](domain: BoxDomain[D], numberOfPoints: Int)(implicit rand: Random) extends Sampler[D] {
+case class UniformSampler[D <: Dim: NDSpace](domain: BoxDomain[D], numberOfPoints: Int) extends Sampler[D] {
 
   def volumeOfSampleRegion = domain.volume
   val p = 1.0 / domain.volume
 
-  val ndSpace = implicitly[NDSpace[D]]
+  override def sample()(implicit rand: Random) = {
+    val ndSpace = implicitly[NDSpace[D]]
+    val randGens = for (i <- (0 until ndSpace.dimensionality)) yield {
+      rand.breezeRandomUnform(domain.origin(i), domain.oppositeCorner(i))
+    }
 
-  val randGens = for (i <- (0 until ndSpace.dimensionality)) yield {
-    rand.breezeRandomUnform(domain.origin(i), domain.oppositeCorner(i))
-  }
-
-  override def sample = {
     for (_ <- 0 until numberOfPoints) yield (Point.apply[D](randGens.map(r => r.draw()).toArray), p)
   }
 }
 
-case class RandomMeshSampler3D(mesh: TriangleMesh[_3D], numberOfPoints: Int, seed: Int)(implicit rand: Random) extends Sampler[_3D] {
+case class RandomMeshSampler3D(mesh: TriangleMesh[_3D], numberOfPoints: Int, seed: Int) extends Sampler[_3D] {
 
   val p = 1.0 / mesh.area
-  val mt = new MersenneTwister()
-  mt.setSeed(seed)
+
   // should be replaced with real mesh volume
   val volumeOfSampleRegion = mesh.area
-  def sample = {
+  def sample()(implicit rand: Random) = {
     val points = mesh.pointSet.points.toIndexedSeq
     val distrDim1 = rand.breezeRandomUnform(0, mesh.pointSet.numberOfPoints)
     val pts = (0 until numberOfPoints).map(i => (points(distrDim1.draw().toInt), p))
@@ -106,12 +104,12 @@ case class PointsWithLikelyCorrespondenceSampler(gp: GaussianProcess[_3D, Vector
 
   override val volumeOfSampleRegion = 1.0
   override val numberOfPoints = pts.size
-  override def sample = {
+  override def sample()(implicit rand: Random) = {
     println(s"Sampled: $numberOfPoints"); pts
   }
 }
 
-case class UniformMeshSampler3D(mesh: TriangleMesh[_3D], numberOfPoints: Int, seed: Int)(implicit rnd: Random) extends Sampler[_3D] {
+case class UniformMeshSampler3D(mesh: TriangleMesh[_3D], numberOfPoints: Int) extends Sampler[_3D] {
 
   override val volumeOfSampleRegion: Double = mesh.area
 
@@ -122,10 +120,10 @@ case class UniformMeshSampler3D(mesh: TriangleMesh[_3D], numberOfPoints: Int, se
       sum + mesh.computeTriangleArea(cell)
   }.tail.toArray
 
-  override def sample = {
+  override def sample()(implicit rand: Random) = {
     val samplePoints = {
       for (i <- 0 until numberOfPoints) yield {
-        val drawnValue = rnd.scalaRandom.nextDouble() * mesh.area
+        val drawnValue = rand.scalaRandom.nextDouble() * mesh.area
         val indexOrInsertionPoint = util.Arrays.binarySearch(accumulatedAreas, drawnValue)
         val index = if (indexOrInsertionPoint >= 0) indexOrInsertionPoint else -(indexOrInsertionPoint + 1)
         assert(index >= 0 && index < accumulatedAreas.length)
@@ -137,27 +135,37 @@ case class UniformMeshSampler3D(mesh: TriangleMesh[_3D], numberOfPoints: Int, se
   }
 }
 
-case class FixedPointsUniformMeshSampler3D(mesh: TriangleMesh[_3D], numberOfPoints: Int, seed: Int) extends Sampler[_3D] {
+case class FixedPointsUniformMeshSampler3D(mesh: TriangleMesh[_3D], numberOfPoints: Int) extends Sampler[_3D] {
   override val volumeOfSampleRegion = mesh.area
-  val samplePoints = UniformMeshSampler3D(mesh, numberOfPoints, seed).sample
-  override def sample = samplePoints
+  val samplePoints = UniformMeshSampler3D(mesh, numberOfPoints).sample()
+  override def sample()(implicit rand: Random) = samplePoints
 }
 
-case class FixedPointsMeshSampler3D(mesh: TriangleMesh[_3D], numberOfPoints: Int, seed: Int) extends Sampler[_3D] {
+case class FixedPointsMeshSampler3D(mesh: TriangleMesh[_3D], numberOfPoints: Int) extends Sampler[_3D] {
 
   val volumeOfSampleRegion = mesh.area
   val p = 1.0 / mesh.area
 
-  implicit val random = Random(42)
   val meshPoints = mesh.pointSet.points.toIndexedSeq
-  val samplePoints = for (i <- 0 until numberOfPoints) yield {
-    val idx = random.scalaRandom.nextInt(mesh.pointSet.numberOfPoints)
+
+  def samplePoints(rand: Random) = for (i <- 0 until numberOfPoints) yield {
+    val idx = rand.scalaRandom.nextInt(mesh.pointSet.numberOfPoints)
     meshPoints(idx)
   }
-  assert(samplePoints.size == numberOfPoints)
 
-  def sample = {
-    samplePoints.map(pt => (pt, p))
+  var lastSampledPoints: Option[IndexedSeq[(Point[_3D], Double)]] = None
+
+  def sample()(implicit rand: Random) = {
+
+    lastSampledPoints match {
+      case Some(lastSampledPoints) => lastSampledPoints
+      case None => {
+        val pts = samplePoints(rand).map(pt => (pt, p))
+        lastSampledPoints = Some(pts)
+        pts
+      }
+
+    }
   }
 }
 

--- a/src/main/scala/scalismo/registration/Registration.scala
+++ b/src/main/scala/scalismo/registration/Registration.scala
@@ -18,9 +18,10 @@ package scalismo.registration
 
 import TransformationSpace.ParameterVector
 import breeze.linalg.{ DenseVector, convert }
-import scalismo.geometry.{ Point, NDSpace, Dim }
+import scalismo.geometry.{ _3D, Point, NDSpace, Dim }
 import scalismo.image.{ DifferentiableScalarImage, ScalarImage }
 import scalismo.numerics._
+import scalismo.utils.Random
 
 case class RegistrationConfiguration[D <: Dim: NDSpace, TS <: TransformationSpace[D] with DifferentiableTransforms[D]](
   optimizer: Optimizer,
@@ -101,7 +102,17 @@ object Registration {
 
     val numberOfPoints = sampler.numberOfPoints
     def volumeOfSampleRegion = sampler.volumeOfSampleRegion
-    override lazy val sample: IndexedSeq[(Point[D], Double)] = sampler.sample
+    var lastSampledPoints: Option[IndexedSeq[(Point[D], Double)]] = None
+
+    override def sample()(implicit rnd: Random): IndexedSeq[(Point[D], Double)] = {
+      lastSampledPoints match {
+        case Some(lastSampledPoints) => lastSampledPoints
+        case None => {
+          lastSampledPoints = Some(sampler.sample())
+          lastSampledPoints.get
+        }
+      }
+    }
   }
 
 }

--- a/src/main/scala/scalismo/sampling/algorithms/Metropolis.scala
+++ b/src/main/scala/scalismo/sampling/algorithms/Metropolis.scala
@@ -17,9 +17,9 @@ package scalismo.sampling.algorithms
 
 import scalismo.sampling._
 import scalismo.sampling.loggers.{ AcceptRejectLogger, SilentLogger }
+import scalismo.utils.Random
 
 import scala.math.exp
-import scala.util.Random
 
 /**
  * Metropolis algorithm (MCMC), provides samples from the evaluator distribution by drawing from generator and stochastic accept/reject decisions
@@ -38,7 +38,7 @@ class Metropolis[A] protected (val generator: ProposalGenerator[A] with Symmetri
     // acceptance probability
     val a = proposalP - currentP
     // accept or reject
-    if (a > 0.0 || random.nextDouble() < exp(a)) {
+    if (a > 0.0 || random.scalaRandom.nextDouble() < exp(a)) {
       logger.accept(current, proposal, generator, evaluator)
       proposal
     } else {
@@ -76,7 +76,7 @@ class MetropolisHastings[A] protected (val generator: ProposalGenerator[A] with 
     val a = proposalP - currentP - t
 
     // accept or reject
-    if (a > 0.0 || random.nextDouble() < exp(a)) {
+    if (a > 0.0 || random.scalaRandom.nextDouble() < exp(a)) {
       logger.accept(current, proposal, generator, evaluator)
       proposal
     } else {

--- a/src/main/scala/scalismo/sampling/proposals/CombinedProposal.scala
+++ b/src/main/scala/scalismo/sampling/proposals/CombinedProposal.scala
@@ -16,8 +16,7 @@
 package scalismo.sampling.proposals
 
 import scalismo.sampling.{ ProposalGenerator, TransitionProbability }
-
-import scala.util.Random
+import scalismo.utils.Random
 
 /**
  * Container for multiple ProposalGenerators stacked together, applied one after the other

--- a/src/main/scala/scalismo/sampling/proposals/MetropolisFilterProposals.scala
+++ b/src/main/scala/scalismo/sampling/proposals/MetropolisFilterProposals.scala
@@ -18,8 +18,7 @@ package scalismo.sampling.proposals
 import scalismo.sampling._
 import scalismo.sampling.algorithms.MetropolisHastings
 import scalismo.sampling.loggers.{ AcceptRejectLogger, SilentLogger }
-
-import scala.util.Random
+import scalismo.utils.Random
 
 /** Metropolis Filter Proposal with no correction */
 class MetropolisFilterProposal[A](val generator: ProposalGenerator[A] with TransitionRatio[A],

--- a/src/main/scala/scalismo/sampling/proposals/MixtureProposal.scala
+++ b/src/main/scala/scalismo/sampling/proposals/MixtureProposal.scala
@@ -16,8 +16,7 @@
 package scalismo.sampling.proposals
 
 import scalismo.sampling.{ ProposalGenerator, SymmetricTransition, TransitionProbability }
-
-import scala.util.Random
+import scalismo.utils.Random
 
 /** mixture of proposals: mixture distribution of multiple proposal distributions */
 class MixtureProposal[A](proposals: IndexedSeq[(Double, ProposalGenerator[A])])(implicit rnd: Random)
@@ -38,7 +37,7 @@ class MixtureProposal[A](proposals: IndexedSeq[(Double, ProposalGenerator[A])])(
   private var lastActive = 0
 
   override def propose(current: A): A = {
-    val r = rnd.nextDouble()
+    val r = rnd.scalaRandom.nextDouble()
     val i = p.indexWhere(p => p >= r) // find first element larger than random, use l
     lastActive = i
     generators(i).propose(current)

--- a/src/main/scala/scalismo/statisticalmodel/DiscreteGaussianProcess.scala
+++ b/src/main/scala/scalismo/statisticalmodel/DiscreteGaussianProcess.scala
@@ -20,6 +20,7 @@ import breeze.linalg.{ DenseMatrix, DenseVector }
 import scalismo.common._
 import scalismo.geometry._
 import scalismo.kernels.{ DiscreteMatrixValuedPDKernel, MatrixValuedPDKernel }
+import scalismo.utils.Random
 
 /**
  * A representation of a gaussian process, which is only defined on a discrete domain.
@@ -36,7 +37,7 @@ class DiscreteGaussianProcess[D <: Dim: NDSpace, Value] private[scalismo] (val m
 
   val outputDim = vectorizer.dim
 
-  def sample: DiscreteField[D, Value] = {
+  def sample()(implicit rand: Random): DiscreteField[D, Value] = {
     // define the mean and kernel matrix for the given points and construct the
     // corresponding MV Normal distribution, from which we then sample
 
@@ -45,7 +46,7 @@ class DiscreteGaussianProcess[D <: Dim: NDSpace, Value] private[scalismo] (val m
 
     val mvNormal = MultivariateNormalDistribution(mu, K)
 
-    val sampleVec = mvNormal.sample()
+    val sampleVec = mvNormal.sample
 
     // The sample is a vector. We convert it back to a discreteVectorField.
     DiscreteField.createFromDenseVector[D, Value](domain, sampleVec)

--- a/src/main/scala/scalismo/statisticalmodel/DiscreteLowRankGaussianProcess.scala
+++ b/src/main/scala/scalismo/statisticalmodel/DiscreteLowRankGaussianProcess.scala
@@ -17,7 +17,6 @@ package scalismo.statisticalmodel
 
 import breeze.linalg.svd.SVD
 import breeze.linalg.{ diag, *, DenseMatrix, DenseVector }
-import breeze.stats.distributions.Gaussian
 import scalismo.common._
 import scalismo.geometry._
 import scalismo.kernels.{ DiscreteMatrixValuedPDKernel, MatrixValuedPDKernel }
@@ -27,7 +26,7 @@ import scalismo.registration.Transformation
 import scalismo.statisticalmodel.DiscreteLowRankGaussianProcess._
 import scalismo.statisticalmodel.LowRankGaussianProcess.Eigenpair
 import scalismo.statisticalmodel.DiscreteLowRankGaussianProcess.{ Eigenpair => DiscreteEigenpair }
-import scalismo.utils.Memoize
+import scalismo.utils.{ Random, Memoize }
 
 /**
  * Represents a low-rank gaussian process, that is only defined at a finite, discrete set of points.
@@ -102,8 +101,8 @@ case class DiscreteLowRankGaussianProcess[D <: Dim: NDSpace, Value] private[scal
   /**
    * Discrete version of [[DiscreteLowRankGaussianProcess.sample]]
    */
-  override def sample: DiscreteField[D, Value] = {
-    val coeffs = for (_ <- 0 until rank) yield Gaussian(0, 1).draw()
+  override def sample()(implicit random: Random): DiscreteField[D, Value] = {
+    val coeffs = for (_ <- 0 until rank) yield random.breezeRandomGaussian(0, 1).draw()
     instance(DenseVector(coeffs.toArray))
   }
 

--- a/src/main/scala/scalismo/statisticalmodel/DiscreteLowRankGaussianProcess.scala
+++ b/src/main/scala/scalismo/statisticalmodel/DiscreteLowRankGaussianProcess.scala
@@ -190,11 +190,11 @@ case class DiscreteLowRankGaussianProcess[D <: Dim: NDSpace, Value] private[scal
 
       override val numberOfPoints = nNystromPoints
       val p = volumeOfSampleRegion / numberOfPoints
-      val randGen = new util.Random()
+
       val domainPoints = domain.points.toIndexedSeq
 
-      override def sample = {
-        val sampledPtIds = for (_ <- 0 until nNystromPoints) yield randGen.nextInt(domain.numberOfPoints)
+      override def sample()(implicit rand: Random) = {
+        val sampledPtIds = for (_ <- 0 until nNystromPoints) yield rand.scalaRandom.nextInt(domain.numberOfPoints)
         sampledPtIds.map(ptId => (domainPoints(ptId), p))
       }
     }

--- a/src/main/scala/scalismo/statisticalmodel/GaussianProcess.scala
+++ b/src/main/scala/scalismo/statisticalmodel/GaussianProcess.scala
@@ -20,7 +20,7 @@ import scalismo.common._
 import scalismo.geometry.Vector
 import scalismo.geometry._
 import scalismo.kernels._
-
+import scalismo.utils.Random
 /**
  * A gaussian process from a D dimensional input space, whose input values are points,
  * to a DO dimensional output space. The output space is a Euclidean vector space of dimensionality DO.
@@ -40,8 +40,8 @@ class GaussianProcess[D <: Dim: NDSpace, Value] protected (val mean: Field[D, Va
    *
    * Sample values of the Gaussian process evaluated at the given points.
    */
-  def sampleAtPoints(domain: DiscreteDomain[D]): DiscreteField[D, Value] = {
-    this.marginal(domain).sample
+  def sampleAtPoints(domain: DiscreteDomain[D])(implicit rand: Random): DiscreteField[D, Value] = {
+    this.marginal(domain).sample()
   }
 
   /**

--- a/src/main/scala/scalismo/statisticalmodel/LowRankGaussianProcess.scala
+++ b/src/main/scala/scalismo/statisticalmodel/LowRankGaussianProcess.scala
@@ -17,14 +17,13 @@ package scalismo.statisticalmodel
 
 import breeze.linalg.svd.SVD
 import breeze.linalg.{ diag, DenseMatrix, DenseVector }
-import breeze.stats.distributions.Gaussian
 import scalismo.common._
 import scalismo.geometry.{ Dim, NDSpace, Point, SquareMatrix, Vector }
 import scalismo.kernels.{ Kernel, MatrixValuedPDKernel }
 import scalismo.numerics.Sampler
 import scalismo.registration.RigidTransformation
 import scalismo.statisticalmodel.LowRankGaussianProcess.{ Eigenpair, KLBasis }
-import scalismo.utils.Memoize
+import scalismo.utils.{ Random, Memoize }
 
 /**
  *
@@ -66,17 +65,17 @@ class LowRankGaussianProcess[D <: Dim: NDSpace, Value](mean: Field[D, Value],
   /**
    * A random sample of the gaussian process
    */
-  def sample: Field[D, Value] = {
-    val coeffs = for (_ <- klBasis.indices) yield Gaussian(0, 1).draw()
+  def sample()(implicit rand: Random): Field[D, Value] = {
+    val coeffs = for (_ <- klBasis.indices) yield rand.breezeRandomGaussian(0, 1).draw()
     instance(DenseVector(coeffs.toArray))
   }
 
   /**
    * A random sample evaluated at the given points
    */
-  override def sampleAtPoints(domain: DiscreteDomain[D]): DiscreteField[D, Value] = {
+  override def sampleAtPoints(domain: DiscreteDomain[D])(implicit rand: Random): DiscreteField[D, Value] = {
     // TODO check that points are part of the domain
-    val aSample = sample
+    val aSample = sample()
     val values = domain.points.map(pt => aSample(pt))
     DiscreteField(domain, values.toIndexedSeq)
   }

--- a/src/main/scala/scalismo/statisticalmodel/MultivariateNormalDistribution.scala
+++ b/src/main/scala/scalismo/statisticalmodel/MultivariateNormalDistribution.scala
@@ -19,6 +19,7 @@ import breeze.linalg.svd.SVD
 import breeze.linalg._
 import scalismo.geometry.Vector
 import scalismo.geometry._
+import scalismo.utils.Random
 
 import scala.util.Try
 
@@ -37,7 +38,7 @@ private[statisticalmodel] trait MultivariateNormalDistributionLike[V, M] {
 
   def mahalanobisDistance(x: V): Double
 
-  def sample(): V
+  def sample()(implicit rand: Random): V
 }
 
 case class MultivariateNormalDistribution(mean: DenseVector[Double], cov: DenseMatrix[Double])
@@ -100,9 +101,9 @@ case class MultivariateNormalDistribution(mean: DenseVector[Double], cov: DenseM
     math.sqrt(x0 dot (covInv * x0))
   }
 
-  override def sample(): DenseVector[Double] = {
+  override def sample()(implicit rand: Random): DenseVector[Double] = {
 
-    val normalSamples = for (i <- 0 until dim) yield breeze.stats.distributions.Gaussian(0, 1).draw()
+    val normalSamples = for (i <- 0 until dim) yield rand.breezeRandomGaussian(0, 1).draw()
     val u = DenseVector[Double](normalSamples.toArray)
 
     mean + (root * u)
@@ -225,7 +226,7 @@ case class NDimensionalNormalDistribution[D <: Dim: NDSpace](mean: Vector[D], co
 
   override def dim: Int = implicitly[NDSpace[D]].dimensionality
 
-  override def sample(): Vector[D] = Vector.fromBreezeVector(impl.sample())
+  override def sample()(implicit rand: Random): Vector[D] = Vector.fromBreezeVector(impl.sample)
 
   override def principalComponents: Seq[(Vector[D], Double)] = impl.principalComponents.map { case (v, d) => (Vector.fromBreezeVector(v), d) }
 

--- a/src/main/scala/scalismo/statisticalmodel/StatisticalMeshModel.scala
+++ b/src/main/scala/scalismo/statisticalmodel/StatisticalMeshModel.scala
@@ -26,6 +26,7 @@ import scalismo.numerics.FixedPointsUniformMeshSampler3D
 import scalismo.registration.RigidTransformation
 import scalismo.statisticalmodel.DiscreteLowRankGaussianProcess.Eigenpair
 import scalismo.statisticalmodel.dataset.DataCollection
+import scalismo.utils.Random
 
 import scala.util.{ Failure, Success, Try }
 
@@ -57,7 +58,7 @@ case class StatisticalMeshModel private (referenceMesh: TriangleMesh[_3D], gp: D
    * draws a random shape.
    * @see [[DiscreteLowRankGaussianProcess.sample]]
    */
-  def sample = warpReference(gp.sample)
+  def sample()(implicit rand: Random) = warpReference(gp.sample())
 
   /**
    * returns the probability density for an instance of the model
@@ -235,7 +236,7 @@ object StatisticalMeshModel {
     )
     val newCov = modelGP.cov + biasModel.cov
     val newGP = GaussianProcess(newMean, newCov)
-    val sampler = FixedPointsUniformMeshSampler3D(model.referenceMesh, 2 * numBasisFunctions, 42)
+    val sampler = FixedPointsUniformMeshSampler3D(model.referenceMesh, 2 * numBasisFunctions)
     val newLowRankGP = LowRankGaussianProcess.approximateGP(newGP, sampler, numBasisFunctions)
     StatisticalMeshModel(model.referenceMesh, newLowRankGP)
   }

--- a/src/main/scala/scalismo/statisticalmodel/asm/ActiveShapeModel.scala
+++ b/src/main/scala/scalismo/statisticalmodel/asm/ActiveShapeModel.scala
@@ -23,6 +23,7 @@ import scalismo.mesh.TriangleMesh
 import scalismo.numerics.Sampler
 import scalismo.registration.{ LandmarkRegistration, RigidTransformation, RigidTransformationSpace, Transformation }
 import scalismo.statisticalmodel.{ MultivariateNormalDistribution, StatisticalMeshModel }
+import scalismo.utils.Random
 
 import scala.collection.immutable
 import scala.util.{ Failure, Try }
@@ -84,10 +85,10 @@ case class ActiveShapeModel(statisticalModel: StatisticalMeshModel, profiles: Pr
   /**
    * Returns a random sample mesh from the shape model, along with randomly sampled feature profiles at the profile points
    */
-  def sample(): ASMSample = {
+  def sample(implicit rand: Random): ASMSample = {
     val sampleMesh = statisticalModel.sample
     val randomProfilePoints = profiles.data.map(p => sampleMesh.pointSet.point(p.pointId))
-    val randomFeatures = profiles.data.map(_.distribution.sample())
+    val randomFeatures = profiles.data.map(_.distribution.sample)
     val featureField = DiscreteFeatureField(new UnstructuredPointsDomain3D(randomProfilePoints), randomFeatures)
     ASMSample(sampleMesh, featureField, featureExtractor)
   }
@@ -96,10 +97,10 @@ case class ActiveShapeModel(statisticalModel: StatisticalMeshModel, profiles: Pr
    * Utility function that allows to randomly sample different feature profiles, while keeping the profile points
    * Meant to allow to easily inspect/debug the feature distribution
    */
-  def sampleFeaturesOnly(): ASMSample = {
+  def sampleFeaturesOnly(implicit rand: Random): ASMSample = {
     val smean = statisticalModel.mean
     val meanProfilePoints = profiles.data.map(p => smean.pointSet.point(p.pointId))
-    val randomFeatures = profiles.data.map(_.distribution.sample())
+    val randomFeatures = profiles.data.map(_.distribution.sample)
     val featureField = DiscreteFeatureField(new UnstructuredPointsDomain3D(meanProfilePoints), randomFeatures)
     ASMSample(smean, featureField, featureExtractor)
   }

--- a/src/main/scala/scalismo/statisticalmodel/asm/ActiveShapeModel.scala
+++ b/src/main/scala/scalismo/statisticalmodel/asm/ActiveShapeModel.scala
@@ -85,8 +85,8 @@ case class ActiveShapeModel(statisticalModel: StatisticalMeshModel, profiles: Pr
   /**
    * Returns a random sample mesh from the shape model, along with randomly sampled feature profiles at the profile points
    */
-  def sample(implicit rand: Random): ASMSample = {
-    val sampleMesh = statisticalModel.sample
+  def sample()(implicit rand: Random): ASMSample = {
+    val sampleMesh = statisticalModel.sample()
     val randomProfilePoints = profiles.data.map(p => sampleMesh.pointSet.point(p.pointId))
     val randomFeatures = profiles.data.map(_.distribution.sample)
     val featureField = DiscreteFeatureField(new UnstructuredPointsDomain3D(randomProfilePoints), randomFeatures)
@@ -97,7 +97,7 @@ case class ActiveShapeModel(statisticalModel: StatisticalMeshModel, profiles: Pr
    * Utility function that allows to randomly sample different feature profiles, while keeping the profile points
    * Meant to allow to easily inspect/debug the feature distribution
    */
-  def sampleFeaturesOnly(implicit rand: Random): ASMSample = {
+  def sampleFeaturesOnly()(implicit rand: Random): ASMSample = {
     val smean = statisticalModel.mean
     val meanProfilePoints = profiles.data.map(p => smean.pointSet.point(p.pointId))
     val randomFeatures = profiles.data.map(_.distribution.sample)

--- a/src/main/scala/scalismo/statisticalmodel/dataset/DataCollection.scala
+++ b/src/main/scala/scalismo/statisticalmodel/dataset/DataCollection.scala
@@ -22,9 +22,9 @@ import scalismo.geometry.{ Dim, Point, _3D }
 import scalismo.io.MeshIO
 import scalismo.mesh.{ MeshMetrics, TriangleList, TriangleMesh, TriangleMesh3D }
 import scalismo.registration.{ LandmarkRegistration, Transformation }
+import scalismo.utils.Random
 
 import scala.annotation.tailrec
-import scala.util.Random
 
 private[dataset] case class CrossvalidationFold(trainingData: DataCollection, testingData: DataCollection)
 
@@ -47,13 +47,13 @@ case class DataItem[D <: Dim](info: String, transformation: Transformation[D])
  * @param dataItems Sequence of data items containing the required transformations to apply to the reference mesh in order to obtain
  * other elements of the dataset.
  */
-case class DataCollection(reference: TriangleMesh[_3D], dataItems: Seq[DataItem[_3D]]) {
+case class DataCollection(reference: TriangleMesh[_3D], dataItems: Seq[DataItem[_3D]])(implicit random: Random) {
 
   val size: Int = dataItems.size
 
   private[dataset] def createCrossValidationFolds(nFolds: Int): Seq[CrossvalidationFold] = {
 
-    val shuffledDataItems = Random.shuffle(dataItems)
+    val shuffledDataItems = random.scalaRandom.shuffle(dataItems)
     val foldSize = shuffledDataItems.size / nFolds
     val dataGroups = shuffledDataItems.grouped(foldSize).toSeq
 

--- a/src/main/scala/scalismo/utils/Random.scala
+++ b/src/main/scala/scalismo/utils/Random.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2015 University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package scalismo.utils
+
+import breeze.stats.distributions.{ ThreadLocalRandomGenerator, RandBasis }
+import org.apache.commons.math3.random.MersenneTwister
+
+/**
+  * A thin wrapper around different random number generators.
+  *
+  * The purpose of this class is to allow for a unified way of declaring methods that need a source
+  * of randomness. The idea is that any method that needs a source of randomness takes an implicit instance to this class as an argument.
+  * If the user does not specify an own implicit instance, the default source in the companion object is used.
+  * If the result should be deterministic, the user can define his/her own implicit instance with a fixed seed.
+  *
+  * @param seed The seed for the Random number generator
+  */
+case class Random(seed: Long) {
+
+  private val randBasis: RandBasis = new RandBasis(new ThreadLocalRandomGenerator(new MersenneTwister(seed)))
+
+  val scalaRandom: scala.util.Random = new scala.util.Random(seed)
+
+  def breezeRandomGaussian(mu: Double, sigma2: Double): breeze.stats.distributions.Rand[Double] = {
+    breeze.stats.distributions.Gaussian(mu, sigma2)(randBasis)
+  }
+
+  def breezeRandomUnform(a: Double, b: Double): breeze.stats.distributions.Rand[Double] = {
+    breeze.stats.distributions.Uniform(a, b)(randBasis)
+  }
+
+}
+
+object Random {
+
+  implicit val randomGenerator = Random(System.currentTimeMillis())
+
+}

--- a/src/main/scala/scalismo/utils/Random.scala
+++ b/src/main/scala/scalismo/utils/Random.scala
@@ -19,15 +19,15 @@ import breeze.stats.distributions.{ ThreadLocalRandomGenerator, RandBasis }
 import org.apache.commons.math3.random.MersenneTwister
 
 /**
-  * A thin wrapper around different random number generators.
-  *
-  * The purpose of this class is to allow for a unified way of declaring methods that need a source
-  * of randomness. The idea is that any method that needs a source of randomness takes an implicit instance to this class as an argument.
-  * If the user does not specify an own implicit instance, the default source in the companion object is used.
-  * If the result should be deterministic, the user can define his/her own implicit instance with a fixed seed.
-  *
-  * @param seed The seed for the Random number generator
-  */
+ * A thin wrapper around different random number generators.
+ *
+ * The purpose of this class is to allow for a unified way of declaring methods that need a source
+ * of randomness. The idea is that any method that needs a source of randomness takes an implicit instance to this class as an argument.
+ * If the user does not specify an own implicit instance, the default source in the companion object is used.
+ * If the result should be deterministic, the user can define his/her own implicit instance with a fixed seed.
+ *
+ * @param seed The seed for the Random number generator
+ */
 case class Random(seed: Long) {
 
   private val randBasis: RandBasis = new RandBasis(new ThreadLocalRandomGenerator(new MersenneTwister(seed)))

--- a/src/main/scala/scalismo/utils/VantagePointTree.scala
+++ b/src/main/scala/scalismo/utils/VantagePointTree.scala
@@ -16,7 +16,6 @@
 package scalismo.utils
 
 import scala.collection.mutable
-import scala.util.Random
 
 /** represents a metric to be used with the Vantage Point tree */
 trait Metric[A] {
@@ -132,21 +131,21 @@ object VantagePointTree {
   def apply[A](data: Iterable[A], metric: Metric[A], pivotSelector: Iterable[A] => A): VantagePointTree[A] = recursiveTreeBuilder(data, metric, pivotSelector)
 
   /** select a random element as pivot */
-  def randomPivotSelector[A](points: Iterable[A]): A = {
-    Random.shuffle(points).head
+  def randomPivotSelector[A](points: Iterable[A])(implicit random: Random): A = {
+    random.scalaRandom.shuffle(points).head
   }
 
   /** select first element as pivot */
   def firstPivotSelector[A](points: Iterable[A]): A = points.head
 
   /** select central element as pivot */
-  def centralPivotSelector[A](metric: Metric[A], samples: Int)(points: Iterable[A]): A = points.toSeq match {
+  def centralPivotSelector[A](metric: Metric[A], samples: Int)(points: Iterable[A])(implicit rand: Random): A = points.toSeq match {
     case Seq() => throw new RuntimeException("cannot select from empty seq!")
     case head +: Seq() => head
     case first +: second +: Seq() => first
     case _ =>
       // draw candidates, select the most central
-      val trials = Random.shuffle(points).take(math.min(samples, points.size))
+      val trials = rand.scalaRandom.shuffle(points).take(math.min(samples, points.size))
       def spread(pivot: A) = {
         val dists = points.toSeq map { p => metric(pivot, p) }
         val medianDistance = median(dists)

--- a/src/test/scala/scalismo/geometry/GeometryTests.scala
+++ b/src/test/scala/scalismo/geometry/GeometryTests.scala
@@ -17,11 +17,13 @@ package scalismo.geometry
 
 import breeze.linalg.{ DenseMatrix, DenseVector }
 import scalismo.ScalismoTestSuite
+import scalismo.utils.Random
 
 import scala.language.implicitConversions
-import scala.util.Random
 
 class GeometryTests extends ScalismoTestSuite {
+
+  implicit val random = Random(42)
 
   val p = Point(0.1, 3.0, 1.1)
   val pGeneric: Point[_3D] = p
@@ -29,7 +31,7 @@ class GeometryTests extends ScalismoTestSuite {
   val vGeneric: Vector[_3D] = v
 
   def checkPoint[D <: Dim: NDSpace]() = {
-    def randomPoint(): Point[D] = Point[D](Array.fill(NDSpace[D].dimensionality)(scala.util.Random.nextDouble()))
+    def randomPoint(): Point[D] = Point[D](Array.fill(NDSpace[D].dimensionality)(random.scalaRandom.nextDouble()))
     val pt = randomPoint()
 
     describe(s"A random nD Point $pt (n=${NDSpace[D].dimensionality})") {
@@ -84,7 +86,7 @@ class GeometryTests extends ScalismoTestSuite {
   checkPoint[_3D]()
 
   def checkVector[D <: Dim: NDSpace]() = {
-    def randomVector(): Vector[D] = Vector[D](Array.fill(NDSpace[D].dimensionality)(scala.util.Random.nextDouble()))
+    def randomVector(): Vector[D] = Vector[D](Array.fill(NDSpace[D].dimensionality)(random.scalaRandom.nextDouble()))
     val v = randomVector()
 
     describe(s"A random nD Vector $v (n=${NDSpace[D].dimensionality})") {
@@ -140,7 +142,7 @@ class GeometryTests extends ScalismoTestSuite {
       }
 
       it("inner product probably (1 example) fulfills dot(a*v,w) == a*dot(v,w)") {
-        val a = scala.util.Random.nextDouble()
+        val a = random.scalaRandom.nextDouble()
         val w = randomVector()
         (v * a).dot(w) - a * v.dot(w) should be < 1.0e-4
       }
@@ -174,7 +176,7 @@ class GeometryTests extends ScalismoTestSuite {
       }
 
       it("has norm which probably (1 example) fulfills (a*v).norm == |a|*v.norm(v)") {
-        val a = scala.util.Random.nextDouble()
+        val a = random.scalaRandom.nextDouble()
         (v * a).norm - math.abs(a) * v.norm should be <= 1e-6
       }
 
@@ -182,7 +184,7 @@ class GeometryTests extends ScalismoTestSuite {
         v.norm2 should be(v.dot(v))
       }
 
-      val f = math.max(1e-10, scala.util.Random.nextDouble())
+      val f = math.max(1e-10, random.scalaRandom.nextDouble())
       it(s"fulfills norm((v*f)/f - v) ~ 0 (f=$f)") {
         ((v * f) / f - v).norm should be(0.0 +- 1e-4)
       }
@@ -195,7 +197,7 @@ class GeometryTests extends ScalismoTestSuite {
   checkVector[_3D]()
 
   def checkIndex[D <: Dim: NDSpace]() = {
-    def randomIndex(): IntVector[D] = IntVector[D](Array.fill(NDSpace[D].dimensionality)(scala.util.Random.nextInt()))
+    def randomIndex(): IntVector[D] = IntVector[D](Array.fill(NDSpace[D].dimensionality)(random.scalaRandom.nextInt()))
     val ind = randomIndex()
 
     describe(s"A random nD Index $ind (n=${NDSpace[D].dimensionality})") {

--- a/src/test/scala/scalismo/io/ActiveShapeModelIOTests.scala
+++ b/src/test/scala/scalismo/io/ActiveShapeModelIOTests.scala
@@ -37,7 +37,7 @@ class ActiveShapeModelIOTests extends ScalismoTestSuite {
     val statismoFile = new File(getClass.getResource("/facemodel.h5").getPath)
     val shapeModel = StatismoIO.readStatismoMeshModel(statismoFile).get
 
-    val (sprofilePoints, _) = new FixedPointsUniformMeshSampler3D(shapeModel.referenceMesh, 100, 42).sample.unzip
+    val (sprofilePoints, _) = new FixedPointsUniformMeshSampler3D(shapeModel.referenceMesh, 100).sample.unzip
     val pointIds = sprofilePoints.map { point => shapeModel.referenceMesh.pointSet.findClosestPoint(point).id }
     val dists = for (i <- pointIds.indices) yield new MultivariateNormalDistribution(DenseVector.ones[Double](3) * i.toDouble, DenseMatrix.eye[Double](3) * i.toDouble)
     val profiles = new Profiles(pointIds.to[immutable.IndexedSeq].zip(dists).map { case (i, d) => Profile(i, d) })

--- a/src/test/scala/scalismo/kernels/KernelTests.scala
+++ b/src/test/scala/scalismo/kernels/KernelTests.scala
@@ -67,7 +67,7 @@ class KernelTests extends ScalismoTestSuite {
 
       val sampleTransformations = for (i <- (0 until 5000).par) yield {
         // TODO: gp.sample() should (arguably) accept seed.
-        val sample: (Point[_3D] => Vector[_3D]) = gp.sample
+        val sample: (Point[_3D] => Vector[_3D]) = gp.sample()
         new Transformation[_3D] {
           override val domain = RealSpace[_3D]
           override val f = (x: Point[_3D]) => x + sample(x)

--- a/src/test/scala/scalismo/mesh/MeshSurfaceDistanceTests.scala
+++ b/src/test/scala/scalismo/mesh/MeshSurfaceDistanceTests.scala
@@ -20,14 +20,13 @@ import scalismo.ScalismoTestSuite
 import scalismo.common.{ PointId, UnstructuredPointsDomain }
 import scalismo.geometry.{ Dim, Point, Vector, _3D }
 import scalismo.mesh.{ TriangleCell, TriangleList, TriangleMesh3D }
-
-import scala.util.Random
+import scalismo.utils.Random
 
 class MeshSurfaceDistanceTests extends ScalismoTestSuite {
 
-  implicit val rnd = Random
+  implicit val rnd = Random(42)
 
-  def rgen(offset: Double = 0.0, scale: Double = 1.0) = Random.nextDouble() * scale + offset
+  def rgen(offset: Double = 0.0, scale: Double = 1.0) = rnd.scalaRandom.nextDouble() * scale + offset
 
   def randomPoint(offset: Double = 0.0, scale: Double = 1.0)(implicit rnd: Random): Point[_3D] = {
     Point(rgen(offset, scale), rgen(offset, scale), rgen(offset, scale))
@@ -200,7 +199,7 @@ class MeshSurfaceDistanceTests extends ScalismoTestSuite {
     }
 
     it("should return the same when used for points as the findClosestPoint from UnstructuredPointsDomain") {
-      Random.setSeed(42)
+
       val points = (for (i <- 0 until 10000) yield randomPoint())
       val pd = UnstructuredPointsDomain(points)
 
@@ -221,7 +220,6 @@ class MeshSurfaceDistanceTests extends ScalismoTestSuite {
     }
 
     it("should return an equal or smaller distance when used for points than the findClosestPoint from UnstructuredPointsDomain for triangles") {
-      Random.setSeed(42)
 
       val triangles = (0 until 100) map { j =>
         // test if two function lead to same cp

--- a/src/test/scala/scalismo/numerics/SamplerTests.scala
+++ b/src/test/scala/scalismo/numerics/SamplerTests.scala
@@ -21,19 +21,17 @@ import scalismo.ScalismoTestSuite
 import scalismo.geometry._
 import scalismo.io.MeshIO
 import scalismo.mesh.TriangleMesh
-import scalismo.utils.Memoize
-
-import scala.util.Random
+import scalismo.utils.{ Random, Memoize }
 
 class SamplerTests extends ScalismoTestSuite {
+
+  implicit val random: Random = Random(42)
 
   val facepath = getClass.getResource("/facemesh.stl").getPath
   val facemesh = MeshIO.readMesh(new File(facepath)).get
 
   describe("A uniform sampler") {
     it("yields approximately uniformly spaced points") {
-
-      val random = new Random()
 
       // precalculate values needed for determining if a point lies in a (triangle) cell.
       case class CellInfo(a: Point[_3D], b: Point[_3D], c: Point[_3D], v0: Vector[_3D], v1: Vector[_3D], dot00: Double, dot01: Double, dot11: Double)
@@ -88,13 +86,13 @@ class SamplerTests extends ScalismoTestSuite {
           } else false
         }
 
-        val sampler = UniformMeshSampler3D(facemesh, numSamplingPoints, seed = random.nextInt())
+        val sampler = UniformMeshSampler3D(facemesh, numSamplingPoints, seed = random.scalaRandom.nextInt())
         val (samplePoints, _) = sampler.sample.unzip
         //        println(s"total number of points: ${facemesh.numberOfPoints}")
 
         def randomArea(mesh: TriangleMesh[_3D], targetRatio: Double): (IndexedSeq[Int], Double) = {
           val cellAreas = facemesh.cells.map(facemesh.computeTriangleArea)
-          val cellIdWithArea = random.shuffle(facemesh.cells.indices zip cellAreas)
+          val cellIdWithArea = random.scalaRandom.shuffle(facemesh.cells.indices zip cellAreas)
 
           var areaRemaining = mesh.area * targetRatio
           val areaCellIds = cellIdWithArea.takeWhile {

--- a/src/test/scala/scalismo/numerics/SamplerTests.scala
+++ b/src/test/scala/scalismo/numerics/SamplerTests.scala
@@ -86,7 +86,7 @@ class SamplerTests extends ScalismoTestSuite {
           } else false
         }
 
-        val sampler = UniformMeshSampler3D(facemesh, numSamplingPoints, seed = random.scalaRandom.nextInt())
+        val sampler = UniformMeshSampler3D(facemesh, numSamplingPoints)
         val (samplePoints, _) = sampler.sample.unzip
         //        println(s"total number of points: ${facemesh.numberOfPoints}")
 
@@ -134,7 +134,7 @@ class SamplerTests extends ScalismoTestSuite {
       }
     }
     it("yields different points when called multiple times") {
-      val sampler = UniformMeshSampler3D(facemesh, 200, seed = 42)
+      val sampler = UniformMeshSampler3D(facemesh, 200)
       val pts1 = sampler.sample.map(_._1)
       val pts2 = sampler.sample.map(_._1)
       assert((pts1 diff pts2).nonEmpty)
@@ -143,7 +143,7 @@ class SamplerTests extends ScalismoTestSuite {
 
   describe("A fixed point uniform mesh sampler") {
     it("yields the same points when called multiple times") {
-      val sampler = FixedPointsUniformMeshSampler3D(facemesh, 200, seed = 42)
+      val sampler = FixedPointsUniformMeshSampler3D(facemesh, 200)
       val pts1 = sampler.sample.map(_._1)
       val pts2 = sampler.sample.map(_._1)
       assert((pts1 diff pts2).isEmpty)

--- a/src/test/scala/scalismo/registration/RegistrationTests.scala
+++ b/src/test/scala/scalismo/registration/RegistrationTests.scala
@@ -25,10 +25,13 @@ import scalismo.io.{ ImageIO, MeshIO }
 import scalismo.kernels.{ DiagonalKernel, GaussianKernel }
 import scalismo.numerics.{ GradientDescentOptimizer, LBFGSOptimizer, UniformSampler }
 import scalismo.statisticalmodel.{ GaussianProcess, LowRankGaussianProcess }
+import scalismo.utils.Random
 
 import scala.language.implicitConversions
 
 class RegistrationTests extends ScalismoTestSuite {
+
+  implicit val random = Random(42)
 
   implicit def doubleToFloat(d: Double): Float = d.toFloat
 

--- a/src/test/scala/scalismo/statisticalmodel/ActiveShapeModelTests.scala
+++ b/src/test/scala/scalismo/statisticalmodel/ActiveShapeModelTests.scala
@@ -11,8 +11,11 @@ import scalismo.numerics.{ Sampler, UniformMeshSampler3D }
 import scalismo.registration.{ LandmarkRegistration, RigidTransformationSpace }
 import scalismo.statisticalmodel.asm._
 import scalismo.statisticalmodel.dataset.DataCollection
+import scalismo.utils.Random
 
 class ActiveShapeModelTests extends ScalismoTestSuite {
+
+  implicit val random = Random(42)
 
   describe("An active shape model") {
 
@@ -20,7 +23,7 @@ class ActiveShapeModelTests extends ScalismoTestSuite {
       val imagePreprocessor = GaussianGradientImagePreprocessor(0.1f)
       // number of points should usually be an odd number, so that the profiles are centered on the profiled points
       val featureExtractor = NormalDirectionFeatureExtractor(numberOfPoints = 5, spacing = 1.0)
-      def samplerPerMesh(mesh: TriangleMesh[_3D]): Sampler[_3D] = UniformMeshSampler3D(mesh, numberOfPoints = 1000, seed = 42)
+      def samplerPerMesh(mesh: TriangleMesh[_3D]): Sampler[_3D] = UniformMeshSampler3D(mesh, numberOfPoints = 1000)
       val searchMethod = NormalDirectionSearchPointSampler(numberOfPoints = 31, searchDistance = 6)
       val fittingConfig = FittingConfiguration(featureDistanceThreshold = 2.0, pointDistanceThreshold = 3.0, modelCoefficientBounds = 3.0)
 

--- a/src/test/scala/scalismo/statisticalmodel/GaussianProcessTests.scala
+++ b/src/test/scala/scalismo/statisticalmodel/GaussianProcessTests.scala
@@ -23,11 +23,14 @@ import scalismo.geometry._
 import scalismo.image.DiscreteImageDomain
 import scalismo.kernels.{ DiagonalKernel, GaussianKernel, MatrixValuedPDKernel }
 import scalismo.numerics.{ GridSampler, UniformSampler }
+import scalismo.utils.Random
 
 import scala.language.implicitConversions
-import scala.util.Random
 
 class GaussianProcessTests extends ScalismoTestSuite {
+
+  implicit val random = Random(42)
+
   implicit def doubleToFloat(d: Double): Float = d.toFloat
 
   implicit def intToPointId(i: Int): PointId = PointId(i)
@@ -360,7 +363,7 @@ class GaussianProcessTests extends ScalismoTestSuite {
       val gp = f.discreteLowRankGp.interpolateNystrom(100)
       val discreteGp = gp.discretize(UnstructuredPointsDomain(f.discretizationPoints))
 
-      val gaussRNG = breeze.stats.distributions.Gaussian(0, 1)
+      val gaussRNG = random.breezeRandomGaussian(0, 1)
       val coeffs = DenseVector.rand(gp.rank, gaussRNG)
 
       val sample = gp.instance(coeffs)
@@ -444,7 +447,7 @@ class GaussianProcessTests extends ScalismoTestSuite {
     it("yields the same values on the discrete points when interpolated with nearest neighbor") {
       val f = Fixture
       val interpolatedGP = f.discreteLowRankGp.interpolateNearestNeighbor
-      val gaussRNG = breeze.stats.distributions.Gaussian(0, 1)
+      val gaussRNG = random.breezeRandomGaussian(0, 1)
       val coeffs = DenseVector.rand(interpolatedGP.rank, gaussRNG)
 
       val discreteInstance = f.discreteLowRankGp.instance(coeffs)
@@ -458,7 +461,7 @@ class GaussianProcessTests extends ScalismoTestSuite {
       val orignalLowRankPosterior = f.lowRankGp.posterior(f.trainingDataLowRankGP)
       val interpolatedGPPosterior = f.discreteLowRankGp.interpolateNearestNeighbor.posterior(f.trainingDataLowRankGP)
 
-      val gaussRNG = breeze.stats.distributions.Gaussian(0, 1)
+      val gaussRNG = random.breezeRandomGaussian(0, 1)
       val coeffs = DenseVector.rand(orignalLowRankPosterior.rank, gaussRNG)
 
       val originalPosteriorInstance = orignalLowRankPosterior.instance(coeffs)
@@ -476,10 +479,10 @@ class GaussianProcessTests extends ScalismoTestSuite {
     it("yields the same values for an instance at a point when either only the point or the complete instance is calculated") {
       val f = Fixture
       val gp = f.discreteLowRankGp
-      val points = (0 until 1000) map { i => Random.nextInt(gp._domain.numberOfPoints) }
+      val points = (0 until 1000) map { i => random.scalaRandom.nextInt(gp._domain.numberOfPoints) }
       points.foreach { pid =>
         val k = gp.rank
-        val gaussRNG = breeze.stats.distributions.Gaussian(0, 1)
+        val gaussRNG = random.breezeRandomGaussian(0, 1)
         val coeffs = DenseVector.rand(k, gaussRNG)
         val instance = gp.instance(coeffs)
         instance.data(pid) shouldBe gp.instanceAtPoint(coeffs, pid)

--- a/src/test/scala/scalismo/statisticalmodel/MultivariateNormalDistributionTests.scala
+++ b/src/test/scala/scalismo/statisticalmodel/MultivariateNormalDistributionTests.scala
@@ -18,8 +18,12 @@ package scalismo.statisticalmodel
 import breeze.linalg.{ DenseMatrix, DenseVector }
 import scalismo.ScalismoTestSuite
 import scalismo.geometry._
+import scalismo.utils.Random
 
 class MultivariateNormalDistributionTests extends ScalismoTestSuite {
+
+  implicit val random = Random(42)
+
   describe("A 1D Multivariate normal") {
     it("should give the same pdf values as breeze Gaussian with the same parameters") {
       val mvn = new MultivariateNormalDistribution(DenseVector(2.0), DenseMatrix(3.0))

--- a/src/test/scala/scalismo/statisticalmodel/StatisticalModelTests.scala
+++ b/src/test/scala/scalismo/statisticalmodel/StatisticalModelTests.scala
@@ -22,9 +22,12 @@ import scalismo.ScalismoTestSuite
 import scalismo.geometry._
 import scalismo.io.StatismoIO
 import scalismo.registration.{ RigidTransformation, RigidTransformationSpace }
+import scalismo.utils.Random
 
 import scala.language.implicitConversions
 class StatisticalModelTests extends ScalismoTestSuite {
+
+  implicit val random = Random(42)
 
   implicit def doubleToFloat(d: Double): Float = d.toFloat
 
@@ -34,7 +37,7 @@ class StatisticalModelTests extends ScalismoTestSuite {
 
       for (i <- 0 until 10) {
         val coeffsData = (0 until oldModel.rank).map { _ =>
-          breeze.stats.distributions.Gaussian(0, 1).draw()
+          random.breezeRandomGaussian(0, 1).draw()
         }
         val coeffs = DenseVector(coeffsData.toArray)
         val inst = oldModel.instance(coeffs)

--- a/src/test/scala/scalismo/statisticalmodel/dataset/DataCollectionTests.scala
+++ b/src/test/scala/scalismo/statisticalmodel/dataset/DataCollectionTests.scala
@@ -25,10 +25,13 @@ import scalismo.kernels.{ DiagonalKernel, GaussianKernel }
 import scalismo.mesh.MeshMetrics
 import scalismo.registration.{ LandmarkRegistration, TranslationTransform }
 import scalismo.statisticalmodel.{ GaussianProcess, StatisticalMeshModel }
+import scalismo.utils.Random
 
 class DataCollectionTests extends ScalismoTestSuite {
 
   describe("A datacollection") {
+
+    implicit val random = Random(42)
 
     val transformations = for (i <- 0 until 10) yield TranslationTransform(Vector(i.toDouble, 0.0, 0.0))
     val dataItems = for ((t, i) <- transformations.zipWithIndex) yield DataItem(s"transformation-$i", t)

--- a/src/test/scala/scalismo/utils/RandomTests.scala
+++ b/src/test/scala/scalismo/utils/RandomTests.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2015 University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package scalismo.utils
+
+import scalismo.ScalismoTestSuite
+import scalismo.geometry.{Point, _3D}
+
+import scala.collection.immutable.IndexedSeq
+
+class RandomTests extends ScalismoTestSuite {
+
+
+  describe("A random source") {
+
+
+    it("should yield a deterministic sequence when correctly seeded") {
+
+      def randomNumbersSeeded() = {
+        val r = Random(42)
+        (r.scalaRandom.nextInt, r.breezeRandomGaussian(0, 1).draw(), r.breezeRandomUnform(0, 1).draw())
+      }
+      randomNumbersSeeded() should equal(randomNumbersSeeded())
+
+    }
+
+    it ("should yield a random sequence when no implicit is defined") {
+
+      def randomNumbersNotSeeded()  = {
+        val r = implicitly[Random]
+        (r.scalaRandom.nextInt, r.breezeRandomGaussian(0, 1).draw(), r.breezeRandomUnform(0, 1).draw())
+      }
+      randomNumbersNotSeeded() should not equal(randomNumbersNotSeeded())
+    }
+  }
+}

--- a/src/test/scala/scalismo/utils/RandomTests.scala
+++ b/src/test/scala/scalismo/utils/RandomTests.scala
@@ -16,15 +16,13 @@
 package scalismo.utils
 
 import scalismo.ScalismoTestSuite
-import scalismo.geometry.{Point, _3D}
+import scalismo.geometry.{ Point, _3D }
 
 import scala.collection.immutable.IndexedSeq
 
 class RandomTests extends ScalismoTestSuite {
 
-
   describe("A random source") {
-
 
     it("should yield a deterministic sequence when correctly seeded") {
 
@@ -36,13 +34,13 @@ class RandomTests extends ScalismoTestSuite {
 
     }
 
-    it ("should yield a random sequence when no implicit is defined") {
+    it("should yield a random sequence when no implicit is defined") {
 
-      def randomNumbersNotSeeded()  = {
+      def randomNumbersNotSeeded() = {
         val r = implicitly[Random]
         (r.scalaRandom.nextInt, r.breezeRandomGaussian(0, 1).draw(), r.breezeRandomUnform(0, 1).draw())
       }
-      randomNumbersNotSeeded() should not equal(randomNumbersNotSeeded())
+      randomNumbersNotSeeded() should not equal (randomNumbersNotSeeded())
     }
   }
 }

--- a/src/test/scala/scalismo/utils/VantagePointTreeTests.scala
+++ b/src/test/scala/scalismo/utils/VantagePointTreeTests.scala
@@ -24,8 +24,9 @@ import scala.util.Random
 class VantagePointTreeTests extends ScalismoTestSuite {
 
   // seeded random generator
-  implicit val rnd = new Random(1024L)
-  def randomPoint()(implicit rnd: Random): Point[_3D] = Point(rnd.nextDouble(), rnd.nextDouble(), rnd.nextDouble())
+  implicit val rnd = Random(42)
+
+  def randomPoint()(implicit rnd: Random): Point[_3D] = Point(rnd.scalaRandom.nextDouble(), rnd.scalaRandom.nextDouble(), rnd.scalaRandom.nextDouble())
 
   // test size, VP size, lookup size
   val n = 50


### PR DESCRIPTION
A thin wrapper around different random number generators is introduced, which should become the new default source of randomness for all methods in scalismo that need random numbers.

The idea is that every method takes an implicit instance of the new Random class as an argument.

The new mechanism has the following behaviour:
* If the user does not specify an own implicit instance, the default source in the companion object is used.
* If the result should be reproducible, the user can define his/her own implicit instance with a fixed seed.