### PR TITLE
fix git versioning issues with sbt + versions

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -76,7 +76,8 @@ object STKBuild extends Build {
         git.remoteRepo := "git@github.com:unibas-gravis/scalismo.git"
       )++
       Seq(
-        git.useGitDescribe := true,
+        git.baseVersion := "develop",
+        git.useGitDescribe := false,
         useJGit
       ) ++
       buildInfoSettings ++


### PR DESCRIPTION
Change git versions from git describe to plain develop-SHA1:

sbt resolves ```0.x.+``` with all versions created through git describe in the format ```0.x.0-4-SHA1```, even though they are not ```0.x``` releases but ongoing development on master