### PR TITLE
Update to scala 2.12.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,7 @@ env:
 #  - rm -f $HOME/.ivy2/.*.lock $HOME/.ivy2/*.lock
 
 scala:
-  - 2.10.4
-#  - 2.11.4
+  - 2.12.1
 
 script:
   - jdk_switcher use oraclejdk8

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -13,14 +13,14 @@ import com.typesafe.sbt.SbtGit.useJGit
 
 object BuildSettings {
   val buildOrganization = "ch.unibas.cs.gravis"
-  val buildScalaVersion = "2.11.7"
+  val buildScalaVersion = "2.12.1"
 
   val publishURL = Resolver.file("file", new File("/export/contrib/statismo/repo/public"))
 
   val buildSettings = Defaults.defaultSettings ++ Seq(
     organization := buildOrganization,
     scalaVersion := buildScalaVersion,
-    crossScalaVersions := Seq("2.10.5", "2.11.7"),
+    crossScalaVersions := Seq("2.11.7"),
     javacOptions ++= Seq("-source", "1.6", "-target", "1.6"),
     scalacOptions ++= Seq("-encoding", "UTF-8", "-Xlint", "-deprecation", "-unchecked", "-feature", "-target:jvm-1.6")
   )
@@ -43,10 +43,10 @@ object Resolvers {
 
 object Dependencies {
   import BuildSettings.scalismoPlatform
-  val scalatest = "org.scalatest" %% "scalatest" % "2.2+" % "test"
+  val scalatest = "org.scalatest" %% "scalatest" % "3.0.1" % "test"
   val breezeMath = "org.scalanlp" %% "breeze" % "0.13"
   val breezeNative = "org.scalanlp" %% "breeze-natives" % "0.13"
-  val sprayJson = "io.spray" %% "spray-json" % "1.2.6"
+  val sprayJson = "io.spray" %% "spray-json" % "1.3.3"
   val scalismoNativeStub = "ch.unibas.cs.gravis" % "scalismo-native-stub" % "3.0.0"
   val scalismoNativeImpl = "ch.unibas.cs.gravis" % s"scalismo-native-$scalismoPlatform" % "3.0.0" % "test"
   val slf4jNop = "org.slf4j" % "slf4j-nop" % "1.6.0" // this silences slf4j complaints in registration classes

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -21,8 +21,14 @@ object BuildSettings {
     organization := buildOrganization,
     scalaVersion := buildScalaVersion,
     crossScalaVersions := Seq("2.11.8", "2.12.1"),
-    javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
-    scalacOptions ++= Seq("-encoding", "UTF-8", "-Xlint", "-deprecation", "-unchecked", "-feature", "-target:jvm-1.8")
+    javacOptions ++= (CrossVersion.partialVersion(scalaVersion.value) match {
+      case Some((2,  11)) => Seq("-source", "1.6", "-target", "1.6")
+      case _ => Seq("-source", "1.8", "-target", "1.8")
+    }),
+    scalacOptions ++= (CrossVersion.partialVersion(scalaVersion.value) match {
+      case Some((2,  11)) =>  Seq("-encoding", "UTF-8", "-Xlint", "-deprecation", "-unchecked", "-feature", "-target:jvm-1.6")
+      case _ => Seq("-encoding", "UTF-8", "-Xlint", "-deprecation", "-unchecked", "-feature", "-target:jvm-1.8")
+    })
   )
 
   // nativelibs implementation to use (e.g., "linux64"). If not explicitly set, use "all"

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -13,16 +13,16 @@ import com.typesafe.sbt.SbtGit.useJGit
 
 object BuildSettings {
   val buildOrganization = "ch.unibas.cs.gravis"
-  val buildScalaVersion = "2.12.1"
+  val buildScalaVersion = "2.11.8"
 
   val publishURL = Resolver.file("file", new File("/export/contrib/statismo/repo/public"))
 
   val buildSettings = Defaults.defaultSettings ++ Seq(
     organization := buildOrganization,
     scalaVersion := buildScalaVersion,
-    crossScalaVersions := Seq("2.11.7"),
-    javacOptions ++= Seq("-source", "1.6", "-target", "1.6"),
-    scalacOptions ++= Seq("-encoding", "UTF-8", "-Xlint", "-deprecation", "-unchecked", "-feature", "-target:jvm-1.6")
+    crossScalaVersions := Seq("2.11.8", "2.12.1"),
+    javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
+    scalacOptions ++= Seq("-encoding", "UTF-8", "-Xlint", "-deprecation", "-unchecked", "-feature", "-target:jvm-1.8")
   )
 
   // nativelibs implementation to use (e.g., "linux64"). If not explicitly set, use "all"

--- a/src/main/scala/scalismo/sampling/proposals/MixtureProposal.scala
+++ b/src/main/scala/scalismo/sampling/proposals/MixtureProposal.scala
@@ -23,16 +23,16 @@ class MixtureProposal[A](proposals: IndexedSeq[(Double, ProposalGenerator[A])])(
     extends ProposalGenerator[A] {
 
   /** mixture components */
-  val generators = proposals.map(_._2)
+  val generators: IndexedSeq[ProposalGenerator[A]] = proposals.map(_._2)
 
-  val mixtureFactors = {
+  val mixtureFactors: IndexedSeq[Double] = {
     val f = proposals.map(_._1)
     val totalP = f.sum
     f.map(c => c / totalP)
   }
 
   // cumsum
-  protected val p = mixtureFactors.scanLeft(0.0)((t, p) => t + p).tail
+  protected val p: IndexedSeq[Double] = mixtureFactors.scanLeft(0.0)((t, p) => t + p).tail
   // keep state: last active proposal, useful for printing only
   private var lastActive = 0
 
@@ -43,14 +43,14 @@ class MixtureProposal[A](proposals: IndexedSeq[(Double, ProposalGenerator[A])])(
     generators(i).propose(current)
   }
 
-  override def toString = generators(lastActive).toString
+  override def toString: String = generators(lastActive).toString
 }
 
 /** mixture with transition probabilities */
 private class MixtureProposalWithTransition[A](proposals: IndexedSeq[(Double, ProposalGenerator[A] with TransitionProbability[A])])(implicit rnd: Random)
     extends MixtureProposal[A](proposals) with TransitionProbability[A] {
 
-  override val generators = proposals.map(_._2)
+  override val generators: IndexedSeq[ProposalGenerator[A] with TransitionProbability[A]] = proposals.map(_._2)
 
   override def logTransitionProbability(from: A, to: A): Double = {
     val transitions = generators.map(g => g.logTransitionProbability(from, to))


### PR DESCRIPTION
Major scala update to version 2.12.1. The new version with many cool new [features in 2.12.0](http://www.scala-lang.org/news/2.12.0) (and less impressive [2.12.1](http://www.scala-lang.org/news/2.12.1)). This will make scalismo leaner and slightly easier to use.

Be aware: you need java 8 now!

Only few adaptation were needed:

- Some dependency updates (thanks Marcel)
- explicit types in `MixtureProposal`
- Travis update to use scala 2.12.1 (already on jdk8)