### PR TITLE
Explicit tolerance for merging in STL

### DIFF
--- a/src/main/scala/scalismo/io/MeshIO.scala
+++ b/src/main/scala/scalismo/io/MeshIO.scala
@@ -250,6 +250,16 @@ object MeshIO {
   private def readSTL(file: File, correctMesh: Boolean = false): Try[TriangleMesh[_3D]] = {
     val stlReader = new vtkSTLReader()
     stlReader.SetFileName(file.getAbsolutePath)
+
+    stlReader.MergingOn()
+
+    // With the default point locator, it may happen that the stlReader merges
+    // points that are very close by but not identical. To make sure that this never happens
+    // we explicitly specify the tolerance.
+    val pointLocator = new vtkMergePoints()
+    pointLocator.SetTolerance(0.0)
+
+    stlReader.SetLocator(pointLocator)
     stlReader.Update()
     val errCode = stlReader.GetErrorCode()
     if (errCode != 0) {


### PR DESCRIPTION
It seems to have happened in some cases, that the STL reader merged points, which were very close to each other (but not identical). As this destroy any point-to-point correspondence that might exist among meshes, such a merge should never happen. To prevent this, we set the tolerance of the stl reader to zero.