### PR TITLE
Zero mean gaussianprocess

### DIFF
--- a/src/main/scala/scalismo/statisticalmodel/GaussianProcess.scala
+++ b/src/main/scala/scalismo/statisticalmodel/GaussianProcess.scala
@@ -92,8 +92,17 @@ object GaussianProcess {
   /**
    * Creates a new Gaussian process with given mean and covariance, which is defined on the given domain.
    */
-  def apply[D <: Dim: NDSpace, Value](mean: Field[D, Value], cov: MatrixValuedPDKernel[D])(implicit vectorizer: Vectorizer[Value]) = {
+  def apply[D <: Dim: NDSpace, Value](mean: Field[D, Value], cov: MatrixValuedPDKernel[D])(implicit vectorizer: Vectorizer[Value]): GaussianProcess[D, Value] = {
     new GaussianProcess[D, Value](mean, cov)
+  }
+
+  /**
+   * Craetes a new zero-mean Gaussian process with the given covariance function.
+   */
+  def apply[D <: Dim: NDSpace, Value](cov: MatrixValuedPDKernel[D])(implicit vectorizer: Vectorizer[Value]): GaussianProcess[D, Value] = {
+    val zeroVec = vectorizer.unvectorize(DenseVector.zeros(vectorizer.dim))
+    val zeroField = Field[D, Value](RealSpace[D], (p: Point[D]) => zeroVec)
+    GaussianProcess[D, Value](zeroField, cov)
   }
 
   /**

--- a/src/main/scala/scalismo/statisticalmodel/GaussianProcess.scala
+++ b/src/main/scala/scalismo/statisticalmodel/GaussianProcess.scala
@@ -97,7 +97,7 @@ object GaussianProcess {
   }
 
   /**
-   * Craetes a new zero-mean Gaussian process with the given covariance function.
+   * Creates a new zero-mean Gaussian process with the given covariance function.
    */
   def apply[D <: Dim: NDSpace, Value](cov: MatrixValuedPDKernel[D])(implicit vectorizer: Vectorizer[Value]): GaussianProcess[D, Value] = {
     val zeroVec = vectorizer.unvectorize(DenseVector.zeros(vectorizer.dim))

--- a/src/test/scala/scalismo/statisticalmodel/GaussianProcessTests.scala
+++ b/src/test/scala/scalismo/statisticalmodel/GaussianProcessTests.scala
@@ -141,8 +141,7 @@ class GaussianProcessTests extends ScalismoTestSuite {
 
     it("keeps the landmark points fixed for a 2D case") {
       val domain = BoxDomain((-5.0, -5.0), (5.0, 5.0))
-      val gp = GaussianProcess[_2D, Vector[_2D]](Field(domain, _ => Vector(0.0, 0.0)),
-        DiagonalKernel(GaussianKernel[_2D](5), 2))
+      val gp = GaussianProcess[_2D, Vector[_2D]](DiagonalKernel(GaussianKernel[_2D](5), 2))
       val gpLowRank = LowRankGaussianProcess.approximateGP[_2D, Vector[_2D]](gp, UniformSampler(domain, 400), 100)
 
       val trainingData = IndexedSeq((Point(-3.0, -3.0), Vector(1.0, 1.0)), (Point(-1.0, 3.0), Vector(0.0, -1.0)))
@@ -161,8 +160,7 @@ class GaussianProcessTests extends ScalismoTestSuite {
 
     it("keeps the landmark points fixed for a 3D case") {
       val domain = BoxDomain((-5.0, -5.0, -5.0), (5.0, 5.0, 5.0))
-      val gp = GaussianProcess[_3D, Vector[_3D]](Field(domain, _ => Vector(0.0, 0.0, 0.0)),
-        DiagonalKernel(GaussianKernel[_3D](5), 3))
+      val gp = GaussianProcess[_3D, Vector[_3D]](DiagonalKernel(GaussianKernel[_3D](5), 3))
       val gpLowRank = LowRankGaussianProcess.approximateGP[_3D, Vector[_3D]](gp, UniformSampler(domain, 6 * 6 * 6), 50)
 
       val trainingData = IndexedSeq((Point(-3.0, -3.0, -1.0), Vector(1.0, 1.0, 2.0)), (Point(-1.0, 3.0, 0.0), Vector(0.0, -1.0, 0.0)))
@@ -186,11 +184,9 @@ class GaussianProcessTests extends ScalismoTestSuite {
 
     object Fixture {
       val domain = BoxDomain((-5.0, -5.0, -5.0), (5.0, 5.0, 5.0))
-      val gp = GaussianProcess[_3D, Vector[_3D]](Field(domain, _ => Vector(0.0, 0.0, 0.0)),
-        DiagonalKernel(GaussianKernel[_3D](5), 3))
+      val gp = GaussianProcess[_3D, Vector[_3D]](DiagonalKernel(GaussianKernel[_3D](5), 3))
 
-      val moreComplexGP = GaussianProcess[_3D, Vector[_3D]](Field(domain, _ => Vector(0.0, 0.0, 0.0)),
-        DiagonalKernel(GaussianKernel[_3D](5) + GaussianKernel[_3D](2.5) * 2 + GaussianKernel[_3D](0.5) * 1, 3))
+      val moreComplexGP = GaussianProcess[_3D, Vector[_3D]](DiagonalKernel(GaussianKernel[_3D](5) + GaussianKernel[_3D](2.5) * 2 + GaussianKernel[_3D](0.5) * 1, 3))
 
       val littleNoise = MultivariateNormalDistribution(DenseVector.zeros[Double](3), DenseMatrix.eye[Double](3))
       val discreteDomain = UnstructuredPointsDomain(IndexedSeq(Point(-3.0, -3.0, -1.0), Point(-1.0, 3.0, 0.0)))


### PR DESCRIPTION
A very common assumption when defining Gaussian process models is that the Gaussian process is zero mean. This is currently quite cumbersome to specify, and the code becomes unreadable. 
This PR proposes to add an additional factory function to the ```GaussianProcess``` object, which makes it possible to create a zero-mean Gaussian process  by specifying only the covariance function

Example: Instead of 
```
GaussianProcess[_3D, Vector[_3D]](Field(domain, _ => Vector(0.0, 0.0, 0.0)), kernel)
```
it is now possible to define 
```
GaussianProcess[_3D, Vector[_3D]](kernel)
```
