### PR TITLE
deprecated DiscreteVectorField class and companion object

### DIFF
--- a/src/main/scala/scalismo/common/DiscreteField.scala
+++ b/src/main/scala/scalismo/common/DiscreteField.scala
@@ -144,9 +144,7 @@ object DiscreteScalarField {
   }
 }
 
-/**
- *
- */
+@deprecated("This will be removed in future versions. Please use DiscreteField class instead (e.g. DiscreteField[_3D,Vector[_3D]] instead of DiscreteVectorField[_3D,_3D])", "since 0.15")
 class DiscreteVectorField[D <: Dim: NDSpace, DO <: Dim: NDSpace](domain: DiscreteDomain[D], data: IndexedSeq[Vector[DO]]) extends DiscreteField[D, Vector[DO]](domain, data) {
 
   override def values = data.iterator
@@ -171,6 +169,7 @@ class DiscreteVectorField[D <: Dim: NDSpace, DO <: Dim: NDSpace](domain: Discret
 
 }
 
+@deprecated("This will be removed in future versions. Please use DiscreteField class instead (e.g. DiscreteField[_3D,Vector[_3D]] instead of DiscreteVectorField[_3D,_3D])", "since 0.15")
 object DiscreteVectorField {
   def apply[D <: Dim: NDSpace, DO <: Dim: NDSpace](domain: DiscreteDomain[D], data: IndexedSeq[Vector[DO]]) = {
     new DiscreteVectorField(domain, data)

--- a/src/main/scala/scalismo/statisticalmodel/StatisticalMeshModel.scala
+++ b/src/main/scala/scalismo/statisticalmodel/StatisticalMeshModel.scala
@@ -108,7 +108,7 @@ case class StatisticalMeshModel private (referenceMesh: TriangleMesh[_3D], gp: D
    */
   def project(mesh: TriangleMesh[_3D]) = {
     val displacements = referenceMesh.pointSet.points.zip(mesh.pointSet.points).map({ case (refPt, tgtPt) => tgtPt - refPt }).toIndexedSeq
-    val dvf = DiscreteVectorField(referenceMesh.pointSet, displacements)
+    val dvf = DiscreteField(referenceMesh.pointSet, displacements)
     warpReference(gp.project(dvf))
   }
 
@@ -117,7 +117,7 @@ case class StatisticalMeshModel private (referenceMesh: TriangleMesh[_3D], gp: D
    */
   def coefficients(mesh: TriangleMesh[_3D]): DenseVector[Double] = {
     val displacements = referenceMesh.pointSet.points.zip(mesh.pointSet.points).map({ case (refPt, tgtPt) => tgtPt - refPt }).toIndexedSeq
-    val dvf = DiscreteVectorField(referenceMesh.pointSet, displacements)
+    val dvf = DiscreteField(referenceMesh.pointSet, displacements)
     gp.coefficients(dvf)
   }
 


### PR DESCRIPTION
as it is now a duplicate of DiscreteField[D, Vector[D]]