### PR TITLE
start vtk garbage collector on initialize.

### DIFF
--- a/src/main/scala/scalismo/package.scala
+++ b/src/main/scala/scalismo/package.scala
@@ -13,7 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+import java.util.concurrent.TimeUnit
+
 import scalismo.support.nativelibs._
+import vtk.vtkObjectBase
 
 package object scalismo {
 
@@ -22,12 +26,18 @@ package object scalismo {
 
   /**
    * Initialize and load the required native libraries
+   *
    * @param ignoreErrors ignore failures when trying to load libraries. Only set this if you know what you are doing!
    */
   def initialize(ignoreErrors: Boolean = false) = initialized.synchronized {
     if (!initialized(0)) {
       val mode = if (ignoreErrors) InitializationMode.WARN_ON_FAIL else InitializationMode.TERMINATE_ON_FAIL
       NativeLibraryBundles.initialize(mode)
+
+      val gc = vtkObjectBase.JAVA_OBJECT_MANAGER.getAutoGarbageCollector
+      gc.SetScheduleTime(60, TimeUnit.SECONDS)
+      gc.Start()
+
       initialized(0) = true
     }
   }


### PR DESCRIPTION
This PR addresses the problem that long running jobs that use ```MeshIO``` run out of memory at some point (issue #193). 

The fix is to start the VTK Garbage Collector explicitly on calling ```scalismo.initialize()```. 

