### PR TITLE
Improved accuracy when computing nystrom approximation. Fixes #176. 

### DIFF
--- a/src/main/scala/scalismo/kernels/Kernel.scala
+++ b/src/main/scala/scalismo/kernels/Kernel.scala
@@ -273,7 +273,10 @@ object Kernel {
     val effectiveNumberOfPointsSampled = ptsForNystrom.size
 
     val K = computeKernelMatrix(ptsForNystrom, k)
-    val (uMat, lambdaMat) = PivotedCholesky.computeApproximateEig(k, ptsForNystrom, 1.0, RelativeTolerance(1e-8))
+
+    // we compute the eigenvectors only approximately, to a tolerance of 1e-5. As the nystrom approximation is
+    // anyway not exact, this should be sufficient for all practical cases.
+    val (uMat, lambdaMat) = PivotedCholesky.computeApproximateEig(k, ptsForNystrom, 1.0, RelativeTolerance(1e-5))
 
     val lambda = lambdaMat.map(lmbda => (lmbda / effectiveNumberOfPointsSampled.toDouble))
     val numParams = (for (i <- (0 until lambda.size) if lambda(i) >= 1e-8) yield 1).size

--- a/src/main/scala/scalismo/kernels/Kernel.scala
+++ b/src/main/scala/scalismo/kernels/Kernel.scala
@@ -18,7 +18,7 @@ package scalismo.kernels
 import breeze.linalg.{ DenseMatrix, DenseVector, diag, pinv }
 import scalismo.common._
 import scalismo.geometry._
-import scalismo.numerics.PivotedCholesky.NumberOfEigenfunctions
+import scalismo.numerics.PivotedCholesky.{ NumberOfEigenfunctions, RelativeTolerance }
 import scalismo.numerics.{ PivotedCholesky, RandomSVD, Sampler }
 import scalismo.statisticalmodel.LowRankGaussianProcess.{ Eigenpair, KLBasis }
 import scalismo.utils.Memoize
@@ -253,8 +253,16 @@ object Kernel {
     kxs
   }
 
+  /**
+   * Computes the leading eigenvalues / eigenfunctions of the integral operator corresponding
+   * to kernel k. The number of leading eigenfunctions is at most n, where n is the number of points sampled.
+   * If the eigenvalues are decaying quickly, it can be much smaller than n.
+   *
+   * @param k (matrix-valued) kernel
+   * @param sampler  A point sampler, which determines the points that are used to compute the approximation.
+   * @return The leading eigenvalue / eigenfunction pairs
+   */
   def computeNystromApproximation[D <: Dim: NDSpace, Value](k: MatrixValuedPDKernel[D],
-    numBasisFunctions: Int,
     sampler: Sampler[D])(implicit vectorizer: Vectorizer[Value], rand: Random): KLBasis[D, Value] = {
 
     // procedure for the nystrom approximation as described in
@@ -264,7 +272,8 @@ object Kernel {
     // depending on the sampler, it may happen that we did not sample all the points we wanted
     val effectiveNumberOfPointsSampled = ptsForNystrom.size
 
-    val (uMat, lambdaMat) = PivotedCholesky.computeApproximateEig(k, ptsForNystrom, 1.0, NumberOfEigenfunctions(numBasisFunctions))
+    val K = computeKernelMatrix(ptsForNystrom, k)
+    val (uMat, lambdaMat) = PivotedCholesky.computeApproximateEig(k, ptsForNystrom, 1.0, RelativeTolerance(1e-8))
 
     val lambda = lambdaMat.map(lmbda => (lmbda / effectiveNumberOfPointsSampled.toDouble))
     val numParams = (for (i <- (0 until lambda.size) if lambda(i) >= 1e-8) yield 1).size

--- a/src/main/scala/scalismo/statisticalmodel/LowRankGaussianProcess.scala
+++ b/src/main/scala/scalismo/statisticalmodel/LowRankGaussianProcess.scala
@@ -20,6 +20,7 @@ import breeze.linalg.{ diag, DenseMatrix, DenseVector }
 import scalismo.common._
 import scalismo.geometry.{ Dim, NDSpace, Point, SquareMatrix, Vector }
 import scalismo.kernels.{ Kernel, MatrixValuedPDKernel }
+import scalismo.numerics.PivotedCholesky.RelativeTolerance
 import scalismo.numerics.Sampler
 import scalismo.registration.RigidTransformation
 import scalismo.statisticalmodel.LowRankGaussianProcess.{ Eigenpair, KLBasis }
@@ -190,8 +191,10 @@ object LowRankGaussianProcess {
   /**
    * Perform a low-rank approximation of the Gaussian process using the Nystrom method. The sample points used for the nystrom method
    * are sampled using the given sample.
+   *
    * @param gp                The gaussian process to approximate
    * @param sampler           determines which points will be used as samples for the nystrom approximation.
+   * @
    */
   def approximateGP[D <: Dim: NDSpace, Value](gp: GaussianProcess[D, Value],
     sampler: Sampler[D])(implicit vectorizer: Vectorizer[Value], rand: Random) = {

--- a/src/main/scala/scalismo/statisticalmodel/LowRankGaussianProcess.scala
+++ b/src/main/scala/scalismo/statisticalmodel/LowRankGaussianProcess.scala
@@ -183,7 +183,19 @@ object LowRankGaussianProcess {
   def approximateGP[D <: Dim: NDSpace, Value](gp: GaussianProcess[D, Value],
     sampler: Sampler[D],
     numBasisFunctions: Int)(implicit vectorizer: Vectorizer[Value], rand: Random) = {
-    val kltBasis: KLBasis[D, Value] = Kernel.computeNystromApproximation[D, Value](gp.cov, numBasisFunctions, sampler)
+    val kltBasis: KLBasis[D, Value] = Kernel.computeNystromApproximation[D, Value](gp.cov, sampler)
+    new LowRankGaussianProcess[D, Value](gp.mean, kltBasis.take(numBasisFunctions))
+  }
+
+  /**
+   * Perform a low-rank approximation of the Gaussian process using the Nystrom method. The sample points used for the nystrom method
+   * are sampled using the given sample.
+   * @param gp                The gaussian process to approximate
+   * @param sampler           determines which points will be used as samples for the nystrom approximation.
+   */
+  def approximateGP[D <: Dim: NDSpace, Value](gp: GaussianProcess[D, Value],
+    sampler: Sampler[D])(implicit vectorizer: Vectorizer[Value], rand: Random) = {
+    val kltBasis: KLBasis[D, Value] = Kernel.computeNystromApproximation[D, Value](gp.cov, sampler)
     new LowRankGaussianProcess[D, Value](gp.mean, kltBasis)
   }
 

--- a/src/test/scala/scalismo/registration/KernelTransformationTests.scala
+++ b/src/test/scala/scalismo/registration/KernelTransformationTests.scala
@@ -138,6 +138,5 @@ class KernelTransformationTests extends ScalismoTestSuite {
       eigPairsLessSmooth.size should be > eigPairsMoreSmooth.size
     }
 
-
   }
 }

--- a/src/test/scala/scalismo/statisticalmodel/GaussianProcessTests.scala
+++ b/src/test/scala/scalismo/statisticalmodel/GaussianProcessTests.scala
@@ -226,7 +226,7 @@ class GaussianProcessTests extends ScalismoTestSuite {
       val sampler = GridSampler(DiscreteImageDomain(domain.origin, domain.extent * (1.0 / 7), IntVector(7, 7, 7)))
       val kernel = DiagonalKernel(GaussianKernel[_3D](10), 3)
       val gp = {
-        LowRankGaussianProcess.approximateGP[_3D, Vector[_3D]](GaussianProcess(Field(domain, (_ : Point[_3D]) => Vector(0.0, 0.0, 0.0)), kernel), sampler, 200)
+        LowRankGaussianProcess.approximateGP[_3D, Vector[_3D]](GaussianProcess(Field(domain, (_: Point[_3D]) => Vector(0.0, 0.0, 0.0)), kernel), sampler, 200)
       }
     }
 
@@ -297,7 +297,7 @@ class GaussianProcessTests extends ScalismoTestSuite {
       val sampler = UniformSampler(domain, 7 * 7 * 7)
       val kernel = covKernel
       val gp = {
-        LowRankGaussianProcess.approximateGP[_3D, Vector[_3D]](GaussianProcess(Field(domain, (_ : Point[_3D]) => Vector(0.0, 0.0, 0.0)), kernel), sampler, 5)
+        LowRankGaussianProcess.approximateGP[_3D, Vector[_3D]](GaussianProcess(Field(domain, (_: Point[_3D]) => Vector(0.0, 0.0, 0.0)), kernel), sampler, 5)
       }
       val fewPointsSampler = UniformSampler(domain, 2 * 2 * 2)
       val pts = fewPointsSampler.sample.map(_._1)

--- a/src/test/scala/scalismo/statisticalmodel/GaussianProcessTests.scala
+++ b/src/test/scala/scalismo/statisticalmodel/GaussianProcessTests.scala
@@ -226,7 +226,7 @@ class GaussianProcessTests extends ScalismoTestSuite {
       val sampler = GridSampler(DiscreteImageDomain(domain.origin, domain.extent * (1.0 / 7), IntVector(7, 7, 7)))
       val kernel = DiagonalKernel(GaussianKernel[_3D](10), 3)
       val gp = {
-        LowRankGaussianProcess.approximateGP[_3D, Vector[_3D]](GaussianProcess(Field(domain, _ => Vector(0.0, 0.0, 0.0)), kernel), sampler, 200)
+        LowRankGaussianProcess.approximateGP[_3D, Vector[_3D]](GaussianProcess(Field(domain, (_ : Point[_3D]) => Vector(0.0, 0.0, 0.0)), kernel), sampler, 200)
       }
     }
 
@@ -297,7 +297,7 @@ class GaussianProcessTests extends ScalismoTestSuite {
       val sampler = UniformSampler(domain, 7 * 7 * 7)
       val kernel = covKernel
       val gp = {
-        LowRankGaussianProcess.approximateGP[_3D, Vector[_3D]](GaussianProcess(Field(domain, _ => Vector(0.0, 0.0, 0.0)), kernel), sampler, 5)
+        LowRankGaussianProcess.approximateGP[_3D, Vector[_3D]](GaussianProcess(Field(domain, (_ : Point[_3D]) => Vector(0.0, 0.0, 0.0)), kernel), sampler, 5)
       }
       val fewPointsSampler = UniformSampler(domain, 2 * 2 * 2)
       val pts = fewPointsSampler.sample.map(_._1)


### PR DESCRIPTION
This PR improves the way the low-rank approximation of  a Gaussian process is computed in two ways:

1) It improves the accuracy of the eigenvector computations in the Nystrom approximation (see issue #176)
2) It provides a new interface for performing a low rank approximation of a Gaussian process, which automatically determines the number of basis functions that need to be computed to reach a certain approximation accuracy.

