### PR TITLE
Clean Random & make RandBasis available

### DIFF
--- a/src/main/scala/scalismo/numerics/RandomSVD.scala
+++ b/src/main/scala/scalismo/numerics/RandomSVD.scala
@@ -17,8 +17,9 @@ package scalismo.numerics
 
 import breeze.linalg.qr.QR
 import breeze.linalg.svd.SVD
-import breeze.linalg.{ diag, DenseMatrix, DenseVector, norm }
-import scalismo.utils.{ Random, Benchmark }
+import breeze.linalg.{ DenseMatrix, DenseVector, diag, norm }
+import breeze.stats.distributions.Gaussian
+import scalismo.utils.{ Benchmark, Random }
 
 /**
  * Implementation of a Randomized approach for SVD,
@@ -36,7 +37,7 @@ object RandomSVD {
     val l = k + 5
     val m = A.rows
 
-    val standardNormal = rand.breezeRandomGaussian(0, 1)
+    val standardNormal = Gaussian(0, 1)(rand.breezeRandBasis)
 
     // create a gaussian random matrix
     val Omega = DenseMatrix.zeros[Double](m, l).map(_ => standardNormal.draw())

--- a/src/main/scala/scalismo/numerics/Sampler.scala
+++ b/src/main/scala/scalismo/numerics/Sampler.scala
@@ -56,7 +56,7 @@ case class UniformSampler[D <: Dim: NDSpace](domain: BoxDomain[D], numberOfPoint
   override def sample()(implicit rand: Random) = {
     val ndSpace = implicitly[NDSpace[D]]
     val randGens = for (i <- (0 until ndSpace.dimensionality)) yield {
-      rand.breezeRandomUnform(domain.origin(i), domain.oppositeCorner(i))
+      rand.breezeRandomUniform(domain.origin(i), domain.oppositeCorner(i))
     }
 
     for (_ <- 0 until numberOfPoints) yield (Point.apply[D](randGens.map(r => r.draw()).toArray), p)
@@ -71,7 +71,7 @@ case class RandomMeshSampler3D(mesh: TriangleMesh[_3D], numberOfPoints: Int, see
   val volumeOfSampleRegion = mesh.area
   def sample()(implicit rand: Random) = {
     val points = mesh.pointSet.points.toIndexedSeq
-    val distrDim1 = rand.breezeRandomUnform(0, mesh.pointSet.numberOfPoints)
+    val distrDim1 = rand.breezeRandomUniform(0, mesh.pointSet.numberOfPoints)
     val pts = (0 until numberOfPoints).map(i => (points(distrDim1.draw().toInt), p))
     pts
   }

--- a/src/main/scala/scalismo/statisticalmodel/DiscreteLowRankGaussianProcess.scala
+++ b/src/main/scala/scalismo/statisticalmodel/DiscreteLowRankGaussianProcess.scala
@@ -16,7 +16,8 @@
 package scalismo.statisticalmodel
 
 import breeze.linalg.svd.SVD
-import breeze.linalg.{ diag, *, DenseMatrix, DenseVector }
+import breeze.linalg.{ *, DenseMatrix, DenseVector, diag }
+import breeze.stats.distributions.Gaussian
 import scalismo.common._
 import scalismo.geometry._
 import scalismo.kernels.{ DiscreteMatrixValuedPDKernel, MatrixValuedPDKernel }
@@ -26,7 +27,7 @@ import scalismo.registration.Transformation
 import scalismo.statisticalmodel.DiscreteLowRankGaussianProcess._
 import scalismo.statisticalmodel.LowRankGaussianProcess.Eigenpair
 import scalismo.statisticalmodel.DiscreteLowRankGaussianProcess.{ Eigenpair => DiscreteEigenpair }
-import scalismo.utils.{ Random, Memoize }
+import scalismo.utils.{ Memoize, Random }
 
 /**
  * Represents a low-rank gaussian process, that is only defined at a finite, discrete set of points.
@@ -102,7 +103,8 @@ case class DiscreteLowRankGaussianProcess[D <: Dim: NDSpace, Value] private[scal
    * Discrete version of [[DiscreteLowRankGaussianProcess.sample]]
    */
   override def sample()(implicit random: Random): DiscreteField[D, Value] = {
-    val coeffs = for (_ <- 0 until rank) yield random.breezeRandomGaussian(0, 1).draw()
+    val standardNormal = Gaussian(0, 1)(random.breezeRandBasis)
+    val coeffs = standardNormal.sample(rank)
     instance(DenseVector(coeffs.toArray))
   }
 

