### PR TITLE
Improved accuracy when computing nystrom approximation. Fixes #176.

### DIFF
--- a/src/test/scala/scalismo/registration/KernelTransformationTests.scala
+++ b/src/test/scala/scalismo/registration/KernelTransformationTests.scala
@@ -41,7 +41,7 @@ class KernelTransformationTests extends ScalismoTestSuite {
 
       val sampler = UniformSampler(domain, 500)
 
-      val eigPairs = Kernel.computeNystromApproximation[_1D, Vector[_1D]](kernel, 100, sampler)
+      val eigPairs = Kernel.computeNystromApproximation[_1D, Vector[_1D]](kernel, sampler)
 
       def approxKernel(x: Point[_1D], y: Point[_1D]) = {
         eigPairs.indices.foldLeft(0.0)((sum, i) => {
@@ -64,7 +64,7 @@ class KernelTransformationTests extends ScalismoTestSuite {
       val numPoints = 500
       val sampler = UniformSampler(domain, numPoints)
       val (points, _) = sampler.sample.unzip
-      val eigPairsApprox = Kernel.computeNystromApproximation[_1D, Vector[_1D]](scalarKernel, 10, sampler)
+      val eigPairsApprox = Kernel.computeNystromApproximation[_1D, Vector[_1D]](scalarKernel, sampler)
       val approxLambdas = eigPairsApprox.map(_.eigenvalue)
 
       val realKernelMatrix = DenseMatrix.zeros[Double](numPoints * kernelDim, numPoints * kernelDim)
@@ -90,7 +90,7 @@ class KernelTransformationTests extends ScalismoTestSuite {
       val sampler = UniformSampler(domain, 400)
       val (pts, _) = sampler.sample.unzip
 
-      val eigPairsApprox = Kernel.computeNystromApproximation[_2D, Vector[_2D]](ndKernel, 10, sampler)
+      val eigPairsApprox = Kernel.computeNystromApproximation[_2D, Vector[_2D]](ndKernel, sampler)
       val approxLambdas = eigPairsApprox.map(_.eigenvalue)
 
       val realKernelMatrix = DenseMatrix.zeros[Double](pts.size * kernelDim, pts.size * kernelDim)
@@ -111,7 +111,7 @@ class KernelTransformationTests extends ScalismoTestSuite {
       val grid = DiscreteImageDomain(domain.origin, domain.extent * (1.0 / 1000.0), IntVector(1000))
       val sampler = GridSampler(grid)
 
-      val eigPairs = Kernel.computeNystromApproximation[_1D, Vector[_1D]](kernel, 100, sampler)
+      val eigPairs = Kernel.computeNystromApproximation[_1D, Vector[_1D]](kernel, sampler)
 
       val integrator = Integrator(sampler)
 
@@ -125,5 +125,42 @@ class KernelTransformationTests extends ScalismoTestSuite {
         v should be(1f +- 0.1)
       }
     }
+
+    it("leads to fewer eigenfunctions when the kernel is more smooth") {
+      val kernelLessSmooth = DiagonalKernel(GaussianKernel[_1D](0.5), 1)
+      val kernelMoreSmooth = DiagonalKernel(GaussianKernel[_1D](2.0), 1)
+      val domain = BoxDomain(-5.0, 5.0)
+      val grid = DiscreteImageDomain(domain.origin, domain.extent * (1.0 / 1000.0), IntVector(1000))
+      val sampler = GridSampler(grid)
+
+      val eigPairsLessSmooth = Kernel.computeNystromApproximation[_1D, Vector[_1D]](kernelLessSmooth, sampler)
+      val eigPairsMoreSmooth = Kernel.computeNystromApproximation[_1D, Vector[_1D]](kernelMoreSmooth, sampler)
+      eigPairsLessSmooth.size should be > eigPairsMoreSmooth.size
+    }
+
+    it("yields the same leading eigenfunctions, whether only the first or all are approximated") {
+      val kernel = DiagonalKernel(GaussianKernel[_1D](2.0), 1)
+      val domain = BoxDomain(-5.0, 5.0)
+      val grid = DiscreteImageDomain(domain.origin, domain.extent * (1.0 / 1000.0), IntVector(1000))
+      val sampler = GridSampler(grid)
+
+      val numLeadingBasisFunctions = 2
+      val eigPairsAll = Kernel.computeNystromApproximation[_1D, Vector[_1D]](kernel, sampler)
+      val eigPairsFirstTwoOnly = Kernel.computeNystromApproximation[_1D, Vector[_1D]](kernel, numLeadingBasisFunctions, sampler)
+
+      for (i <- 0 until numLeadingBasisFunctions) {
+        eigPairsAll(i).eigenvalue should equal(eigPairsFirstTwoOnly(i).eigenvalue +- 1e-5)
+        sampler.sample().map(_._1).foreach {
+          pt =>
+            {
+              Math.min( // sign of eigenfunction is arbitrary. We therefore check both possibilities
+                (eigPairsAll(i).eigenfunction(pt) - eigPairsFirstTwoOnly(i).eigenfunction(pt)).norm,
+                (eigPairsAll(i).eigenfunction(pt) + eigPairsFirstTwoOnly(i).eigenfunction(pt)).norm
+              ) should equal(0.0 +- 1e-5)
+            }
+        }
+      }
+    }
+
   }
 }


### PR DESCRIPTION
There are now two variants of the Nystrom method. In the first variant the user does specify
the number of leading eigenfunctions that should be computed. In this case a RandomSVD is used for
computing the leading eigenvectors of the Kernel matrix. If the user does not specify the number of
eigenfunctions, the method chooses the number of eigenfunctions such that a certain relative error tolerance
is fulfilled.