### PR TITLE
Fix SilentLogger's apply method

### DIFF
--- a/src/main/scala/scalismo/sampling/loggers/SilentLogger.scala
+++ b/src/main/scala/scalismo/sampling/loggers/SilentLogger.scala
@@ -18,7 +18,7 @@ package scalismo.sampling.loggers
 import scalismo.sampling.{ DistributionEvaluator, ProposalGenerator }
 
 object SilentLogger {
-  def apply[A] = new SilentLogger[A]()
+  def apply[A]() = new SilentLogger[A]()
 }
 
 /** silent logger, does nothing */


### PR DESCRIPTION
In the class `SilentLogger` the `apply` method is written without parentheses. This leads to the following behaviour:
```
val type: SilentLogger.type = SilentLogger
val logger: SilentLogger[A] = SilentLogger.apply
// val logger2: SilentLogger[A] = SilentLogger() → does not compile
```
The last line is working when we add parentheses which is the content of the pull request.