--- a/src/main/scala/scalismo/statisticalmodel/LowRankGaussianProcess.scala
+++ b/src/main/scala/scalismo/statisticalmodel/LowRankGaussianProcess.scala
@@ -16,7 +16,8 @@
 package scalismo.statisticalmodel
 
 import breeze.linalg.svd.SVD
-import breeze.linalg.{ diag, DenseMatrix, DenseVector }
+import breeze.linalg.{ DenseMatrix, DenseVector, diag }
+import breeze.stats.distributions.Gaussian
 import scalismo.common._
 import scalismo.geometry.{ Dim, NDSpace, Point, SquareMatrix, Vector }
 import scalismo.kernels.{ Kernel, MatrixValuedPDKernel }
@@ -24,7 +25,7 @@ import scalismo.numerics.PivotedCholesky.RelativeTolerance
 import scalismo.numerics.Sampler
 import scalismo.registration.RigidTransformation
 import scalismo.statisticalmodel.LowRankGaussianProcess.{ Eigenpair, KLBasis }
-import scalismo.utils.{ Random, Memoize }
+import scalismo.utils.{ Memoize, Random }
 
 /**
  *
@@ -67,7 +68,8 @@ class LowRankGaussianProcess[D <: Dim: NDSpace, Value](mean: Field[D, Value],
    * A random sample of the gaussian process
    */
   def sample()(implicit rand: Random): Field[D, Value] = {
-    val coeffs = for (_ <- klBasis.indices) yield rand.breezeRandomGaussian(0, 1).draw()
+    val standardNormal = Gaussian(0, 1)(rand.breezeRandBasis)
+    val coeffs = standardNormal.sample(klBasis.length)
     instance(DenseVector(coeffs.toArray))
   }
 

--- a/src/main/scala/scalismo/statisticalmodel/MultivariateNormalDistribution.scala
+++ b/src/main/scala/scalismo/statisticalmodel/MultivariateNormalDistribution.scala
@@ -17,6 +17,7 @@ package scalismo.statisticalmodel
 
 import breeze.linalg.svd.SVD
 import breeze.linalg._
+import breeze.stats.distributions.Gaussian
 import scalismo.geometry.Vector
 import scalismo.geometry._
 import scalismo.utils.Random
