### PR TITLE
Thread save SpatialIndex with tests. fixes #159

### DIFF
--- a/src/main/scala/scalismo/mesh/boundingSpheres/DiscreteSpatialIndex.scala
+++ b/src/main/scala/scalismo/mesh/boundingSpheres/DiscreteSpatialIndex.scala
@@ -63,14 +63,18 @@ private class DiscreteSpatialIndexImplementation(private val bs: BoundingSphere,
    */
   def closestPoint(point: Point[_3D]): ClosestPointIsPoint = {
     val p = point.toVector
-    val lastP = pointList(lastIdx.idx)
+    val lastP = pointList(lastIdx.get().idx)
     val lastD = toPoint(lastP, p)
     val d: Distance2 = new Distance2(lastD.distance2)
-    distanceToPartition(p, bs, d, lastIdx)
-    ClosestPointIsPoint(pointList(lastIdx.idx).toPoint, d.distance2, lastIdx.idx)
+    distanceToPartition(p, bs, d, lastIdx.get())
+    ClosestPointIsPoint(pointList(lastIdx.get().idx).toPoint, d.distance2, lastIdx.get().idx)
   }
 
-  private val lastIdx: Index = Index(0)
+  private val lastIdx: ThreadLocal[Index] = new ThreadLocal[Index](){
+    override protected def initialValue() : Index = {
+      return new Index(0);
+    }
+  }
   private val pointList = points.map(_.toVector).toIndexedSeq
 
   private def distanceToPartition(point: Vector[_3D],

--- a/src/main/scala/scalismo/mesh/boundingSpheres/SurfaceSpatialIndex.scala
+++ b/src/main/scala/scalismo/mesh/boundingSpheres/SurfaceSpatialIndex.scala
@@ -121,7 +121,7 @@ private case class TriangleMesh3DSpatialIndex(bs: BoundingSphere,
    */
   override def getShortestDistance(point: Point[_3D]): Double = {
     _getClosestPoint(point)
-    res.distance2
+    res.get().distance2
   }
 
   /**
@@ -129,7 +129,7 @@ private case class TriangleMesh3DSpatialIndex(bs: BoundingSphere,
    */
   override def getClosestPoint(point: Point[_3D]): (Point[_3D], Double) = {
     _getClosestPoint(point)
-    (res.pt.toPoint, res.distance2)
+    (res.get().pt.toPoint, res.get().distance2)
   }
 
   /**
@@ -140,19 +140,19 @@ private case class TriangleMesh3DSpatialIndex(bs: BoundingSphere,
     _getClosestPoint(point)
 
     // handle found point type
-    val triangle = mesh.triangulation.triangle(TriangleId(lastIdx.idx))
-    res.ptType match {
+    val triangle = mesh.triangulation.triangle(TriangleId(lastIdx.get().idx))
+    res.get().ptType match {
 
-      case POINT => ClosestPointIsPoint(res.pt.toPoint, res.distance2, triangle.pointIds(res.idx._1).id)
+      case POINT => ClosestPointIsPoint(res.get().pt.toPoint, res.get().distance2, triangle.pointIds(res.get().idx._1).id)
 
-      case ON_LINE => res.idx match {
-        case (0, _) => ClosestPointOnLine(res.pt.toPoint, res.distance2, (triangle.pointIds(0).id, triangle.pointIds(1).id), res.bc.a)
-        case (1, _) => ClosestPointOnLine(res.pt.toPoint, res.distance2, (triangle.pointIds(1).id, triangle.pointIds(2).id), res.bc.a)
-        case (2, _) => ClosestPointOnLine(res.pt.toPoint, res.distance2, (triangle.pointIds(2).id, triangle.pointIds(0).id), res.bc.a)
+      case ON_LINE => res.get().idx match {
+        case (0, _) => ClosestPointOnLine(res.get().pt.toPoint, res.get().distance2, (triangle.pointIds(0).id, triangle.pointIds(1).id), res.get().bc.a)
+        case (1, _) => ClosestPointOnLine(res.get().pt.toPoint, res.get().distance2, (triangle.pointIds(1).id, triangle.pointIds(2).id), res.get().bc.a)
+        case (2, _) => ClosestPointOnLine(res.get().pt.toPoint, res.get().distance2, (triangle.pointIds(2).id, triangle.pointIds(0).id), res.get().bc.a)
         case _ => throw (new RuntimeException("not a valid line index"))
       }
 
-      case IN_TRIANGLE => ClosestPointInTriangle(res.pt.toPoint, res.distance2, lastIdx.idx, (res.bc.a, res.bc.b))
+      case IN_TRIANGLE => ClosestPointInTriangle(res.get().pt.toPoint, res.get().distance2, lastIdx.get().idx, (res.get().bc.a, res.get().bc.b))
 
       case _ => throw (new RuntimeException("not a valid PointType"))
     }
@@ -166,16 +166,24 @@ private case class TriangleMesh3DSpatialIndex(bs: BoundingSphere,
     val p = point.toVector
 
     // last triangle might be a good candidate
-    val result = BSDistance.toTriangle(point.toVector, triangles(lastIdx.idx))
-    updateCP(res, result)
+    val result = BSDistance.toTriangle(point.toVector, triangles(lastIdx.get().idx))
+    updateCP(res.get(), result)
 
     // search for true candidate
-    distanceToPartition(p, bs, res, lastIdx)
+    distanceToPartition(p, bs, res.get(), lastIdx.get())
   }
 
   /** @note both values contain a mutable state, this is needed to improve speed when having many queries with successive near points. */
-  private val lastIdx: Index = Index(0)
-  private val res = CP(Double.MaxValue, Vector(-1, -1, -1), POINT, BC(0, 0), (-1, -1))
+  private val lastIdx: ThreadLocal[Index] = new ThreadLocal[Index](){
+    override protected def initialValue() : Index = {
+      return new Index(0);
+    }
+  }
+  private val res: ThreadLocal[CP] = new ThreadLocal[CP](){
+    override protected def initialValue() : CP = {
+      return new CP(Double.MaxValue, Vector(-1, -1, -1), POINT, BC(0, 0), (-1, -1));
+    }
+  }
 
   /**
    * Search for the closest point recursively


### PR DESCRIPTION
Introduced ThreadLocal variabales to make the SurfaceSpatialIndex and the DiscreteSpatialIndex thread safe. This pull request fixes #159 without changing the interface. A test is provided that a map and a par.map of sequential requests to a spatial index returns the same results.

In terms of computation speed it seems to make little to no difference when we use ThreadLocal variables for the single threaded case.