### PR TITLE
use closestPointOnSurface for computing binary image from mesh

### DIFF
--- a/src/main/scala/scalismo/mesh/boundingSpheres/ClosestPoint.scala
+++ b/src/main/scala/scalismo/mesh/boundingSpheres/ClosestPoint.scala
@@ -19,7 +19,7 @@ import scalismo.common.PointId
 import scalismo.geometry.{ Point, _3D }
 import scalismo.mesh.{ BarycentricCoordinates, TriangleId }
 
-class ClosestPoint(val point: Point[_3D],
+sealed class ClosestPoint(val point: Point[_3D],
     val distanceSquared: Double) {
   def <(that: ClosestPoint) = {
     this.distanceSquared < that.distanceSquared


### PR DESCRIPTION
So far, the computation of a binary image involved checking for every image point the angle to the normal at the closest vertex point. This PR proposes to replace this with the closest point on the surface. Especially for meshes with a low resolution, this should increase the accuracy. 