@@ -102,8 +103,8 @@ case class MultivariateNormalDistribution(mean: DenseVector[Double], cov: DenseM
   }
 
   override def sample()(implicit rand: Random): DenseVector[Double] = {
-
-    val normalSamples = for (i <- 0 until dim) yield rand.breezeRandomGaussian(0, 1).draw()
+    val standardNormal = Gaussian(0, 1)(rand.breezeRandBasis)
+    val normalSamples = standardNormal.sample(dim)
     val u = DenseVector[Double](normalSamples.toArray)
 
     mean + (root * u)

--- a/src/main/scala/scalismo/utils/Random.scala
+++ b/src/main/scala/scalismo/utils/Random.scala
@@ -34,10 +34,12 @@ case class Random(seed: Long) {
 
   val scalaRandom: scala.util.Random = new scala.util.Random(seed)
 
+  @deprecated("directly use breezeRandBasis and breeze.stats.distributions.Gaussian")
   def breezeRandomGaussian(mu: Double, sigma: Double): breeze.stats.distributions.Rand[Double] = {
     breeze.stats.distributions.Gaussian(mu, sigma)(breezeRandBasis)
   }
 
+  @deprecated("directly use breezeRandBasis and breeze.stats.distributions.Uniform")
   def breezeRandomUniform(a: Double, b: Double): breeze.stats.distributions.Rand[Double] = {
     breeze.stats.distributions.Uniform(a, b)(breezeRandBasis)
   }

--- a/src/main/scala/scalismo/utils/Random.scala
+++ b/src/main/scala/scalismo/utils/Random.scala
@@ -30,22 +30,22 @@ import org.apache.commons.math3.random.MersenneTwister
  */
 case class Random(seed: Long) {
 
-  private val randBasis: RandBasis = new RandBasis(new ThreadLocalRandomGenerator(new MersenneTwister(seed)))
+  implicit val breezeRandBasis: RandBasis = new RandBasis(new ThreadLocalRandomGenerator(new MersenneTwister(seed)))
 
   val scalaRandom: scala.util.Random = new scala.util.Random(seed)
 
-  def breezeRandomGaussian(mu: Double, sigma2: Double): breeze.stats.distributions.Rand[Double] = {
-    breeze.stats.distributions.Gaussian(mu, sigma2)(randBasis)
+  def breezeRandomGaussian(mu: Double, sigma: Double): breeze.stats.distributions.Rand[Double] = {
+    breeze.stats.distributions.Gaussian(mu, sigma)(breezeRandBasis)
   }
 
-  def breezeRandomUnform(a: Double, b: Double): breeze.stats.distributions.Rand[Double] = {
-    breeze.stats.distributions.Uniform(a, b)(randBasis)
+  def breezeRandomUniform(a: Double, b: Double): breeze.stats.distributions.Rand[Double] = {
+    breeze.stats.distributions.Uniform(a, b)(breezeRandBasis)
   }
 
 }
 
 object Random {
 
-  implicit val randomGenerator = Random(System.currentTimeMillis())
+  implicit val randomGenerator = Random(System.nanoTime())
 
 }

--- a/src/test/scala/scalismo/statisticalmodel/GaussianProcessTests.scala
+++ b/src/test/scala/scalismo/statisticalmodel/GaussianProcessTests.scala
@@ -18,6 +18,7 @@ package scalismo.statisticalmodel
 import _root_.java.io.File
 
 import breeze.linalg.{ DenseMatrix, DenseVector }
+import breeze.stats.distributions.Gaussian
 import scalismo.ScalismoTestSuite
 import scalismo.common._
 import scalismo.geometry.Point.implicits._
@@ -371,7 +372,7 @@ class GaussianProcessTests extends ScalismoTestSuite {
       val gp = f.discreteLowRankGp.interpolateNystrom(100)
       val discreteGp = gp.discretize(UnstructuredPointsDomain(f.discretizationPoints))
 
-      val gaussRNG = random.breezeRandomGaussian(0, 1)
+      val gaussRNG = Gaussian(0, 1)(random.breezeRandBasis)
       val coeffs = DenseVector.rand(gp.rank, gaussRNG)
 
       val sample = gp.instance(coeffs)
@@ -455,7 +456,7 @@ class GaussianProcessTests extends ScalismoTestSuite {
     it("yields the same values on the discrete points when interpolated with nearest neighbor") {
       val f = Fixture
       val interpolatedGP = f.discreteLowRankGp.interpolateNearestNeighbor
-      val gaussRNG = random.breezeRandomGaussian(0, 1)
+      val gaussRNG = Gaussian(0, 1)(random.breezeRandBasis)
       val coeffs = DenseVector.rand(interpolatedGP.rank, gaussRNG)
 
       val discreteInstance = f.discreteLowRankGp.instance(coeffs)
@@ -469,7 +470,7 @@ class GaussianProcessTests extends ScalismoTestSuite {
       val orignalLowRankPosterior = f.lowRankGp.posterior(f.trainingDataLowRankGP)
       val interpolatedGPPosterior = f.discreteLowRankGp.interpolateNearestNeighbor.posterior(f.trainingDataLowRankGP)
 
-      val gaussRNG = random.breezeRandomGaussian(0, 1)
+      val gaussRNG = Gaussian(0, 1)(random.breezeRandBasis)
       val coeffs = DenseVector.rand(orignalLowRankPosterior.rank, gaussRNG)
 
       val originalPosteriorInstance = orignalLowRankPosterior.instance(coeffs)
@@ -490,7 +491,7 @@ class GaussianProcessTests extends ScalismoTestSuite {
       val points = (0 until 1000) map { i => random.scalaRandom.nextInt(gp._domain.numberOfPoints) }
       points.foreach { pid =>
         val k = gp.rank
-        val gaussRNG = random.breezeRandomGaussian(0, 1)
+        val gaussRNG = Gaussian(0, 1)(random.breezeRandBasis)
         val coeffs = DenseVector.rand(k, gaussRNG)
         val instance = gp.instance(coeffs)
         instance.data(pid) shouldBe gp.instanceAtPoint(coeffs, pid)

--- a/src/test/scala/scalismo/statisticalmodel/StatisticalModelTests.scala
+++ b/src/test/scala/scalismo/statisticalmodel/StatisticalModelTests.scala
@@ -18,6 +18,7 @@ package scalismo.statisticalmodel
 import java.io.File
 
 import breeze.linalg.DenseVector
+import breeze.stats.distributions.Gaussian
 import scalismo.ScalismoTestSuite
 import scalismo.geometry._
 import scalismo.io.StatismoIO
@@ -36,9 +37,8 @@ class StatisticalModelTests extends ScalismoTestSuite {
     def compareModels(oldModel: StatisticalMeshModel, newModel: StatisticalMeshModel) {
 
       for (i <- 0 until 10) {
-        val coeffsData = (0 until oldModel.rank).map { _ =>
-          random.breezeRandomGaussian(0, 1).draw()
-        }
+        val standardNormal = Gaussian(0, 1)(random.breezeRandBasis)
+        val coeffsData = standardNormal.sample(oldModel.rank)
         val coeffs = DenseVector(coeffsData.toArray)
         val inst = oldModel.instance(coeffs)
         val instNew = newModel.instance(coeffs)

--- a/src/test/scala/scalismo/utils/RandomTests.scala
+++ b/src/test/scala/scalismo/utils/RandomTests.scala
@@ -15,10 +15,8 @@
  */
 package scalismo.utils
 
+import breeze.stats.distributions.{ Gaussian, Uniform }
 import scalismo.ScalismoTestSuite
-import scalismo.geometry.{ Point, _3D }
-
-import scala.collection.immutable.IndexedSeq
 
 class RandomTests extends ScalismoTestSuite {
 
@@ -28,7 +26,9 @@ class RandomTests extends ScalismoTestSuite {
 
       def randomNumbersSeeded() = {
         val r = Random(42)
-        (r.scalaRandom.nextInt, r.breezeRandomGaussian(0, 1).draw(), r.breezeRandomUniform(0, 1).draw())
+        val standardNormal = Gaussian(0, 1)(r.breezeRandBasis)
+        val uniform = Uniform(0, 1)(r.breezeRandBasis)
+        (r.scalaRandom.nextInt, standardNormal.draw(), uniform.draw())
       }
       randomNumbersSeeded() should equal(randomNumbersSeeded())
 
@@ -38,7 +38,9 @@ class RandomTests extends ScalismoTestSuite {
 
       def randomNumbersNotSeeded() = {
         val r = implicitly[Random]
-        (r.scalaRandom.nextInt, r.breezeRandomGaussian(0, 1).draw(), r.breezeRandomUniform(0, 1).draw())
+        val standardNormal = Gaussian(0, 1)(r.breezeRandBasis)
+        val uniform = Uniform(0, 1)(r.breezeRandBasis)
+        (r.scalaRandom.nextInt, standardNormal.draw(), uniform.draw())
       }
       randomNumbersNotSeeded() should not equal (randomNumbersNotSeeded())
     }

--- a/src/test/scala/scalismo/utils/RandomTests.scala
+++ b/src/test/scala/scalismo/utils/RandomTests.scala
@@ -28,7 +28,7 @@ class RandomTests extends ScalismoTestSuite {
 
       def randomNumbersSeeded() = {
         val r = Random(42)
-        (r.scalaRandom.nextInt, r.breezeRandomGaussian(0, 1).draw(), r.breezeRandomUnform(0, 1).draw())
+        (r.scalaRandom.nextInt, r.breezeRandomGaussian(0, 1).draw(), r.breezeRandomUniform(0, 1).draw())
       }
       randomNumbersSeeded() should equal(randomNumbersSeeded())
 
@@ -38,7 +38,7 @@ class RandomTests extends ScalismoTestSuite {
 
       def randomNumbersNotSeeded() = {
         val r = implicitly[Random]
-        (r.scalaRandom.nextInt, r.breezeRandomGaussian(0, 1).draw(), r.breezeRandomUnform(0, 1).draw())
+        (r.scalaRandom.nextInt, r.breezeRandomGaussian(0, 1).draw(), r.breezeRandomUniform(0, 1).draw())
       }
       randomNumbersNotSeeded() should not equal (randomNumbersNotSeeded())
     }


### PR DESCRIPTION
The `Random` object is meant to unify how randomness is used and ensures a seeded state. However, it was not possible to get a breeze `RandBasis` due to it being private. When working mit more than `breezeUniform` and `breezeGaussian` this is required, e.g. in 

```scala
import breeze.stats.distributions._

val rnd = Random(9)
import rnd.breezeRandBasis
val gauss = Exponential(2.0)
gauss.draw() // should yield: 0.48878484018783064
```

- Also fixed a typo in `breezeUniform`
- Ranamed parameter `sigma` of `breezeGaussian` to avoid confusion - it is a standard deviation, not a variance
- Use `System.nanoTime()` for more fine-grained seeding
