### PR TITLE
renamed getShortestDistance in SurfaceSpatialIndex to getSquaredShort…

### DIFF
--- a/src/main/scala/scalismo/mesh/boundingSpheres/SurfaceSpatialIndex.scala
+++ b/src/main/scala/scalismo/mesh/boundingSpheres/SurfaceSpatialIndex.scala
@@ -30,7 +30,7 @@ trait SurfaceSpatialIndex[D <: Dim] {
    *
    * @return Squared distance.
    */
-  def getShortestDistance(pt: Point[D]): Double
+  def getSquaredShortestDistance(pt: Point[D]): Double
 
   /**
    * Query the closest point on a surface.
@@ -119,7 +119,7 @@ private case class TriangleMesh3DSpatialIndex(bs: BoundingSphere,
   /**
    * Calculates the squared closest distance to the surface.
    */
-  override def getShortestDistance(point: Point[_3D]): Double = {
+  override def getSquaredShortestDistance(point: Point[_3D]): Double = {
     _getClosestPoint(point)
     res.distance2
   }


### PR DESCRIPTION
…estDistance

The original name is confusing as one expects the actual distance to be returned (in my case I was surprised that this was different from computing the distance to the closest point myself)