### PR TITLE
Introducing a convenience method to reduce the rank of Gaussian process models

### DIFF
--- a/src/main/scala/scalismo/statisticalmodel/DiscreteLowRankGaussianProcess.scala
+++ b/src/main/scala/scalismo/statisticalmodel/DiscreteLowRankGaussianProcess.scala
@@ -119,6 +119,15 @@ case class DiscreteLowRankGaussianProcess[D <: Dim: NDSpace, Value] private[scal
   }
 
   /**
+   * Returns a reduced rank model, using only the leading basis function of the Karhunen-loeve expansion.
+   *
+   * @param newRank: The rank of the new Gaussian process.
+   */
+  def truncate(rank: Int) = {
+    DiscreteLowRankGaussianProcess[D, Value](mean, klBasis.take(rank))
+  }
+
+  /**
    * Discrete version of [[LowRankGaussianProcess.project(IndexedSeq[(Point[D], Vector[DO])], Double)]]
    */
   override def project(s: DiscreteField[D, Value]): DiscreteField[D, Value] = {

--- a/src/main/scala/scalismo/statisticalmodel/LowRankGaussianProcess.scala
+++ b/src/main/scala/scalismo/statisticalmodel/LowRankGaussianProcess.scala
@@ -82,6 +82,15 @@ class LowRankGaussianProcess[D <: Dim: NDSpace, Value](mean: Field[D, Value],
   }
 
   /**
+   * Returns a reduced rank model, using only the leading basis function of the Karhunen-loeve expansion.
+   *
+   * @param newRank: The rank of the new Gaussian process.
+   */
+  def truncate(newRank: Int): LowRankGaussianProcess[D, Value] = {
+    new LowRankGaussianProcess(mean, klBasis.take(newRank))
+  }
+
+  /**
    * Returns the sample of the gaussian process that best explains the given training data. It is assumed that the training data (values)
    * are subject to 0 mean Gaussian noise
    *

--- a/src/main/scala/scalismo/statisticalmodel/StatisticalMeshModel.scala
+++ b/src/main/scala/scalismo/statisticalmodel/StatisticalMeshModel.scala
@@ -104,6 +104,15 @@ case class StatisticalMeshModel private (referenceMesh: TriangleMesh[_3D], gp: D
   }
 
   /**
+   * Returns a reduced rank model, using only the leading basis functions.
+   *
+   * @param newRank: The rank of the new model.
+   */
+  def truncate(newRank: Int): StatisticalMeshModel = {
+    new StatisticalMeshModel(referenceMesh, gp.truncate(newRank))
+  }
+
+  /**
    * @see [[DiscreteLowRankGaussianProcess.project]]
    */
   def project(mesh: TriangleMesh[_3D]) = {

--- a/src/test/scala/scalismo/statisticalmodel/GaussianProcessTests.scala
+++ b/src/test/scala/scalismo/statisticalmodel/GaussianProcessTests.scala
@@ -15,12 +15,15 @@
  */
 package scalismo.statisticalmodel
 
+import _root_.java.io.File
+
 import breeze.linalg.{ DenseMatrix, DenseVector }
 import scalismo.ScalismoTestSuite
 import scalismo.common._
 import scalismo.geometry.Point.implicits._
 import scalismo.geometry._
 import scalismo.image.DiscreteImageDomain
+import scalismo.io.StatismoIO
 import scalismo.kernels.{ DiagonalKernel, GaussianKernel, MatrixValuedPDKernel }
 import scalismo.numerics.{ GridSampler, UniformSampler }
 import scalismo.utils.Random
@@ -238,6 +241,15 @@ class GaussianProcessTests extends ScalismoTestSuite {
       for (i <- 0 until coeffs.size) {
         computedCoeffs(i) should be(coeffs(i) +- 1e-2)
       }
+    }
+
+    it("has the right rank when reduced") {
+      val gp = Fixture.gp
+
+      val newRank = gp.rank / 2
+      val truncatedGP = gp.truncate(newRank)
+      truncatedGP.rank should equal(newRank)
+
     }
 
     it("yields the same object when a sample from the model is projected") {

--- a/src/test/scala/scalismo/statisticalmodel/StatisticalModelTests.scala
+++ b/src/test/scala/scalismo/statisticalmodel/StatisticalModelTests.scala
@@ -79,6 +79,16 @@ class StatisticalModelTests extends ScalismoTestSuite {
       compareModels(model, newModel)
     }
 
+    it("has the right rank when reduced") {
+      val path = getClass.getResource("/facemodel.h5").getPath
+      val model = StatismoIO.readStatismoMeshModel(new File(path)).get
+
+      val newRank = model.rank / 2
+      val truncatedModel = model.truncate(newRank)
+      truncatedModel.rank should equal(newRank)
+
+    }
+
     //    it("can write a changed mean statistical mode, read it and still yield the same space") {
     //      val tmpStatismoFile = File.createTempFile("statModel", ".h5")
     //      tmpStatismoFile.deleteOnExit()


### PR DESCRIPTION
A common task when working with shape models is to reduce the rank of a model (i.e. to create a new model with only the leading basis functions).

While this was always possible in scalismo, it was so well hidden and cumbersome that the uninitiated would never find out how to do it. This PR proposes to add a method ```truncate``` to the ```StatisticalMeshModel``` and the ```(Discrete)LowrankGaussianProcess``` classes. 

To obtain a new statistical model, which is only represented using the first 5 basis function, the following code can be used:
```scala
val reducedRankModel = model.truncate(newRank = 5)
```
