### PR TITLE
MeshOperations

### DIFF
--- a/src/main/scala/scalismo/mesh/Mesh.scala
+++ b/src/main/scala/scalismo/mesh/Mesh.scala
@@ -35,7 +35,7 @@ object Mesh {
     def dist(pt: Point[_3D]): Float = Math.sqrt(spIndex.getSquaredShortestDistance(pt)).toFloat
 
     def grad(pt: Point[_3D]) = {
-      val closestPt = spIndex.getClosestPoint(pt)._1
+      val closestPt = spIndex.getClosestPoint(pt).point
       val grad = Vector(pt(0) - closestPt(0), pt(1) - closestPt(1), pt(2) - closestPt(2))
       grad * (1.0 / grad.norm)
     }

--- a/src/main/scala/scalismo/mesh/Mesh.scala
+++ b/src/main/scala/scalismo/mesh/Mesh.scala
@@ -1,87 +1,87 @@
-///*
-// * Copyright 2015 University of Basel, Graphics and Vision Research Group
-// *
-// * Licensed under the Apache License, Version 2.0 (the "License");
-// * you may not use this file except in compliance with the License.
-// * You may obtain a copy of the License at
-// *
-// *     http://www.apache.org/licenses/LICENSE-2.0
-// *
-// * Unless required by applicable law or agreed to in writing, software
-// * distributed under the License is distributed on an "AS IS" BASIS,
-// * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// * See the License for the specific language governing permissions and
-// * limitations under the License.
-// */
-//package scalismo.mesh
-//
-//import scalismo.common.{ PointId, RealSpace, UnstructuredPointsDomain }
-//import scalismo.geometry._
-//import scalismo.image.{ DifferentiableScalarImage, ScalarImage }
-//import scalismo.mesh.boundingSpheres.{ SurfaceSpatialIndex, TriangleMesh3DSpatialIndex }
-//
-///**
-// * Defines utility functions on [[TriangleMesh]] instances
-// */
-//object Mesh {
-//
-//  /**
-//   * Returns a new continuous [[DifferentiableScalarImage]] defined on 3-dimensional [[RealSpace]] which is the distance transform of the mesh
-//   */
-//  @deprecated("Is moved to TriangleMesh3DMeshOperations.","0.14")
-//  def meshToDistanceImage(mesh: TriangleMesh[_3D]): DifferentiableScalarImage[_3D] = {
-//    val spIndex = TriangleMesh3DSpatialIndex.fromTriangleMesh3D(mesh)
-//
-//    def dist(pt: Point[_3D]): Float = Math.sqrt(spIndex.getSquaredShortestDistance(pt)).toFloat
-//
-//    def grad(pt: Point[_3D]) = {
-//      val closestPt = spIndex.getClosestPoint(pt)._1
-//      val grad = Vector(pt(0) - closestPt(0), pt(1) - closestPt(1), pt(2) - closestPt(2))
-//      grad * (1.0 / grad.norm)
-//    }
-//    DifferentiableScalarImage(RealSpace[_3D], (pt: Point[_3D]) => dist(pt), (pt: Point[_3D]) => grad(pt))
-//  }
-//
-//  /**
-//   * Returns a new continuous binary [[ScalarImage]] defined on 3-dimensional [[RealSpace]] , where the mesh surface is used to split the image domain.
-//   * Points lying on the space side pointed towards by the surface normals will have value 0. Points lying on the other side have
-//   * value 1. Hence if the mesh is a closed surface, points inside the surface have value 1 and points outside 0.
-//   *
-//   */
-//  @deprecated("Is moved to TriangleMesh3DMeshOperations.","0.14")
-//  def meshToBinaryImage(mesh: TriangleMesh[_3D]): ScalarImage[_3D] = {
-//    def inside(pt: Point[_3D]): Short = {
-//      val closestMeshPt = mesh.pointSet.findClosestPoint(pt)
-//      val dotprod = mesh.vertexNormals(closestMeshPt.id) dot (closestMeshPt.point - pt)
-//      if (dotprod > 0.0) 1 else 0
-//    }
-//
-//    ScalarImage(RealSpace[_3D], (pt: Point[_3D]) => inside(pt))
-//  }
-//
-//  /**
-//   * Returns a new [[TriangleMesh]] where all points satisfying the given predicate are removed.
-//   * All cells containing deleted points are also deleted.
-//   *
-//   */
-//  @deprecated("Is moved to TriangleMesh3DMeshOperations.","0.14")
-//  def clipMesh(mesh: TriangleMesh[_3D], clipPointPredicate: Point[_3D] => Boolean): TriangleMesh[_3D] = {
-//
-//    // predicate tested at the beginning, once.
-//    val remainingPoints = mesh.pointSet.points.toIndexedSeq.par.filter { !clipPointPredicate(_) }.zipWithIndex.toMap
-//    val pts = mesh.pointSet.points.toIndexedSeq
-//
-//    val remainingPointTriplet = mesh.cells.par.map {
-//      cell =>
-//        val points = cell.pointIds.map(pointId => pts(pointId.id))
-//        (points, points.map(p => remainingPoints.get(p).isDefined).reduce(_ && _))
-//    }.filter(_._2).map(_._1)
-//
-//    val points = remainingPointTriplet.flatten.distinct
-//    val pt2Id = points.zipWithIndex.toMap
-//    val cells = remainingPointTriplet.map { case vec => TriangleCell(PointId(pt2Id(vec(0))), PointId(pt2Id(vec(1))), PointId(pt2Id(vec(2)))) }
-//
-//    TriangleMesh3D(points.toIndexedSeq, TriangleList(cells.toIndexedSeq))
-//  }
-//
-//}
+/*
+ * Copyright 2015 University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package scalismo.mesh
+
+import scalismo.common.{ PointId, RealSpace, UnstructuredPointsDomain }
+import scalismo.geometry._
+import scalismo.image.{ DifferentiableScalarImage, ScalarImage }
+import scalismo.mesh.boundingSpheres.{ SurfaceSpatialIndex, TriangleMesh3DSpatialIndex }
+
+/**
+ * Defines utility functions on [[TriangleMesh]] instances
+ */
+object Mesh {
+
+  /**
+   * Returns a new continuous [[DifferentiableScalarImage]] defined on 3-dimensional [[RealSpace]] which is the distance transform of the mesh
+   */
+  @deprecated("Is moved to TriangleMesh3DMeshOperations.", "0.14")
+  def meshToDistanceImage(mesh: TriangleMesh[_3D]): DifferentiableScalarImage[_3D] = {
+    val spIndex = TriangleMesh3DSpatialIndex.fromTriangleMesh3D(mesh)
+
+    def dist(pt: Point[_3D]): Float = Math.sqrt(spIndex.getSquaredShortestDistance(pt)).toFloat
+
+    def grad(pt: Point[_3D]) = {
+      val closestPt = spIndex.getClosestPoint(pt)._1
+      val grad = Vector(pt(0) - closestPt(0), pt(1) - closestPt(1), pt(2) - closestPt(2))
+      grad * (1.0 / grad.norm)
+    }
+    DifferentiableScalarImage(RealSpace[_3D], (pt: Point[_3D]) => dist(pt), (pt: Point[_3D]) => grad(pt))
+  }
+
+  /**
+   * Returns a new continuous binary [[ScalarImage]] defined on 3-dimensional [[RealSpace]] , where the mesh surface is used to split the image domain.
+   * Points lying on the space side pointed towards by the surface normals will have value 0. Points lying on the other side have
+   * value 1. Hence if the mesh is a closed surface, points inside the surface have value 1 and points outside 0.
+   *
+   */
+  @deprecated("Is moved to TriangleMesh3DMeshOperations.", "0.14")
+  def meshToBinaryImage(mesh: TriangleMesh[_3D]): ScalarImage[_3D] = {
+    def inside(pt: Point[_3D]): Short = {
+      val closestMeshPt = mesh.pointSet.findClosestPoint(pt)
+      val dotprod = mesh.vertexNormals(closestMeshPt.id) dot (closestMeshPt.point - pt)
+      if (dotprod > 0.0) 1 else 0
+    }
+
+    ScalarImage(RealSpace[_3D], (pt: Point[_3D]) => inside(pt))
+  }
+
+  /**
+   * Returns a new [[TriangleMesh]] where all points satisfying the given predicate are removed.
+   * All cells containing deleted points are also deleted.
+   *
+   */
+  @deprecated("Is moved to TriangleMesh3DMeshOperations.", "0.14")
+  def clipMesh(mesh: TriangleMesh[_3D], clipPointPredicate: Point[_3D] => Boolean): TriangleMesh[_3D] = {
+
+    // predicate tested at the beginning, once.
+    val remainingPoints = mesh.pointSet.points.toIndexedSeq.par.filter { !clipPointPredicate(_) }.zipWithIndex.toMap
+    val pts = mesh.pointSet.points.toIndexedSeq
+
+    val remainingPointTriplet = mesh.cells.par.map {
+      cell =>
+        val points = cell.pointIds.map(pointId => pts(pointId.id))
+        (points, points.map(p => remainingPoints.get(p).isDefined).reduce(_ && _))
+    }.filter(_._2).map(_._1)
+
+    val points = remainingPointTriplet.flatten.distinct
+    val pt2Id = points.zipWithIndex.toMap
+    val cells = remainingPointTriplet.map { case vec => TriangleCell(PointId(pt2Id(vec(0))), PointId(pt2Id(vec(1))), PointId(pt2Id(vec(2)))) }
+
+    TriangleMesh3D(points.toIndexedSeq, TriangleList(cells.toIndexedSeq))
+  }
+
+}

--- a/src/main/scala/scalismo/mesh/Mesh.scala
+++ b/src/main/scala/scalismo/mesh/Mesh.scala
@@ -1,85 +1,87 @@
-/*
- * Copyright 2015 University of Basel, Graphics and Vision Research Group
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-package scalismo.mesh
-
-import scalismo.common.{ PointId, RealSpace, UnstructuredPointsDomain }
-import scalismo.geometry._
-import scalismo.image.{ DifferentiableScalarImage, ScalarImage }
-import scalismo.mesh.boundingSpheres.SurfaceSpatialIndex
-
-/**
- * Defines utility functions on [[TriangleMesh]] instances
- */
-object Mesh {
-
-  /**
-   * Returns a new continuous [[DifferentiableScalarImage]] defined on 3-dimensional [[RealSpace]] which is the distance transform of the mesh
-   */
-  def meshToDistanceImage(mesh: TriangleMesh[_3D]): DifferentiableScalarImage[_3D] = {
-    val spIndex = SurfaceSpatialIndex.fromTriangleMesh3D(mesh)
-
-    def dist(pt: Point[_3D]): Float = Math.sqrt(spIndex.getSquaredShortestDistance(pt)).toFloat
-
-    def grad(pt: Point[_3D]) = {
-      val closestPt = spIndex.getClosestPoint(pt)._1
-      val grad = Vector(pt(0) - closestPt(0), pt(1) - closestPt(1), pt(2) - closestPt(2))
-      grad * (1.0 / grad.norm)
-    }
-    DifferentiableScalarImage(RealSpace[_3D], (pt: Point[_3D]) => dist(pt), (pt: Point[_3D]) => grad(pt))
-  }
-
-  /**
-   * Returns a new continuous binary [[ScalarImage]] defined on 3-dimensional [[RealSpace]] , where the mesh surface is used to split the image domain.
-   * Points lying on the space side pointed towards by the surface normals will have value 0. Points lying on the other side have
-   * value 1. Hence if the mesh is a closed surface, points inside the surface have value 1 and points outside 0.
-   *
-   */
-  def meshToBinaryImage(mesh: TriangleMesh[_3D]): ScalarImage[_3D] = {
-    def inside(pt: Point[_3D]): Short = {
-      val closestMeshPt = mesh.pointSet.findClosestPoint(pt)
-      val dotprod = mesh.vertexNormals(closestMeshPt.id) dot (closestMeshPt.point - pt)
-      if (dotprod > 0.0) 1 else 0
-    }
-
-    ScalarImage(RealSpace[_3D], (pt: Point[_3D]) => inside(pt))
-  }
-
-  /**
-   * Returns a new [[TriangleMesh]] where all points satisfying the given predicate are removed.
-   * All cells containing deleted points are also deleted.
-   *
-   */
-
-  def clipMesh(mesh: TriangleMesh[_3D], clipPointPredicate: Point[_3D] => Boolean): TriangleMesh[_3D] = {
-
-    // predicate tested at the beginning, once.
-    val remainingPoints = mesh.pointSet.points.toIndexedSeq.par.filter { !clipPointPredicate(_) }.zipWithIndex.toMap
-    val pts = mesh.pointSet.points.toIndexedSeq
-
-    val remainingPointTriplet = mesh.cells.par.map {
-      cell =>
-        val points = cell.pointIds.map(pointId => pts(pointId.id))
-        (points, points.map(p => remainingPoints.get(p).isDefined).reduce(_ && _))
-    }.filter(_._2).map(_._1)
-
-    val points = remainingPointTriplet.flatten.distinct
-    val pt2Id = points.zipWithIndex.toMap
-    val cells = remainingPointTriplet.map { case vec => TriangleCell(PointId(pt2Id(vec(0))), PointId(pt2Id(vec(1))), PointId(pt2Id(vec(2)))) }
-
-    TriangleMesh3D(points.toIndexedSeq, TriangleList(cells.toIndexedSeq))
-  }
-
-}
+///*
+// * Copyright 2015 University of Basel, Graphics and Vision Research Group
+// *
+// * Licensed under the Apache License, Version 2.0 (the "License");
+// * you may not use this file except in compliance with the License.
+// * You may obtain a copy of the License at
+// *
+// *     http://www.apache.org/licenses/LICENSE-2.0
+// *
+// * Unless required by applicable law or agreed to in writing, software
+// * distributed under the License is distributed on an "AS IS" BASIS,
+// * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// * See the License for the specific language governing permissions and
+// * limitations under the License.
+// */
+//package scalismo.mesh
+//
+//import scalismo.common.{ PointId, RealSpace, UnstructuredPointsDomain }
+//import scalismo.geometry._
+//import scalismo.image.{ DifferentiableScalarImage, ScalarImage }
+//import scalismo.mesh.boundingSpheres.{ SurfaceSpatialIndex, TriangleMesh3DSpatialIndex }
+//
+///**
+// * Defines utility functions on [[TriangleMesh]] instances
+// */
+//object Mesh {
+//
+//  /**
+//   * Returns a new continuous [[DifferentiableScalarImage]] defined on 3-dimensional [[RealSpace]] which is the distance transform of the mesh
+//   */
+//  @deprecated("Is moved to TriangleMesh3DMeshOperations.","0.14")
+//  def meshToDistanceImage(mesh: TriangleMesh[_3D]): DifferentiableScalarImage[_3D] = {
+//    val spIndex = TriangleMesh3DSpatialIndex.fromTriangleMesh3D(mesh)
+//
+//    def dist(pt: Point[_3D]): Float = Math.sqrt(spIndex.getSquaredShortestDistance(pt)).toFloat
+//
+//    def grad(pt: Point[_3D]) = {
+//      val closestPt = spIndex.getClosestPoint(pt)._1
+//      val grad = Vector(pt(0) - closestPt(0), pt(1) - closestPt(1), pt(2) - closestPt(2))
+//      grad * (1.0 / grad.norm)
+//    }
+//    DifferentiableScalarImage(RealSpace[_3D], (pt: Point[_3D]) => dist(pt), (pt: Point[_3D]) => grad(pt))
+//  }
+//
+//  /**
+//   * Returns a new continuous binary [[ScalarImage]] defined on 3-dimensional [[RealSpace]] , where the mesh surface is used to split the image domain.
+//   * Points lying on the space side pointed towards by the surface normals will have value 0. Points lying on the other side have
+//   * value 1. Hence if the mesh is a closed surface, points inside the surface have value 1 and points outside 0.
+//   *
+//   */
+//  @deprecated("Is moved to TriangleMesh3DMeshOperations.","0.14")
+//  def meshToBinaryImage(mesh: TriangleMesh[_3D]): ScalarImage[_3D] = {
+//    def inside(pt: Point[_3D]): Short = {
+//      val closestMeshPt = mesh.pointSet.findClosestPoint(pt)
+//      val dotprod = mesh.vertexNormals(closestMeshPt.id) dot (closestMeshPt.point - pt)
+//      if (dotprod > 0.0) 1 else 0
+//    }
+//
+//    ScalarImage(RealSpace[_3D], (pt: Point[_3D]) => inside(pt))
+//  }
+//
+//  /**
+//   * Returns a new [[TriangleMesh]] where all points satisfying the given predicate are removed.
+//   * All cells containing deleted points are also deleted.
+//   *
+//   */
+//  @deprecated("Is moved to TriangleMesh3DMeshOperations.","0.14")
+//  def clipMesh(mesh: TriangleMesh[_3D], clipPointPredicate: Point[_3D] => Boolean): TriangleMesh[_3D] = {
+//
+//    // predicate tested at the beginning, once.
+//    val remainingPoints = mesh.pointSet.points.toIndexedSeq.par.filter { !clipPointPredicate(_) }.zipWithIndex.toMap
+//    val pts = mesh.pointSet.points.toIndexedSeq
+//
+//    val remainingPointTriplet = mesh.cells.par.map {
+//      cell =>
+//        val points = cell.pointIds.map(pointId => pts(pointId.id))
+//        (points, points.map(p => remainingPoints.get(p).isDefined).reduce(_ && _))
+//    }.filter(_._2).map(_._1)
+//
+//    val points = remainingPointTriplet.flatten.distinct
+//    val pt2Id = points.zipWithIndex.toMap
+//    val cells = remainingPointTriplet.map { case vec => TriangleCell(PointId(pt2Id(vec(0))), PointId(pt2Id(vec(1))), PointId(pt2Id(vec(2)))) }
+//
+//    TriangleMesh3D(points.toIndexedSeq, TriangleList(cells.toIndexedSeq))
+//  }
+//
+//}

--- a/src/main/scala/scalismo/mesh/MeshBoundaryPredicates.scala
+++ b/src/main/scala/scalismo/mesh/MeshBoundaryPredicates.scala
@@ -28,16 +28,16 @@ import scala.collection.Map
 trait MeshBoundaryPredicates {
 
   /**
-   * Check if the point with given index is on the boundary of the underlaying mesh.
+   * Check if the point with given index is on the boundary of the underlying mesh.
    *
    * @return True if point is part of the boundary.
    */
   def pointIsOnBoundary(id: PointId): Boolean
 
   /**
-   * Check if the edge between the two points with given indices is on the boundary of the underlaying mesh.
+   * Check if the edge between the two points with given indices is on the boundary of the underlying mesh.
    *
-   * @note This method does not check weather there exists a nedge between the two points. You will get false for all
+   * @note This method does not check weather there exists an edge between the two points. You will get false for all
    *       edges not in the mesh.
    * @return True if the edge is part of the boundary.
    */
@@ -51,7 +51,7 @@ trait MeshBoundaryPredicates {
 trait TriangularMeshBoundaryPredicates extends MeshBoundaryPredicates {
 
   /**
-   * Check if the triangle with given index is on the boundary of the underlaying mesh.
+   * Check if the triangle with given index is on the boundary of the underlying mesh.
    *
    * @return True if the triangle has at least one border in common with the boundary.
    */
@@ -63,20 +63,21 @@ trait TriangularMeshBoundaryPredicates extends MeshBoundaryPredicates {
  *
  * @note the implementation with a Map instead of a CSCMatrix was three times slower using our test mesh.
  */
-private class BoundaryOfATriangleMeshPredicates(private var vertexIsOnBorder: IndexedSeq[Boolean],
+private class BoundaryOfATriangleMeshPredicates(
+    private var vertexIsOnBorder: IndexedSeq[Boolean],
     private var edgeIsOnBorder: CSCMatrix[Boolean],
     private var triangleIsOnBorder: IndexedSeq[Boolean]) extends TriangularMeshBoundaryPredicates {
 
   override def pointIsOnBoundary(id: PointId): Boolean = {
-    return vertexIsOnBorder(id.id)
+    vertexIsOnBorder(id.id)
   }
 
   override def edgeIsOnBoundary(id1: PointId, id2: PointId): Boolean = {
-    return edgeIsOnBorder(id1.id, id2.id);
+    edgeIsOnBorder(id1.id, id2.id)
   }
 
   override def triangleIsOnBoundary(id: TriangleId): Boolean = {
-    return triangleIsOnBorder(id.id)
+    triangleIsOnBorder(id.id)
   }
 }
 
@@ -104,8 +105,8 @@ object MeshBoundaryPredicates {
     val triangleOnBorder = new Array[Boolean](nTriangles)
 
     val edgeOnBorderBuilder = new CSCMatrix.Builder[Boolean](nPts, nPts)
-    triangles.map { triangle =>
-      edgesOfATriangle.map { edge =>
+    triangles.foreach { triangle =>
+      edgesOfATriangle.foreach { edge =>
         val v1 = triangle.pointIds(edge._1).id
         val v2 = triangle.pointIds(edge._2).id
         edgeOnBorderBuilder.add(v1, v2, false)
@@ -116,8 +117,8 @@ object MeshBoundaryPredicates {
 
     // edges from only a single triangle lie on the border,
     // edges contained in two triangles are not on a border
-    triangles.map { triangle =>
-      edgesOfATriangle.map { edge =>
+    triangles.foreach { triangle =>
+      edgesOfATriangle.foreach { edge =>
         val v1 = triangle.pointIds(edge._1).id
         val v2 = triangle.pointIds(edge._2).id
         edgeOnBorderTmp(v1, v2) = !edgeOnBorderTmp(v1, v2)
@@ -130,10 +131,10 @@ object MeshBoundaryPredicates {
 
     // points at one end of a border edge are also on the border,
     // triangles with one side on the border are also on the border
-    triangles.zipWithIndex.map { t =>
+    triangles.zipWithIndex.foreach { t =>
       val triangle = t._1
       val tIdx = t._2
-      edgesOfATriangle.map { edge =>
+      edgesOfATriangle.foreach { edge =>
         val v1 = triangle.pointIds(edge._1).id
         val v2 = triangle.pointIds(edge._2).id
         if (edgeOnBorder(v1, v2)) {

--- a/src/main/scala/scalismo/mesh/MeshBoundaryPredicates.scala
+++ b/src/main/scala/scalismo/mesh/MeshBoundaryPredicates.scala
@@ -64,8 +64,8 @@ trait TriangularMeshBoundaryPredicates extends MeshBoundaryPredicates {
  * @note the implementation with a Map instead of a CSCMatrix was three times slower using our test mesh.
  */
 private class BoundaryOfATriangleMeshPredicates(private var vertexIsOnBorder: IndexedSeq[Boolean],
-                                                private var edgeIsOnBorder: CSCMatrix[Boolean],
-                                                private var triangleIsOnBorder: IndexedSeq[Boolean]) extends TriangularMeshBoundaryPredicates {
+    private var edgeIsOnBorder: CSCMatrix[Boolean],
+    private var triangleIsOnBorder: IndexedSeq[Boolean]) extends TriangularMeshBoundaryPredicates {
 
   override def pointIsOnBoundary(id: PointId): Boolean = {
     return vertexIsOnBorder(id.id)

--- a/src/main/scala/scalismo/mesh/MeshCompactifier.scala
+++ b/src/main/scala/scalismo/mesh/MeshCompactifier.scala
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2016 University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package scalismo.mesh
+
+import scalismo.common.PointId
+import scalismo.geometry._3D
+
+/**
+ * a general operation on mesh, can also alter surface properties
+ */
+trait MeshManipulation {
+  /**
+   * get the transformed mesh
+   */
+  def transformedMesh: TriangleMesh[_3D]
+
+  /**
+   * apply operation to a surface property
+   * default implementation: warps old surface property (general but inefficient)
+   *
+   * @param property surface property to transform
+   */
+  def applyToSurfaceProperty[A](property: MeshSurfaceProperty[A]): MeshSurfaceProperty[A] = WarpedMeshSurfaceProperty(property, meshSurfaceCorrespondence)
+
+  /**
+   * correspondence on new surface, returns old surface coordinates for each new point on surface
+   */
+  def meshSurfaceCorrespondence: MeshSurfaceCorrespondence
+}
+
+/**
+ * compact a mesh: remove unreferenced points and triangles with invalid points, also respects external filters for points and triangles
+ *
+ * @param mesh           mesh to compact
+ * @param pointFilter    filter to remove points, keeps on true
+ * @param triangleFilter filter to remove triangles, keeps on true
+ */
+class MeshCompactifier(mesh: TriangleMesh[_3D], pointFilter: PointId => Boolean, triangleFilter: TriangleId => Boolean) extends MeshManipulation {
+  private val invalidPoint = PointId(-1)
+
+  private val meshPoints: Int = mesh.pointSet.numberOfPoints
+
+  private val pointValidity: Array[Boolean] = {
+    mesh.pointSet.pointIds.map(pointFilter).toArray
+  }
+
+  @inline
+  private def isPointValid(pointId: PointId) =
+    pointId.id < meshPoints &&
+      pointId != invalidPoint &&
+      pointValidity(pointId.id)
+
+  @inline
+  private def isTriangleValid(triangleId: TriangleId): Boolean = {
+    val t = mesh.triangulation.triangle(triangleId)
+    triangleId != TriangleId.invalid &&
+      triangleFilter(triangleId) &&
+      isPointValid(t.ptId1) &&
+      isPointValid(t.ptId2) &&
+      isPointValid(t.ptId3)
+  }
+
+  private val newTriangles: IndexedSeq[TriangleId] = {
+    mesh.triangulation.triangleIds.filter(isTriangleValid)
+  }
+
+  // find valid points: points referenced by valid triangles
+  private val newPoints: IndexedSeq[PointId] = {
+    newTriangles.iterator.map { mesh.triangulation.triangle }.flatMap { _.pointIds }.toIndexedSeq.distinct.sortBy { _.id }
+  }
+
+  private val numberOfPoints = newPoints.size
+  assert(numberOfPoints <= mesh.pointSet.numberOfPoints)
+
+  private val fwdIndex = Array.fill(mesh.pointSet.numberOfPoints)(invalidPoint)
+  for (newId <- 0 until numberOfPoints) {
+    val oldId = newPoints(newId)
+    fwdIndex(oldId.id) = PointId(newId)
+  }
+
+  /** find new id for old point id */
+  def pointFwdMap(oldId: PointId) = fwdIndex(oldId.id)
+
+  /** find old id for new point id */
+  def pointBackMap(newId: PointId) = newPoints(newId.id)
+
+  /** find old id for new triangle id */
+  def triangleBackMap(newId: TriangleId): TriangleId = newTriangles(newId.id)
+
+  override val transformedMesh: TriangleMesh[_3D] = {
+    val points = newPoints.map {
+      mesh.pointSet.point
+    }
+    val triangles = newTriangles.map { tid =>
+      val t = mesh.triangulation.triangle(tid)
+      TriangleCell(pointFwdMap(t.ptId1), pointFwdMap(t.ptId2), pointFwdMap(t.ptId3))
+    }
+    TriangleMesh3D(points, TriangleList(triangles))
+  }
+
+  override def applyToSurfaceProperty[A](property: MeshSurfaceProperty[A]): MeshSurfaceProperty[A] = {
+    require(property.triangulation == mesh.triangulation, "surface property is not compatible with mesh")
+    property match {
+      case trProp: TriangleProperty[A] =>
+        val newTriangleData = transformedMesh.triangulation.triangleIds.map { tId => trProp.onTriangle(triangleBackMap(tId)) }
+        TriangleProperty(transformedMesh.triangulation, newTriangleData)
+      case ptProp: SurfacePointProperty[A] =>
+        val newPointData = transformedMesh.pointSet.pointIds.map { pId => ptProp.atPoint(pointBackMap(pId)) }.toIndexedSeq
+        SurfacePointProperty(transformedMesh.triangulation, newPointData)(ptProp.interpolator)
+      case _ => super.applyToSurfaceProperty(property) // inefficient default warping
+    }
+  }
+
+  /**
+   * new surface correspondence: maps new triangle id to old
+   */
+  override def meshSurfaceCorrespondence: MeshSurfaceCorrespondence = new MeshSurfaceCorrespondence {
+    override def triangulation: TriangleList = transformedMesh.triangulation
+
+    override def targetTriangulation: TriangleList = mesh.triangulation
+
+    override def correspondingPoint(triangleId: TriangleId, bcc: BarycentricCoordinates): (TriangleId, BarycentricCoordinates) = (triangleBackMap(triangleId), bcc)
+  }
+}
+
+object MeshCompactifier {
+  def apply(mesh: TriangleMesh[_3D], pointFilter: PointId => Boolean, triangleFilter: TriangleId => Boolean): MeshCompactifier = new MeshCompactifier(mesh, pointFilter, triangleFilter)
+}

--- a/src/main/scala/scalismo/mesh/MeshMetrics.scala
+++ b/src/main/scala/scalismo/mesh/MeshMetrics.scala
@@ -76,8 +76,8 @@ object MeshMetrics {
    * Computes a binary image for each mesh and returns the Dice Coefficient between the two images
    */
   def diceCoefficient(m1: TriangleMesh[_3D], m2: TriangleMesh[_3D])(implicit rand: Random): Double = {
-    val imgA = Mesh.meshToBinaryImage(m1)
-    val imgB = Mesh.meshToBinaryImage(m2)
+    val imgA = m1.operations.toBinaryImage
+    val imgB = m2.operations.toBinaryImage
 
     def minPoint(pt1: Point[_3D], pt2: Point[_3D]) = Point(math.min(pt1(0), pt2(0)), math.min(pt1(1), pt2(1)), math.min(pt1(2), pt2(2)))
     def maxPoint(pt1: Point[_3D], pt2: Point[_3D]) = Point(math.max(pt1(0), pt2(0)), math.max(pt1(1), pt2(1)), math.max(pt1(2), pt2(2)))

--- a/src/main/scala/scalismo/mesh/MeshOperations.scala
+++ b/src/main/scala/scalismo/mesh/MeshOperations.scala
@@ -15,6 +15,7 @@
  */
 package scalismo.mesh
 
+import scalismo.common.PointId
 import scalismo.geometry.{Point, Vector, _3D}
 import scalismo.mesh.boundingSpheres._
 
@@ -42,4 +43,12 @@ class TriangleMesh3DOperations(mesh: TriangleMesh3D) {
   def closestPointOnSurfaceWithSquaredDistance(point: Point[_3D]): (Point[_3D],Double) = closestPointOnSurface.getClosestPoint(point)
   def closestPointOnSurface(point: Point[_3D]): ClosestPoint = closestPointOnSurface.getClosestPointMeta(point)
 
+  /**
+    * Boundary predicates
+    */
+  private lazy val boundary: TriangularMeshBoundaryPredicates = MeshBoundaryPredicates(mesh)
+  def pointIsOnBoundary(pid: PointId): Boolean = boundary.pointIsOnBoundary(pid)
+  def edgeIsOnBoundary(pid1: PointId, pid2: PointId): Boolean = boundary.edgeIsOnBoundary(pid1, pid2)
+  def triangleIsOnBoundary(tid: TriangleId): Boolean = boundary.triangleIsOnBoundary(tid: TriangleId)
+  
 }

--- a/src/main/scala/scalismo/mesh/MeshOperations.scala
+++ b/src/main/scala/scalismo/mesh/MeshOperations.scala
@@ -32,7 +32,7 @@ class TriangleMesh3DOperations(mesh: TriangleMesh3D) {
   private lazy val boundingSpheres = BoundingSpheres.createForTriangles(triangles)
 
   private lazy val intersect: TriangulatedSurfaceIntersectionIndex[_3D] = new LineTriangleMesh3DIntersectionIndex(boundingSpheres, mesh, triangles)
-  def hasIntersection(point: Point[_3D], direction: Vector[_3D]) = intersect.hasIntersection(point, direction)
+  def hasIntersection(point: Point[_3D], direction: Vector[_3D]): Boolean = intersect.hasIntersection(point, direction)
   def getIntersectionPoints(point: Point[_3D], direction: Vector[_3D]): Seq[Point[_3D]] = intersect.getIntersectionPoints(point, direction)
   def getIntersectionPointsOnSurface(point: Point[_3D], direction: Vector[_3D]): Seq[(TriangleId, BarycentricCoordinates)] = intersect.getSurfaceIntersectionPoints(point, direction)
 

--- a/src/main/scala/scalismo/mesh/MeshOperations.scala
+++ b/src/main/scala/scalismo/mesh/MeshOperations.scala
@@ -16,39 +16,37 @@
 package scalismo.mesh
 
 import scalismo.common.PointId
-import scalismo.geometry.{Point, Vector, _3D}
+import scalismo.geometry.{ Point, Vector, _3D }
 import scalismo.mesh.boundingSpheres._
-
 
 object MeshOperations {
   def apply(mesh: TriangleMesh3D) = new TriangleMesh3DOperations(mesh)
 }
 
-
 class TriangleMesh3DOperations(mesh: TriangleMesh3D) {
 
   /**
-    * Bounding spheres based mesh operations
-    */
+   * Bounding spheres based mesh operations
+   */
   private lazy val triangles = BoundingSpheres.triangleListFromTriangleMesh3D(mesh)
   private lazy val boundingSpheres = BoundingSpheres.createForTriangles(triangles)
 
   private lazy val intersect: TriangulatedSurfaceIntersectionIndex[_3D] = new LineTriangleMesh3DIntersectionIndex(boundingSpheres, mesh, triangles)
-  def hasIntersection(point: Point[_3D], direction: Vector[_3D]) = intersect.hasIntersection(point,direction)
-  def getIntersectionPoints(point: Point[_3D], direction: Vector[_3D]): Seq[Point[_3D]] = intersect.getIntersectionPoints(point,direction)
+  def hasIntersection(point: Point[_3D], direction: Vector[_3D]) = intersect.hasIntersection(point, direction)
+  def getIntersectionPoints(point: Point[_3D], direction: Vector[_3D]): Seq[Point[_3D]] = intersect.getIntersectionPoints(point, direction)
   def getIntersectionPointsOnSurface(point: Point[_3D], direction: Vector[_3D]): Seq[(TriangleId, BarycentricCoordinates)] = intersect.getSurfaceIntersectionPoints(point, direction)
 
   private lazy val closestPointOnSurface: SurfaceSpatialIndex[_3D] = new TriangleMesh3DSpatialIndex(boundingSpheres, mesh, triangles)
   def shortestDistanceToSurface(point: Point[_3D]): Double = closestPointOnSurface.getSquaredShortestDistance(point: Point[_3D])
-  def closestPointOnSurfaceWithSquaredDistance(point: Point[_3D]): (Point[_3D],Double) = closestPointOnSurface.getClosestPoint(point)
+  def closestPointOnSurfaceWithSquaredDistance(point: Point[_3D]): (Point[_3D], Double) = closestPointOnSurface.getClosestPoint(point)
   def closestPointOnSurface(point: Point[_3D]): ClosestPoint = closestPointOnSurface.getClosestPointMeta(point)
 
   /**
-    * Boundary predicates
-    */
+   * Boundary predicates
+   */
   private lazy val boundary: TriangularMeshBoundaryPredicates = MeshBoundaryPredicates(mesh)
   def pointIsOnBoundary(pid: PointId): Boolean = boundary.pointIsOnBoundary(pid)
   def edgeIsOnBoundary(pid1: PointId, pid2: PointId): Boolean = boundary.edgeIsOnBoundary(pid1, pid2)
   def triangleIsOnBoundary(tid: TriangleId): Boolean = boundary.triangleIsOnBoundary(tid: TriangleId)
-  
+
 }

--- a/src/main/scala/scalismo/mesh/MeshOperations.scala
+++ b/src/main/scala/scalismo/mesh/MeshOperations.scala
@@ -15,17 +15,31 @@
  */
 package scalismo.mesh
 
-import scalismo.mesh.boundingSpheres.{ BoundingSpheres, LineTriangleMesh3DIntersectionIndex, TriangleMesh3DSpatialIndex }
+import scalismo.geometry.{Point, Vector, _3D}
+import scalismo.mesh.boundingSpheres._
+
 
 object MeshOperations {
   def apply(mesh: TriangleMesh3D) = new TriangleMesh3DOperations(mesh)
 }
 
+
 class TriangleMesh3DOperations(mesh: TriangleMesh3D) {
 
+  /**
+    * Bounding spheres based mesh operations
+    */
   private lazy val triangles = BoundingSpheres.triangleListFromTriangleMesh3D(mesh)
   private lazy val boundingSpheres = BoundingSpheres.createForTriangles(triangles)
 
-  lazy val intersect = new LineTriangleMesh3DIntersectionIndex(boundingSpheres, mesh, triangles)
-  lazy val closestPointOnSurface = new TriangleMesh3DSpatialIndex(boundingSpheres, mesh, triangles)
+  private lazy val intersect: TriangulatedSurfaceIntersectionIndex[_3D] = new LineTriangleMesh3DIntersectionIndex(boundingSpheres, mesh, triangles)
+  def hasIntersection(point: Point[_3D], direction: Vector[_3D]) = intersect.hasIntersection(point,direction)
+  def getIntersectionPoints(point: Point[_3D], direction: Vector[_3D]): Seq[Point[_3D]] = intersect.getIntersectionPoints(point,direction)
+  def getIntersectionPointsOnSurface(point: Point[_3D], direction: Vector[_3D]): Seq[(TriangleId, BarycentricCoordinates)] = intersect.getSurfaceIntersectionPoints(point, direction)
+
+  private lazy val closestPointOnSurface: SurfaceSpatialIndex[_3D] = new TriangleMesh3DSpatialIndex(boundingSpheres, mesh, triangles)
+  def shortestDistanceToSurface(point: Point[_3D]): Double = closestPointOnSurface.getSquaredShortestDistance(point: Point[_3D])
+  def closestPointOnSurfaceWithSquaredDistance(point: Point[_3D]): (Point[_3D],Double) = closestPointOnSurface.getClosestPoint(point)
+  def closestPointOnSurface(point: Point[_3D]): ClosestPoint = closestPointOnSurface.getClosestPointMeta(point)
+
 }

--- a/src/main/scala/scalismo/mesh/MeshOperations.scala
+++ b/src/main/scala/scalismo/mesh/MeshOperations.scala
@@ -22,8 +22,10 @@ object MeshOperations {
 }
 
 class TriangleMesh3DOperations(mesh: TriangleMesh3D) {
-  lazy val triangles = BoundingSpheres.triangleListFromTriangleMesh3D(mesh)
-  lazy val boundingSpheres = BoundingSpheres.createForTriangles(triangles)
+
+  private lazy val triangles = BoundingSpheres.triangleListFromTriangleMesh3D(mesh)
+  private lazy val boundingSpheres = BoundingSpheres.createForTriangles(triangles)
+
   lazy val intersect = new LineTriangleMesh3DIntersectionIndex(boundingSpheres, mesh, triangles)
   lazy val closestPointOnSurface = new TriangleMesh3DSpatialIndex(boundingSpheres, mesh, triangles)
 }

--- a/src/main/scala/scalismo/mesh/MeshOperations.scala
+++ b/src/main/scala/scalismo/mesh/MeshOperations.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2016 University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package scalismo.mesh
+
+import scalismo.mesh.boundingSpheres.{ BoundingSpheres, LineTriangleMesh3DIntersectionIndex, TriangleMesh3DSpatialIndex }
+
+object MeshOperations {
+  def apply(mesh: TriangleMesh3D) = new TriangleMesh3DOperations(mesh)
+}
+
+class TriangleMesh3DOperations(mesh: TriangleMesh3D) {
+  lazy val triangles = BoundingSpheres.triangleListFromTriangleMesh3D(mesh)
+  lazy val boundingSpheres = BoundingSpheres.createForTriangles(triangles)
+  lazy val intersect = new LineTriangleMesh3DIntersectionIndex(boundingSpheres, mesh, triangles)
+  lazy val closestPointOnSurface = new TriangleMesh3DSpatialIndex(boundingSpheres, mesh, triangles)
+}

--- a/src/main/scala/scalismo/mesh/MeshOperations.scala
+++ b/src/main/scala/scalismo/mesh/MeshOperations.scala
@@ -43,8 +43,8 @@ class TriangleMesh3DOperations(private val mesh: TriangleMesh3D) {
   def getIntersectionPointsOnSurface(point: Point[_3D], direction: Vector[_3D]): Seq[(TriangleId, BarycentricCoordinates)] = intersect.getSurfaceIntersectionPoints(point, direction)
 
   private lazy val closestPointOnSurface: SurfaceSpatialIndex[_3D] = new TriangleMesh3DSpatialIndex(boundingSpheres, mesh, triangles)
-  def shortestDistanceToSurface(point: Point[_3D]): Double = closestPointOnSurface.getSquaredShortestDistance(point: Point[_3D])
-  def closestPointOnSurfaceWithSquaredDistance(point: Point[_3D]): (Point[_3D], Double) = closestPointOnSurface.getClosestPoint(point)
+  def shortestDistanceToSurfaceSquared(point: Point[_3D]): Double = closestPointOnSurface.getSquaredShortestDistance(point: Point[_3D])
+  def closestPoint(point: Point[_3D]): ClosestPoint = closestPointOnSurface.getClosestPoint(point)
   def closestPointOnSurface(point: Point[_3D]): ClosestPoint = closestPointOnSurface.getClosestPointMeta(point)
 
   /**
@@ -81,10 +81,10 @@ class TriangleMesh3DOperations(private val mesh: TriangleMesh3D) {
    * Returns a new continuous [[DifferentiableScalarImage]] defined on 3-dimensional [[RealSpace]] which is the distance transform of the mesh
    */
   def toDistanceImage: DifferentiableScalarImage[_3D] = {
-    def dist(pt: Point[_3D]): Float = Math.sqrt(shortestDistanceToSurface(pt)).toFloat
+    def dist(pt: Point[_3D]): Float = Math.sqrt(shortestDistanceToSurfaceSquared(pt)).toFloat
 
     def grad(pt: Point[_3D]) = {
-      val closestPt = closestPointOnSurfaceWithSquaredDistance(pt)._1
+      val closestPt = closestPoint(pt).point
       val grad = Vector(pt(0) - closestPt(0), pt(1) - closestPt(1), pt(2) - closestPt(2))
       grad * (1.0 / grad.norm)
     }

--- a/src/main/scala/scalismo/mesh/MeshSurfaceCorrespondence.scala
+++ b/src/main/scala/scalismo/mesh/MeshSurfaceCorrespondence.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2016 University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package scalismo.mesh
+
+/**
+ * express correspondence of a triangulated surface to another triangulation, maps points on this surface to target surface
+ */
+trait MeshSurfaceCorrespondence extends MeshSurfaceProperty[(TriangleId, BarycentricCoordinates)] {
+
+  /**
+   * get corresponding point on target surface
+   * @param triangleId triangle on this surface
+   * @param bcc barycentric coordinates on this surface
+   * @return corresponding triangle and barycentric coordinates on target surface
+   */
+  def correspondingPoint(triangleId: TriangleId, bcc: BarycentricCoordinates): (TriangleId, BarycentricCoordinates)
+
+  /**
+   * triangulation of this surface
+   * @return
+   */
+  override def triangulation: TriangleList
+
+  /**
+   * triangulation of target surface
+   * @return
+   */
+  def targetTriangulation: TriangleList
+
+  override def onSurface(triangleId: TriangleId, bcc: BarycentricCoordinates): (TriangleId, BarycentricCoordinates) = correspondingPoint(triangleId: TriangleId, bcc: BarycentricCoordinates)
+}

--- a/src/main/scala/scalismo/mesh/TriangleMesh.scala
+++ b/src/main/scala/scalismo/mesh/TriangleMesh.scala
@@ -85,7 +85,7 @@ case class TriangleMesh3D(pointSet: UnstructuredPointsDomain[_3D], triangulation
   val triangles = triangulation.triangles
   val cells = triangles
 
-  lazy val operations = MeshOperations(this)
+  lazy val operations: TriangleMesh3DOperations = MeshOperations(this)
 
   lazy val boundingBox = pointSet.boundingBox
 

--- a/src/main/scala/scalismo/mesh/TriangleMesh.scala
+++ b/src/main/scala/scalismo/mesh/TriangleMesh.scala
@@ -176,7 +176,7 @@ case class TriangleMesh3D(pointSet: UnstructuredPointsDomain[_3D], triangulation
    *  A uniform distribution is used for sampling points.
    *
    *  @param t Triangle cell in which to draw a random point
-   *  @param seed Seed value for the random generator
+   *  @param rnd implicit Random object
    */
   def samplePointInTriangleCell(t: TriangleCell)(implicit rnd: Random): Point[_3D] = {
     val A = pointSet.point(t.ptId1).toVector

--- a/src/main/scala/scalismo/mesh/TriangleMesh.scala
+++ b/src/main/scala/scalismo/mesh/TriangleMesh.scala
@@ -85,6 +85,8 @@ case class TriangleMesh3D(pointSet: UnstructuredPointsDomain[_3D], triangulation
   val triangles = triangulation.triangles
   val cells = triangles
 
+  lazy val operations = MeshOperations(this)
+
   lazy val boundingBox = pointSet.boundingBox
 
   /** Get all cell normals as a surface property */

--- a/src/main/scala/scalismo/mesh/WarpedMeshSurfaceProperty.scala
+++ b/src/main/scala/scalismo/mesh/WarpedMeshSurfaceProperty.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2016 University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package scalismo.mesh
+
+/**
+ * use a target surface property through a surface correspondence
+ * Each lookup on this surface returns the property at the corresponding point of the underlying surface
+ * @param underlyingProperty surface property on target surface (underlying)
+ * @param correspondence surface correspondence field mapping points in this triangulation to underlying triangulation
+ * @tparam A type of property
+ */
+case class WarpedMeshSurfaceProperty[A](underlyingProperty: MeshSurfaceProperty[A], correspondence: MeshSurfaceCorrespondence) extends MeshSurfaceProperty[A] {
+  require(underlyingProperty.triangulation == correspondence.targetTriangulation, "correspondence is not compatible with underlying property")
+
+  override def onSurface(triangleId: TriangleId, bcc: BarycentricCoordinates): A = {
+    val oldSurfacePoint = correspondence.onSurface(triangleId, bcc)
+    underlyingProperty(oldSurfacePoint._1, oldSurfacePoint._2)
+  }
+
+  override def triangulation: TriangleList = correspondence.triangulation
+}

--- a/src/main/scala/scalismo/mesh/boundingSpheres/BSDistance.scala
+++ b/src/main/scala/scalismo/mesh/boundingSpheres/BSDistance.scala
@@ -22,7 +22,7 @@ import scalismo.mesh.boundingSpheres.ClosestPointType._
 /**
  * Holds triangles and precalculated vectors.
  */
-private case class Triangle(a: Vector[_3D], b: Vector[_3D], c: Vector[_3D], ab: Vector[_3D], ac: Vector[_3D], n: Vector[_3D])
+private[mesh] case class Triangle(a: Vector[_3D], b: Vector[_3D], c: Vector[_3D], ab: Vector[_3D], ac: Vector[_3D], n: Vector[_3D])
 
 /**
  * Barycentric Coordinates. Pair of doubles characterizing a point by the two vectors AB and AC of a triangle.
@@ -53,13 +53,13 @@ private object BSDistance {
   }
 
   // mutable classes
-  case class Index(var idx: Int)
-  case class Distance2(var distance2: Double)
-  case class CP(var distance2: Double, var pt: Vector[_3D], var ptType: ClosestPointType, var bc: BC, var idx: (Int, Int))
+  private[boundingSpheres] case class Index(var idx: Int)
+  private[boundingSpheres] case class Distance2(var distance2: Double)
+  private[boundingSpheres] case class CP(var distance2: Double, var pt: Vector[_3D], var ptType: ClosestPointType, var bc: BC, var idx: (Int, Int))
 
   // immutable classes
-  case class DistanceSqr(val distance2: Double)
-  case class DistanceSqrAndPoint(val distance2: Double, pt: Vector[_3D])
+  private[boundingSpheres] case class DistanceSqr(val distance2: Double)
+  private[boundingSpheres] case class DistanceSqrAndPoint(val distance2: Double, pt: Vector[_3D])
 
   /**
    * Finds closest point to triangle.

--- a/src/main/scala/scalismo/mesh/boundingSpheres/BSDistance.scala
+++ b/src/main/scala/scalismo/mesh/boundingSpheres/BSDistance.scala
@@ -58,8 +58,8 @@ private object BSDistance {
   private[boundingSpheres] case class CP(var distance2: Double, var pt: Vector[_3D], var ptType: ClosestPointType, var bc: BC, var idx: (Int, Int))
 
   // immutable classes
-  private[boundingSpheres] case class DistanceSqr(val distance2: Double)
-  private[boundingSpheres] case class DistanceSqrAndPoint(val distance2: Double, pt: Vector[_3D])
+  private[boundingSpheres] case class DistanceSqr(distance2: Double)
+  private[boundingSpheres] case class DistanceSqrAndPoint(distance2: Double, pt: Vector[_3D])
 
   /**
    * Finds closest point to triangle.
@@ -207,7 +207,7 @@ private object BSDistance {
 
     val D = t1.crossproduct(t2)
 
-    return D.norm2 / t1.norm2
+    D.norm2 / t1.norm2
   }
 
   @inline

--- a/src/main/scala/scalismo/mesh/boundingSpheres/BSIntersection.scala
+++ b/src/main/scala/scalismo/mesh/boundingSpheres/BSIntersection.scala
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2016 University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package scalismo.mesh.boundingSpheres
+
+import scalismo.geometry.{ Point, Vector, _3D }
+import scalismo.mesh.BarycentricCoordinates
+
+/**
+ * Helper function to calculate intersection points.
+ */
+private[boundingSpheres] object BSIntersection {
+
+  def intersectLineWithTriangle(point: Vector[_3D], direction: Vector[_3D], a: Vector[_3D], b: Vector[_3D], c: Vector[_3D]): (Boolean, Point[_3D]) = {
+    val det = Determinantes.det3x3(
+      a.x - b.x, a.x - c.x, direction.x,
+      a.y - b.y, a.y - c.y, direction.y,
+      a.z - b.z, a.z - c.z, direction.z)
+
+    val beta = Determinantes.det3x3(
+      a.x - point.x, a.x - c.x, direction.x,
+      a.y - point.y, a.y - c.y, direction.y,
+      a.z - point.z, a.z - c.z, direction.z
+    ) / det
+
+    val gamma = Determinantes.det3x3(
+      a.x - b.x, a.x - point.x, direction.x,
+      a.y - b.y, a.y - point.y, direction.y,
+      a.z - b.z, a.z - point.z, direction.z
+    ) / det
+
+    val t = Determinantes.det3x3(
+      a.x - b.x, a.x - c.x, a.x - point.x,
+      a.y - b.y, a.y - c.y, a.y - point.y,
+      a.z - b.z, a.z - c.z, a.z - point.z
+    ) / det
+
+    if (beta >= 0.0 && gamma >= 0.0 && beta + gamma <= 1.0) {
+      (true, Point(
+        point.x + t * direction.x,
+        point.y + t * direction.y,
+        point.z + t * direction.z))
+    } else {
+      (false, Point(-1, -1, -1))
+    }
+
+  }
+
+  def intersectLineWithTriangleBarycentric(point: Vector[_3D], direction: Vector[_3D], a: Vector[_3D], b: Vector[_3D], c: Vector[_3D]): (Boolean, BarycentricCoordinates) = {
+    val det = Determinantes.det3x3(
+      a.x - b.x, a.x - c.x, direction.x,
+      a.y - b.y, a.y - c.y, direction.y,
+      a.z - b.z, a.z - c.z, direction.z)
+
+    val beta = Determinantes.det3x3(
+      a.x - point.x, a.x - c.x, direction.x,
+      a.y - point.y, a.y - c.y, direction.y,
+      a.z - point.z, a.z - c.z, direction.z
+    ) / det
+
+    val gamma = Determinantes.det3x3(
+      a.x - b.x, a.x - point.x, direction.x,
+      a.y - b.y, a.y - point.y, direction.y,
+      a.z - b.z, a.z - point.z, direction.z
+    ) / det
+
+    if (beta >= 0.0 && gamma >= 0.0 && beta + gamma <= 1.0) {
+      (true, BarycentricCoordinates(1 - beta - gamma, beta, gamma))
+    } else {
+      (false, BarycentricCoordinates(-1, -1, -1))
+    }
+  }
+
+  def intersectLineSphereSquared(point: Vector[_3D],
+    direction: Vector[_3D],
+    center: Vector[_3D],
+    r2: Double): Boolean = {
+    BSDistance.squaredDistanceToLineDirection(center, point, direction) < r2
+  }
+
+}
+
+private[boundingSpheres] object Determinantes {
+
+  @inline
+  def det2x2(a1: Double, a2: Double,
+    b1: Double, b2: Double): Double = {
+    (
+      +a1 * b2
+      - b1 * a2
+    )
+  }
+
+  @inline
+  def det3x3(a1: Double, a2: Double, a3: Double,
+    b1: Double, b2: Double, b3: Double,
+    c1: Double, c2: Double, c3: Double): Double = {
+    (
+      +a1 * det2x2(b2, b3, c2, c3)
+      - b1 * det2x2(a2, a3, c2, c3)
+      + c1 * det2x2(a2, a3, b2, b3)
+    )
+  }
+
+  @inline
+  def det4x4(a1: Double, a2: Double, a3: Double, a4: Double,
+    b1: Double, b2: Double, b3: Double, b4: Double,
+    c1: Double, c2: Double, c3: Double, c4: Double,
+    d1: Double, d2: Double, d3: Double, d4: Double): Double = {
+    (
+      +a1 * det3x3(b2, b3, b4, c2, c3, c4, d2, d3, d4)
+      - b1 * det3x3(c2, c3, c4, d2, d3, d4, a2, a3, a4)
+      + c1 * det3x3(d2, d3, d4, a2, a3, a4, b2, b3, b4)
+      - d1 * det3x3(a2, a3, a4, b2, b3, b4, c2, c3, c4)
+      - a2 * det3x3(b3, b4, b1, c3, c4, c1, d3, d4, d1)
+      + b2 * det3x3(c3, c4, c1, d3, d4, d1, a3, a4, a1)
+      - c2 * det3x3(d3, d4, d1, a3, a4, a1, b3, b4, b1)
+      + d2 * det3x3(a3, a4, a1, b3, b4, b1, c3, c4, c1)
+      + a3 * det3x3(b4, b1, b2, c4, c1, c2, d4, d1, d2)
+      - b3 * det3x3(c4, c1, c2, d4, d1, d2, a4, a1, a2)
+      + c3 * det3x3(d4, d1, d2, a4, a1, a2, b4, b1, b2)
+      - d3 * det3x3(a4, a1, a2, b4, b1, b2, c4, c1, c2)
+      - a4 * det3x3(b1, b2, b3, c1, c2, c3, d1, d2, d3)
+      + b4 * det3x3(c1, c2, c3, d1, d2, d3, a1, a2, a3)
+      - c4 * det3x3(d1, d2, d3, a1, a2, a3, b1, b2, b3)
+      + d4 * det3x3(a1, a2, a3, b1, b2, b3, c1, c2, c3)
+    )
+  }
+
+}

--- a/src/main/scala/scalismo/mesh/boundingSpheres/BoundingSpheres.scala
+++ b/src/main/scala/scalismo/mesh/boundingSpheres/BoundingSpheres.scala
@@ -35,7 +35,7 @@ import scala.annotation.tailrec
  * @param r2     Squared radius of bounding sphere.
  * @param idx    Index of entity used to form leave.
  */
-private[mesh]  abstract class BoundingSphere(val center: Vector[_3D],
+private[mesh] abstract class BoundingSphere(val center: Vector[_3D],
     val r2: Double,
     val idx: Int,
     val left: BoundingSphere,

--- a/src/main/scala/scalismo/mesh/boundingSpheres/ClosestPoint.scala
+++ b/src/main/scala/scalismo/mesh/boundingSpheres/ClosestPoint.scala
@@ -15,7 +15,9 @@
  */
 package scalismo.mesh.boundingSpheres
 
-import scalismo.geometry.{ Point, _3D }
+import scalismo.common.PointId
+import scalismo.geometry.{Point, _3D}
+import scalismo.mesh.{BarycentricCoordinates, TriangleId}
 
 class ClosestPoint(val point: Point[_3D],
     val distance2: Double) {
@@ -28,14 +30,14 @@ class ClosestPoint(val point: Point[_3D],
 
 case class ClosestPointIsPoint(override val point: Point[_3D],
   override val distance2: Double,
-  idx: Int) extends ClosestPoint(point, distance2)
+  idx: PointId) extends ClosestPoint(point, distance2)
 
 case class ClosestPointOnLine(override val point: Point[_3D],
   override val distance2: Double,
-  idx: (Int, Int),
+  idx: (PointId, PointId),
   bc: Double) extends ClosestPoint(point, distance2)
 
 case class ClosestPointInTriangle(override val point: Point[_3D],
   override val distance2: Double,
-  idx: Int,
-  bc: (Double, Double)) extends ClosestPoint(point, distance2)
+  idx: TriangleId,
+  bc: BarycentricCoordinates) extends ClosestPoint(point, distance2)

--- a/src/main/scala/scalismo/mesh/boundingSpheres/ClosestPoint.scala
+++ b/src/main/scala/scalismo/mesh/boundingSpheres/ClosestPoint.scala
@@ -16,8 +16,8 @@
 package scalismo.mesh.boundingSpheres
 
 import scalismo.common.PointId
-import scalismo.geometry.{Point, _3D}
-import scalismo.mesh.{BarycentricCoordinates, TriangleId}
+import scalismo.geometry.{ Point, _3D }
+import scalismo.mesh.{ BarycentricCoordinates, TriangleId }
 
 class ClosestPoint(val point: Point[_3D],
     val distance2: Double) {

--- a/src/main/scala/scalismo/mesh/boundingSpheres/ClosestPoint.scala
+++ b/src/main/scala/scalismo/mesh/boundingSpheres/ClosestPoint.scala
@@ -20,24 +20,24 @@ import scalismo.geometry.{ Point, _3D }
 import scalismo.mesh.{ BarycentricCoordinates, TriangleId }
 
 class ClosestPoint(val point: Point[_3D],
-    val distance2: Double) {
+    val distanceSquared: Double) {
   def <(that: ClosestPoint) = {
-    this.distance2 < that.distance2
+    this.distanceSquared < that.distanceSquared
   }
 
   def toPoint() = point
 }
 
-case class ClosestPointIsPoint(override val point: Point[_3D],
-  override val distance2: Double,
-  idx: PointId) extends ClosestPoint(point, distance2)
+case class ClosestPointIsVertex(override val point: Point[_3D],
+  override val distanceSquared: Double,
+  idx: PointId) extends ClosestPoint(point, distanceSquared)
 
 case class ClosestPointOnLine(override val point: Point[_3D],
-  override val distance2: Double,
+  override val distanceSquared: Double,
   idx: (PointId, PointId),
-  bc: Double) extends ClosestPoint(point, distance2)
+  bc: Double) extends ClosestPoint(point, distanceSquared)
 
 case class ClosestPointInTriangle(override val point: Point[_3D],
-  override val distance2: Double,
+  override val distanceSquared: Double,
   idx: TriangleId,
-  bc: BarycentricCoordinates) extends ClosestPoint(point, distance2)
+  bc: BarycentricCoordinates) extends ClosestPoint(point, distanceSquared)

--- a/src/main/scala/scalismo/mesh/boundingSpheres/DiscreteSpatialIndex.scala
+++ b/src/main/scala/scalismo/mesh/boundingSpheres/DiscreteSpatialIndex.scala
@@ -17,6 +17,7 @@ package scalismo.mesh.boundingSpheres
 
 import breeze.numerics._
 import BSDistance.{ Distance2, Index, _ }
+import scalismo.common.PointId
 import scalismo.geometry.{ Point, Vector, _3D }
 import scalismo.mesh.TriangleMesh
 
@@ -67,7 +68,7 @@ private class DiscreteSpatialIndexImplementation(private val bs: BoundingSphere,
     val lastD = toPoint(lastP, p)
     val d: Distance2 = new Distance2(lastD.distance2)
     distanceToPartition(p, bs, d, lastIdx.get())
-    ClosestPointIsPoint(pointList(lastIdx.get().idx).toPoint, d.distance2, lastIdx.get().idx)
+    ClosestPointIsPoint(pointList(lastIdx.get().idx).toPoint, d.distance2, PointId(lastIdx.get().idx))
   }
 
   private val lastIdx: ThreadLocal[Index] = new ThreadLocal[Index]() {

--- a/src/main/scala/scalismo/mesh/boundingSpheres/DiscreteSpatialIndex.scala
+++ b/src/main/scala/scalismo/mesh/boundingSpheres/DiscreteSpatialIndex.scala
@@ -25,7 +25,7 @@ import scalismo.mesh.TriangleMesh
  * SpatialIndex for a set of points
  */
 trait DiscreteSpatialIndex {
-  def closestPoint(point: Point[_3D]): ClosestPointIsPoint
+  def closestPoint(point: Point[_3D]): ClosestPointIsVertex
 }
 
 /**
@@ -62,13 +62,13 @@ private class DiscreteSpatialIndexImplementation(private val bs: BoundingSphere,
   /**
    * find closest point function
    */
-  def closestPoint(point: Point[_3D]): ClosestPointIsPoint = {
+  def closestPoint(point: Point[_3D]): ClosestPointIsVertex = {
     val p = point.toVector
     val lastP = pointList(lastIdx.get().idx)
     val lastD = toPoint(lastP, p)
     val d: Distance2 = new Distance2(lastD.distance2)
     distanceToPartition(p, bs, d, lastIdx.get())
-    ClosestPointIsPoint(pointList(lastIdx.get().idx).toPoint, d.distance2, PointId(lastIdx.get().idx))
+    ClosestPointIsVertex(pointList(lastIdx.get().idx).toPoint, d.distance2, PointId(lastIdx.get().idx))
   }
 
   private val lastIdx: ThreadLocal[Index] = new ThreadLocal[Index]() {

--- a/src/main/scala/scalismo/mesh/boundingSpheres/SurfaceIntersectionIndex.scala
+++ b/src/main/scala/scalismo/mesh/boundingSpheres/SurfaceIntersectionIndex.scala
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2016 University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package scalismo.mesh.boundingSpheres
+
+import scalismo.geometry.{ Dim, Point, Vector, _3D }
+import scalismo.mesh.{ BarycentricCoordinates, TriangleId, TriangleMesh3D }
+
+trait SurfaceIntersectionIndex[D <: Dim] {
+
+  def hasIntersection(point: Point[D], direction: Vector[D]): Boolean
+
+  def getIntersectionPoints(point: Point[D], direction: Vector[D]): Seq[Point[D]]
+
+}
+
+trait TriangulatedSurfaceIntersectionIndex[D <: Dim] extends SurfaceIntersectionIndex[D] {
+
+  def getSurfaceIntersectionPoints(point: Point[D], direction: Vector[D]): Seq[(TriangleId, BarycentricCoordinates)]
+}
+
+object LineSurfaceIntersectionIndexBuilder {
+
+  /**
+   * Creates SurfaceDistance for a TriangleMesh3D.
+   */
+  def fromTriangleMesh3D(mesh: TriangleMesh3D): TriangulatedSurfaceIntersectionIndex[_3D] = {
+
+    // build triangle list (use only Vector[_3D], no Points)
+    val triangles = mesh.triangulation.triangles.map { t =>
+
+      val a = mesh.pointSet.point(t.ptId1).toVector
+      val b = mesh.pointSet.point(t.ptId2).toVector
+      val c = mesh.pointSet.point(t.ptId3).toVector
+      val ab = b - a
+      val ac = c - a
+
+      new Triangle(
+        a, b, c,
+        ab, ac,
+        ab.crossproduct(ac)
+      )
+
+    }
+
+    // build up search structure
+    val bs = BoundingSpheres.createForTriangles(triangles)
+
+    // new distance object
+    new LineTriangleMesh3DIntersectionIndex(bs, mesh, triangles)
+
+  }
+
+}
+
+private[mesh] case class LineTriangleMesh3DIntersectionIndex(private val boundingSphere: BoundingSphere,
+    private val mesh: TriangleMesh3D,
+    private val triangles: Seq[Triangle]) extends TriangulatedSurfaceIntersectionIndex[_3D] {
+
+  override def hasIntersection(point: Point[_3D], direction: Vector[_3D]): Boolean = {
+    intersectWithLine(point.toVector, direction, boundingSphere).size > 0
+  }
+
+  override def getIntersectionPoints(point: Point[_3D], direction: Vector[_3D]): Seq[Point[_3D]] = {
+    intersectWithLine(point.toVector, direction, boundingSphere)
+  }
+
+  override def getSurfaceIntersectionPoints(point: Point[_3D], direction: Vector[_3D]): Seq[(TriangleId, BarycentricCoordinates)] = {
+    surfaceIntersectionPoint(point.toVector, direction, boundingSphere).map(t => (TriangleId(t._1), t._2))
+  }
+
+  private def intersectWithLine(point: Vector[_3D], direction: Vector[_3D], partition: BoundingSphere): Seq[Point[_3D]] = {
+    if (BSIntersection.intersectLineSphereSquared(point, direction, partition.center, partition.r2)) {
+      if (partition.idx < 0) {
+        val l = if (partition.hasLeft) {
+          intersectWithLine(point, direction, partition.left)
+        } else {
+          Nil
+        }
+        val r = if (partition.hasRight) {
+          intersectWithLine(point, direction, partition.right)
+        } else {
+          Nil
+        }
+        l ++ r
+      } else {
+        val triangle = triangles(partition.idx)
+        val intersection: (Boolean, Point[_3D]) = BSIntersection.intersectLineWithTriangle(point, direction, triangle.a, triangle.b, triangle.c)
+        if (intersection._1) {
+          List[Point[_3D]](intersection._2)
+        } else {
+          List[Point[_3D]]()
+        }
+      }
+    } else {
+      List[Point[_3D]]()
+    }
+  }
+
+  private def surfaceIntersectionPoint(point: Vector[_3D], direction: Vector[_3D], partition: BoundingSphere): List[(Int, BarycentricCoordinates)] = {
+    if (BSIntersection.intersectLineSphereSquared(point, direction, partition.center, partition.r2)) {
+      if (partition.idx < 0) {
+        val l = if (partition.hasLeft) {
+          surfaceIntersectionPoint(point, direction, partition.left)
+        } else {
+          Nil
+        }
+        val r = if (partition.hasRight) {
+          surfaceIntersectionPoint(point, direction, partition.right)
+        } else {
+          Nil
+        }
+        l ++ r
+      } else {
+        val triangle = triangles(partition.idx)
+        val intersection = BSIntersection.intersectLineWithTriangleBarycentric(point, direction, triangle.a, triangle.b, triangle.c)
+        if (intersection._1) {
+          List[(Int, BarycentricCoordinates)]((partition.idx, intersection._2))
+        } else {
+          List[(Int, BarycentricCoordinates)]()
+        }
+      }
+    } else {
+      List[(Int, BarycentricCoordinates)]()
+    }
+  }
+
+}

--- a/src/main/scala/scalismo/mesh/boundingSpheres/SurfaceIntersectionIndex.scala
+++ b/src/main/scala/scalismo/mesh/boundingSpheres/SurfaceIntersectionIndex.scala
@@ -18,6 +18,12 @@ package scalismo.mesh.boundingSpheres
 import scalismo.geometry.{ Dim, Point, Vector, _3D }
 import scalismo.mesh.{ BarycentricCoordinates, TriangleId, TriangleMesh3D }
 
+/**
+ * The SurfaceIntersectionIndex supports queries about the intersection of a line
+ * with a surface. The surface is used to build up he index. For
+ * lines in (point,direction) format one can ask if there exists any and also for
+ * the complete list of intersection points.
+ */
 trait SurfaceIntersectionIndex[D <: Dim] {
 
   def hasIntersection(point: Point[D], direction: Vector[D]): Boolean
@@ -26,12 +32,20 @@ trait SurfaceIntersectionIndex[D <: Dim] {
 
 }
 
+/**
+ * The TriangulatedSurfaceIntersectionIndex is a specialization of the SurfaceIntersectionIndex
+ * for TriangleMeshs. The additional query return the intersection points in the
+ * (TriangleId,BarycentricCoordinates) format.
+ */
 trait TriangulatedSurfaceIntersectionIndex[D <: Dim] extends SurfaceIntersectionIndex[D] {
 
   def getSurfaceIntersectionPoints(point: Point[D], direction: Vector[D]): Seq[(TriangleId, BarycentricCoordinates)]
 }
 
-object LineSurfaceIntersectionIndexBuilder {
+/**
+ * LineTriangleMesh3DIntersecitionIndex implements the interface TriangulatedSurfaceIntersectionIndex for TriangleMesh3D.
+ */
+object LineTriangleMesh3DIntersectionIndex {
 
   /**
    * Creates SurfaceDistance for a TriangleMesh3D.
@@ -65,12 +79,15 @@ object LineSurfaceIntersectionIndexBuilder {
 
 }
 
-private[mesh] case class LineTriangleMesh3DIntersectionIndex(private val boundingSphere: BoundingSphere,
+/**
+ * LineTriangleMesh3DIntersecitionIndex implements the interface TriangulatedSurfaceIntersectionIndex for TriangleMesh3D.
+ */
+private[mesh] class LineTriangleMesh3DIntersectionIndex(private val boundingSphere: BoundingSphere,
     private val mesh: TriangleMesh3D,
     private val triangles: Seq[Triangle]) extends TriangulatedSurfaceIntersectionIndex[_3D] {
 
   override def hasIntersection(point: Point[_3D], direction: Vector[_3D]): Boolean = {
-    intersectWithLine(point.toVector, direction, boundingSphere).size > 0
+    intersectWithLine(point.toVector, direction, boundingSphere).nonEmpty
   }
 
   override def getIntersectionPoints(point: Point[_3D], direction: Vector[_3D]): Seq[Point[_3D]] = {

--- a/src/main/scala/scalismo/mesh/boundingSpheres/SurfaceSpatialIndex.scala
+++ b/src/main/scala/scalismo/mesh/boundingSpheres/SurfaceSpatialIndex.scala
@@ -16,8 +16,9 @@
 package scalismo.mesh.boundingSpheres
 
 import breeze.numerics.pow
-import scalismo.geometry.{ Dim, Point, Vector, _3D }
-import scalismo.mesh.{ TriangleId, TriangleMesh3D }
+import scalismo.common.PointId
+import scalismo.geometry.{Dim, Point, Vector, _3D}
+import scalismo.mesh.{BarycentricCoordinates, TriangleId, TriangleMesh3D}
 import scalismo.mesh.boundingSpheres.BSDistance._
 
 /**
@@ -143,16 +144,16 @@ private[mesh] case class TriangleMesh3DSpatialIndex(bs: BoundingSphere,
     val triangle = mesh.triangulation.triangle(TriangleId(lastIdx.get().idx))
     res.get().ptType match {
 
-      case POINT => ClosestPointIsPoint(res.get().pt.toPoint, res.get().distance2, triangle.pointIds(res.get().idx._1).id)
+      case POINT => ClosestPointIsPoint(res.get().pt.toPoint, res.get().distance2, PointId(triangle.pointIds(res.get().idx._1).id))
 
       case ON_LINE => res.get().idx match {
-        case (0, _) => ClosestPointOnLine(res.get().pt.toPoint, res.get().distance2, (triangle.pointIds(0).id, triangle.pointIds(1).id), res.get().bc.a)
-        case (1, _) => ClosestPointOnLine(res.get().pt.toPoint, res.get().distance2, (triangle.pointIds(1).id, triangle.pointIds(2).id), res.get().bc.a)
-        case (2, _) => ClosestPointOnLine(res.get().pt.toPoint, res.get().distance2, (triangle.pointIds(2).id, triangle.pointIds(0).id), res.get().bc.a)
+        case (0, _) => ClosestPointOnLine(res.get().pt.toPoint, res.get().distance2, (PointId(triangle.pointIds(0).id), PointId(triangle.pointIds(1).id)), res.get().bc.a)
+        case (1, _) => ClosestPointOnLine(res.get().pt.toPoint, res.get().distance2, (PointId(triangle.pointIds(1).id), PointId(triangle.pointIds(2).id)), res.get().bc.a)
+        case (2, _) => ClosestPointOnLine(res.get().pt.toPoint, res.get().distance2, (PointId(triangle.pointIds(2).id), PointId(triangle.pointIds(0).id)), res.get().bc.a)
         case _ => throw (new RuntimeException("not a valid line index"))
       }
 
-      case IN_TRIANGLE => ClosestPointInTriangle(res.get().pt.toPoint, res.get().distance2, lastIdx.get().idx, (res.get().bc.a, res.get().bc.b))
+      case IN_TRIANGLE => ClosestPointInTriangle(res.get().pt.toPoint, res.get().distance2, TriangleId(lastIdx.get().idx), BarycentricCoordinates(1.0 - res.get().bc.a - res.get().bc.b, res.get().bc.a, res.get().bc.b))
 
       case _ => throw (new RuntimeException("not a valid PointType"))
     }

--- a/src/main/scala/scalismo/mesh/boundingSpheres/SurfaceSpatialIndex.scala
+++ b/src/main/scala/scalismo/mesh/boundingSpheres/SurfaceSpatialIndex.scala
@@ -38,7 +38,7 @@ trait SurfaceSpatialIndex[D <: Dim] {
    *
    * @return The closest point and the squared distance.
    */
-  def getClosestPoint(pt: Point[D]): (Point[D], Double)
+  def getClosestPoint(pt: Point[D]): ClosestPoint
 
   /**
    * Query the closest point on a surface.
@@ -128,9 +128,9 @@ private[mesh] class TriangleMesh3DSpatialIndex(private val bs: BoundingSphere,
   /**
    * Calculates the point and the squared closest distance to the surface.
    */
-  override def getClosestPoint(point: Point[_3D]): (Point[_3D], Double) = {
+  override def getClosestPoint(point: Point[_3D]): ClosestPoint = {
     _getClosestPoint(point)
-    (res.get().pt.toPoint, res.get().distance2)
+    new ClosestPoint(res.get().pt.toPoint, res.get().distance2)
   }
 
   /**
@@ -144,7 +144,7 @@ private[mesh] class TriangleMesh3DSpatialIndex(private val bs: BoundingSphere,
     val triangle = mesh.triangulation.triangle(TriangleId(lastIdx.get().idx))
     res.get().ptType match {
 
-      case POINT => ClosestPointIsPoint(res.get().pt.toPoint, res.get().distance2, PointId(triangle.pointIds(res.get().idx._1).id))
+      case POINT => ClosestPointIsVertex(res.get().pt.toPoint, res.get().distance2, PointId(triangle.pointIds(res.get().idx._1).id))
 
       case ON_LINE => res.get().idx match {
         case (0, _) => ClosestPointOnLine(res.get().pt.toPoint, res.get().distance2, (PointId(triangle.pointIds(0).id), PointId(triangle.pointIds(1).id)), res.get().bc.a)

--- a/src/main/scala/scalismo/mesh/boundingSpheres/SurfaceSpatialIndex.scala
+++ b/src/main/scala/scalismo/mesh/boundingSpheres/SurfaceSpatialIndex.scala
@@ -111,9 +111,9 @@ private case class ClosestPointMeta(val distance2: Double,
 /**
  * Surface distance implementation for TriangleMesh3D.
  */
-private case class TriangleMesh3DSpatialIndex(bs: BoundingSphere,
+private[mesh] case class TriangleMesh3DSpatialIndex(bs: BoundingSphere,
   mesh: TriangleMesh3D,
-  triangles: IndexedSeq[Triangle])
+  triangles: Seq[Triangle])
     extends SurfaceSpatialIndex[_3D] {
 
   /**

--- a/src/main/scala/scalismo/mesh/boundingSpheres/SurfaceSpatialIndex.scala
+++ b/src/main/scala/scalismo/mesh/boundingSpheres/SurfaceSpatialIndex.scala
@@ -17,8 +17,8 @@ package scalismo.mesh.boundingSpheres
 
 import breeze.numerics.pow
 import scalismo.common.PointId
-import scalismo.geometry.{Dim, Point, Vector, _3D}
-import scalismo.mesh.{BarycentricCoordinates, TriangleId, TriangleMesh3D}
+import scalismo.geometry.{ Dim, Point, Vector, _3D }
+import scalismo.mesh.{ BarycentricCoordinates, TriangleId, TriangleMesh3D }
 import scalismo.mesh.boundingSpheres.BSDistance._
 
 /**

--- a/src/main/scala/scalismo/statisticalmodel/StatisticalMeshModel.scala
+++ b/src/main/scala/scalismo/statisticalmodel/StatisticalMeshModel.scala
@@ -90,7 +90,7 @@ case class StatisticalMeshModel private (referenceMesh: TriangleMesh[_3D], gp: D
    * @see [[DiscreteLowRankGaussianProcess.marginal]]
    */
   def marginal(ptIds: IndexedSeq[PointId]) = {
-    val clippedReference = Mesh.clipMesh(referenceMesh, p => { !ptIds.contains(referenceMesh.pointSet.findClosestPoint(p).id) })
+    val clippedReference = referenceMesh.operations.clip(p => { !ptIds.contains(referenceMesh.pointSet.findClosestPoint(p).id) })
     // not all of the ptIds remain in the reference after clipping, since their cells might disappear
     val remainingPtIds = clippedReference.pointSet.points.map(p => referenceMesh.pointSet.findClosestPoint(p).id).toIndexedSeq
     if (remainingPtIds.isEmpty) {

--- a/src/test/scala/scalismo/mesh/MeshSurfaceDistanceTests.scala
+++ b/src/test/scala/scalismo/mesh/MeshSurfaceDistanceTests.scala
@@ -233,7 +233,7 @@ class MeshSurfaceDistanceTests extends ScalismoTestSuite {
 
       val pd = UnstructuredPointsDomain(points)
 
-      val sd = SurfaceSpatialIndex.fromTriangleMesh3D(TriangleMesh3D(
+      val sd = TriangleMesh3DSpatialIndex.fromTriangleMesh3D(TriangleMesh3D(
         triangles.flatMap(t => Seq(t.a.toPoint, t.b.toPoint, t.c.toPoint)),
         TriangleList((0 until 3 * triangles.length).grouped(3).map(g => TriangleCell(PointId(g(0)), PointId(g(1)), PointId(g(2)))).toIndexedSeq)
       ))
@@ -261,7 +261,7 @@ class MeshSurfaceDistanceTests extends ScalismoTestSuite {
         Triangle(a, b, c, b - a, c - a, (b - a).crossproduct(c - a))
       }
 
-      val sd = SurfaceSpatialIndex.fromTriangleMesh3D(TriangleMesh3D(
+      val sd = TriangleMesh3DSpatialIndex.fromTriangleMesh3D(TriangleMesh3D(
         triangles.flatMap(t => Seq(t.a.toPoint, t.b.toPoint, t.c.toPoint)),
         TriangleList((0 until 3 * triangles.length).grouped(3).map(g => TriangleCell(PointId(g(0)), PointId(g(1)), PointId(g(2)))).toIndexedSeq)
       ))

--- a/src/test/scala/scalismo/mesh/MeshSurfaceDistanceTests.scala
+++ b/src/test/scala/scalismo/mesh/MeshSurfaceDistanceTests.scala
@@ -213,7 +213,7 @@ class MeshSurfaceDistanceTests extends ScalismoTestSuite {
 
         val cp = md.closestPoint(p)
 
-        vdist shouldBe cp.distance2
+        vdist shouldBe cp.distanceSquared
         vpt.point shouldBe cp.point
       }
 
@@ -247,7 +247,7 @@ class MeshSurfaceDistanceTests extends ScalismoTestSuite {
 
         val ge = sd.getClosestPoint(p.toPoint)
 
-        require(vd >= ge._2)
+        require(vd >= ge.distanceSquared)
       }
     }
 
@@ -276,8 +276,8 @@ class MeshSurfaceDistanceTests extends ScalismoTestSuite {
       cpsSeq.zip(cpsPar) foreach { pair =>
         val seq = pair._1
         val par = pair._2
-        require(seq._1 == par._1)
-        require(seq._2 == par._2)
+        require(seq.point == par.point)
+        require(seq.distanceSquared == par.distanceSquared)
       }
 
     }
@@ -311,7 +311,7 @@ class MeshSurfaceDistanceTests extends ScalismoTestSuite {
         val par = pair._2
         require(seq.point == par.point)
         require(seq.idx == par.idx)
-        require(seq.distance2 == par.distance2)
+        require(seq.distanceSquared == par.distanceSquared)
       }
     }
 

--- a/src/test/scala/scalismo/mesh/MeshTests.scala
+++ b/src/test/scala/scalismo/mesh/MeshTests.scala
@@ -73,7 +73,7 @@ class MeshTests extends ScalismoTestSuite {
     it("computes the right binary image for the unit sphere") {
       val path = getClass.getResource("/unit-sphere.stl").getPath
       val spheremesh = MeshIO.readMesh(new File(path)).get
-      val binaryImg = Mesh.meshToBinaryImage(spheremesh)
+      val binaryImg = spheremesh.operations.toBinaryImage
       binaryImg(Point(0, 0, 0)) should be(1)
       binaryImg(Point(2, 0, 0)) should be(0)
     }


### PR DESCRIPTION
As discussed offline i started this branch as a discussion basis. Yet I only moved the intersect and closestPointOnSurface operations to the MeshOperation class. The important changes are in:
- MeshOperations 
- TriangleMesh

Functionality in MeshOperations:
- Intersect
- ClosestPoint
- MeshBoundaryPredicate