### PR TITLE
added shutdown hook to ensure termination of vtk garbage collector

### DIFF
--- a/src/main/scala/scalismo/package.scala
+++ b/src/main/scala/scalismo/package.scala
@@ -39,26 +39,28 @@ package object scalismo {
       NativeLibraryBundles.initialize(mode)
 
       if (gcInterval > 0) {
-        setupVTKGCThread(gcInterval, TimeUnit.MILLISECONDS)
+        setupVTKGCThread(gcInterval)
       }
       initialized(0) = true
     }
 
   }
 
-  private def setupVTKGCThread(gcInterval: Long, unit: TimeUnit): Unit = {
+  private def setupVTKGCThread(gcInterval: Long): Unit = {
+
+    val runGC = new Runnable() {
+      override def run() {
+        vtkObjectBase.JAVA_OBJECT_MANAGER.gc(false)
+      }
+    }
 
     val gcThread = new Thread {
       override def run() {
         while (true) {
-          unit.sleep(gcInterval)
+          Thread.sleep(gcInterval)
 
           // As vtk is very sensitive to threading issues, we run the gc on the EDT thread.
-          SwingUtilities.invokeLater(new Runnable() {
-            override def run() {
-              vtkObjectBase.JAVA_OBJECT_MANAGER.gc(false)
-            }
-          });
+          SwingUtilities.invokeLater(runGC);
 
         }
       }

--- a/src/main/scala/scalismo/package.scala
+++ b/src/main/scala/scalismo/package.scala
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
-import java.util.concurrent.TimeUnit
+import java.util.concurrent
+import java.util.concurrent.{ Executors, TimeUnit }
+import javax.swing.SwingUtilities
 
 import scalismo.support.nativelibs._
 import vtk.vtkObjectBase
@@ -28,21 +30,42 @@ package object scalismo {
    * Initialize and load the required native libraries
    *
    * @param ignoreErrors ignore failures when trying to load libraries. Only set this if you know what you are doing!
+   * @param gcInterval time interval (in milliseconds) for running the vtk garbage collection.
+   *                   A value <= 0 means that garbage collection is not run automatically.
    */
-  def initialize(ignoreErrors: Boolean = false) = initialized.synchronized {
+  def initialize(ignoreErrors: Boolean = false, gcInterval: Long = 60 * 1000) = initialized.synchronized {
     if (!initialized(0)) {
       val mode = if (ignoreErrors) InitializationMode.WARN_ON_FAIL else InitializationMode.TERMINATE_ON_FAIL
       NativeLibraryBundles.initialize(mode)
 
-      val gc = vtkObjectBase.JAVA_OBJECT_MANAGER.getAutoGarbageCollector
-      gc.SetScheduleTime(60, TimeUnit.SECONDS)
-      gc.Start()
-
-      // we need to stop the garbage collection when the JVM shutdowns.
-      // Otherwise it prevents the JVM from shutting down correctly.
-      Runtime.getRuntime().addShutdownHook(new Thread { gc.Stop() })
-
+      if (gcInterval > 0) {
+        setupVTKGCThread(gcInterval, TimeUnit.MILLISECONDS)
+      }
       initialized(0) = true
     }
+
   }
+
+  private def setupVTKGCThread(gcInterval: Long, unit: TimeUnit): Unit = {
+
+    val gcThread = new Thread {
+      override def run() {
+        while (true) {
+          TimeUnit.MILLISECONDS.sleep(gcInterval)
+
+          // As vtk is very sensitive to threading issues, we run the gc on the EDT thread.
+          SwingUtilities.invokeLater(new Runnable() {
+            override def run() {
+              vtkObjectBase.JAVA_OBJECT_MANAGER.gc(false)
+            }
+          });
+
+        }
+      }
+    }
+
+    gcThread.setDaemon(true)
+    gcThread.start()
+  }
+
 }

--- a/src/main/scala/scalismo/package.scala
+++ b/src/main/scala/scalismo/package.scala
@@ -51,7 +51,7 @@ package object scalismo {
     val gcThread = new Thread {
       override def run() {
         while (true) {
-          TimeUnit.MILLISECONDS.sleep(gcInterval)
+          unit.sleep(gcInterval)
 
           // As vtk is very sensitive to threading issues, we run the gc on the EDT thread.
           SwingUtilities.invokeLater(new Runnable() {

--- a/src/main/scala/scalismo/package.scala
+++ b/src/main/scala/scalismo/package.scala
@@ -38,6 +38,10 @@ package object scalismo {
       gc.SetScheduleTime(60, TimeUnit.SECONDS)
       gc.Start()
 
+      // we need to stop the garbage collection when the JVM shutdowns.
+      // Otherwise it prevents the JVM from shutting down correctly.
+      Runtime.getRuntime().addShutdownHook(new Thread { gc.Stop() })
+
       initialized(0) = true
     }
   }


### PR DESCRIPTION
Enabling  the VTK Garbage collector (introduced in version 0.15.1 to avoid memory leaks) sometimes prevents the application from terminating. This is fixed by using a shutdown hook, in which the garbage collector is explicitly stopped. 