### PR TITLE
change travis build such that it fails if source is not properly formatted

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ env:
  - SCALISMO_PLATFORM=linux64
 
 ## Caching seems to cause problems of its own, so we leave it commented for now.
-## We use travis_wait instead (see below in the script: section) to give the build more time. 
+## We use travis_wait instead (see below in the script: section) to give the build more time.
 #cache:
 #  directories:
 #  - $HOME/.ivy2
@@ -21,4 +21,4 @@ script:
   - jdk_switcher use oraclejdk8
   - travis_wait sbt ++$TRAVIS_SCALA_VERSION update
   - sbt ++$TRAVIS_SCALA_VERSION -Djava.awt.headless=true compile test
-
+  - sbt scalariformFormat && git diff --exit-code   # fails build if scalariform results in changes to the code


### PR DESCRIPTION
This change causes Travis to fail if the source is not properly formatted (according to scalariform).  This will make it much easier to spot when the formatting for a  proposed change is not correct. 

In the case of an incorrect formatting, a PR should not be merged. This should help to avoid situations, as the one described in PR #169, but also more generally lead to more clear commits/diffs. 