### PR TITLE
Cleaner logging for sampling

### DIFF
--- a/src/main/scala/scalismo/sampling/MarkovChain.scala
+++ b/src/main/scala/scalismo/sampling/MarkovChain.scala
@@ -25,21 +25,3 @@ trait MarkovChain[A] {
   /** provide a chain starting from current as an iterator */
   def iterator(current: A): Iterator[A] = Iterator.iterate(current)(next)
 }
-
-object MarkovChain {
-  /** fat interface with rich enhancements for Markov Chains - only implementation, not a type */
-  implicit class RichMarkovChain[A](mc: MarkovChain[A]) {
-    def loggedWith(logger: ChainStateLogger[A]): MarkovChain[A] = new LoggedMarkovChain[A](mc, logger)
-  }
-
-  class LoggedMarkovChain[A](chain: MarkovChain[A], logger: ChainStateLogger[A]) extends MarkovChain[A] {
-    /** next sample in chain */
-    override def next(current: A): A = {
-      val sample = chain.next(current)
-      logger.logState(sample)
-      sample
-    }
-
-    override def toString = chain.toString
-  }
-}

--- a/src/main/scala/scalismo/sampling/proposals/MetropolisFilterProposals.scala
+++ b/src/main/scala/scalismo/sampling/proposals/MetropolisFilterProposals.scala
@@ -26,9 +26,9 @@ class MetropolisFilterProposal[A](val generator: ProposalGenerator[A] with Trans
   val logger: AcceptRejectLogger[A])(implicit random: Random)
     extends ProposalGenerator[A] with UnitTransition[A] {
 
-  private val mH = MetropolisHastings(generator, evaluator, logger)
+  private val mH = MetropolisHastings(generator, evaluator)
 
-  override def propose(current: A): A = mH.next(current)
+  override def propose(current: A): A = mH.next(current, logger)
 
   override def toString = s"MetropolisFilterProposal($generator,$evaluator)"
 }
@@ -49,9 +49,9 @@ class CorrectedMetropolisFilterProposal[A](val generator: ProposalGenerator[A] w
   val logger: AcceptRejectLogger[A])(implicit random: Random)
     extends ProposalGenerator[A] with TransitionProbability[A] {
 
-  private val mH = MetropolisHastings(generator, evaluator, logger)
+  private val mH = MetropolisHastings(generator, evaluator)
 
-  override def propose(current: A): A = mH.next(current)
+  override def propose(current: A): A = mH.next(current, logger)
 
   override def logTransitionRatio(from: A, to: A): Double = {
     evaluator.logValue(to) - evaluator.logValue(from)


### PR DESCRIPTION
Logging in `sampling` was a bit messy: Chains allowed to run multiple iterators (multiple runs with the same settings but no communication), however, logging was on object level only. So multiple runs inferred in the same logger.

I cleaned this and made the loggers attach to individual runs rather than the complete object. You can now start a "logged" iterator in a `Metropolis`/`MetropolisHastings` algorithm. Also a `MarkovChain` has no global logger any more but can attach one to the chain iterator.