### PR TITLE
Use sbt-git for versioning

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -16,3 +16,5 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "0.8.1")
 addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.5.3")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.3.2")
+
+addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.8.5")


### PR DESCRIPTION
Thanks to the use of sbt-git, the build version can be determined based on the git version. More precisely, git describe is used to build a unique version, based on the last tagged release and a short hash of the current commit.