### PR TITLE
Removed scalariform.sbt

### DIFF
--- a/scalariform.sbt
+++ b/scalariform.sbt
@@ -1,1 +1,0 @@
-scalariformSettings


### PR DESCRIPTION
The reason to remove this file is that this produces published versions of scalismo that are not contained in the git-history of commits. As we now want to use single commit based artifacts, this is no longer an option.