### PR TITLE
remove requirement that transformationspaces need differentiable transforms

### DIFF
--- a/src/main/scala/scalismo/registration/GaussianProcessTransformationSpace.scala
+++ b/src/main/scala/scalismo/registration/GaussianProcessTransformationSpace.scala
@@ -22,7 +22,8 @@ import TransformationSpace.ParameterVector
 import breeze.linalg.{ DenseMatrix, DenseVector }
 import scalismo.geometry.Vector.VectorVectorizer
 
-class GaussianProcessTransformationSpace[D <: Dim] private (gp: LowRankGaussianProcess[D, Vector[D]])(implicit vectorizer: VectorVectorizer[D]) extends TransformationSpace[D] with DifferentiableTransforms[D] {
+class GaussianProcessTransformationSpace[D <: Dim] private (gp: LowRankGaussianProcess[D, Vector[D]])(implicit vectorizer: VectorVectorizer[D])
+    extends TransformationSpace[D] {
 
   override type T = GaussianProcessTransformation[D]
 
@@ -51,7 +52,8 @@ class GaussianProcessTransformationSpace[D <: Dim] private (gp: LowRankGaussianP
 
 }
 
-class GaussianProcessTransformation[D <: Dim] private (gp: LowRankGaussianProcess[D, Vector[D]], alpha: ParameterVector) extends ParametricTransformation[D] with CanDifferentiate[D] {
+class GaussianProcessTransformation[D <: Dim] private (gp: LowRankGaussianProcess[D, Vector[D]], alpha: ParameterVector)
+    extends ParametricTransformation[D] {
 
   val instance = gp.instance(alpha)
   val parameters = alpha
@@ -62,14 +64,18 @@ class GaussianProcessTransformation[D <: Dim] private (gp: LowRankGaussianProces
     val newPointAsVector = instance(x)
     x + newPointAsVector
   }
-  def takeDerivative(x: Point[D]) = { throw new NotImplementedError("take derivative of kernel") }
+
 }
 
 object GaussianProcessTransformation {
-  def apply[D <: Dim](gp: LowRankGaussianProcess[D, Vector[D]], alpha: TransformationSpace.ParameterVector) = new GaussianProcessTransformation[D](gp, alpha)
+  def apply[D <: Dim](gp: LowRankGaussianProcess[D, Vector[D]], alpha: TransformationSpace.ParameterVector) = {
+    new GaussianProcessTransformation[D](gp, alpha)
+  }
 }
 
 object GaussianProcessTransformationSpace {
-  def apply[D <: Dim](gp: LowRankGaussianProcess[D, Vector[D]])(implicit vectorizer: VectorVectorizer[D]) = new GaussianProcessTransformationSpace[D](gp)
+  def apply[D <: Dim](gp: LowRankGaussianProcess[D, Vector[D]])(implicit vectorizer: VectorVectorizer[D]) = {
+    new GaussianProcessTransformationSpace[D](gp)
+  }
 }
 

--- a/src/main/scala/scalismo/registration/Registration.scala
+++ b/src/main/scala/scalismo/registration/Registration.scala
@@ -23,7 +23,7 @@ import scalismo.image.{ DifferentiableScalarImage, ScalarImage }
 import scalismo.numerics._
 import scalismo.utils.Random
 
-case class RegistrationConfiguration[D <: Dim: NDSpace, TS <: TransformationSpace[D] with DifferentiableTransforms[D]](
+case class RegistrationConfiguration[D <: Dim: NDSpace, TS <: TransformationSpace[D]](
   optimizer: Optimizer,
   metric: ImageMetric[D],
   transformationSpace: TS,
@@ -32,9 +32,9 @@ case class RegistrationConfiguration[D <: Dim: NDSpace, TS <: TransformationSpac
 
 object Registration {
 
-  case class RegistrationState[D <: Dim, TS <: TransformationSpace[D] with DifferentiableTransforms[D]](registrationResult: TS#T, optimizerState: Optimizer#State)
+  case class RegistrationState[D <: Dim, TS <: TransformationSpace[D]](registrationResult: TS#T, optimizerState: Optimizer#State)
 
-  def iterations[D <: Dim: NDSpace, TS <: TransformationSpace[D] with DifferentiableTransforms[D]](config: RegistrationConfiguration[D, TS])(
+  def iterations[D <: Dim: NDSpace, TS <: TransformationSpace[D]](config: RegistrationConfiguration[D, TS])(
     fixedImage: ScalarImage[D],
     movingImage: DifferentiableScalarImage[D],
     initialParameters: DenseVector[Double] = config.transformationSpace.identityTransformParameters): Iterator[RegistrationState[D, TS]] =
@@ -72,7 +72,7 @@ object Registration {
       }
     }
 
-  def registration[D <: Dim: NDSpace, TS <: TransformationSpace[D] with DifferentiableTransforms[D]](configuration: RegistrationConfiguration[D, TS])(
+  def registration[D <: Dim: NDSpace, TS <: TransformationSpace[D]](configuration: RegistrationConfiguration[D, TS])(
     fixedImage: ScalarImage[D],
     movingImage: DifferentiableScalarImage[D]): TS#T = {
 


### PR DESCRIPTION
So far we required in the registration that a  ```TransformationSpace``` has ```DifferentiableTransforms```. But the requirement that transforms are differentiable is not used in the registration and can therefore be removed. 

This also allows us to get rid of an ugly hack: We had to make ```GaussianProcessTransformation``` differentiable to satisfy the interface in the registration, but as kernels are in general not differentiable, we threw a not ImplementedException in the  ```takeDerivative``` method. 