### PR TITLE
Implicit Random needs now explicit import for the default value

### DIFF
--- a/src/main/scala/scalismo/geometry/Landmark.scala
+++ b/src/main/scala/scalismo/geometry/Landmark.scala
@@ -35,7 +35,7 @@ case class Landmark[D <: Dim: NDSpace](id: String, point: Point[D], description:
 
         // in order to transform the uncertainty, we simulate random landmark points
         // and estimate their distribution.
-        val transformedPoints = for (i <- 0 until 500) yield {
+        val transformedPoints = for (i <- 0 until 5000) yield {
           val sampledPoint = point + NDSpace[D].createVector(uncertainty.sample()(random).toArray)
           transformation(sampledPoint)
         }

--- a/src/main/scala/scalismo/image/Image.scala
+++ b/src/main/scala/scalismo/image/Image.scala
@@ -20,9 +20,12 @@ import scalismo.common._
 import scalismo.geometry._
 import scalismo.numerics.Integrator
 import scalismo.registration.{ CanDifferentiate, Transformation }
+
 import scala.language.implicitConversions
 import scala.reflect.ClassTag
 import scalismo.numerics.GridSampler
+
+import scalismo.utils.Random
 
 /**
  * An image whose values are scalar.
@@ -77,7 +80,7 @@ class ScalarImage[D <: Dim: NDSpace] protected (override val domain: Domain[D], 
    * @param  numberOfPointsPerDim Number of points to be used to approximate the filter. Depending on the
    * support size of the filter and the Frequency of the image, increasing this value can help avoid artifacts (at the cost of heavier computation)
    */
-  def convolve(filter: Filter[D], numberOfPointsPerDim: Int)(implicit c: CreateDiscreteImageDomain[D]): ScalarImage[D] = {
+  def convolve(filter: Filter[D], numberOfPointsPerDim: Int)(implicit c: CreateDiscreteImageDomain[D], rng: Random): ScalarImage[D] = {
 
     val dim = implicitly[NDSpace[D]].dimensionality
     val supportSpacing = filter.support.extent * (1f / numberOfPointsPerDim.toFloat)
@@ -180,7 +183,7 @@ class DifferentiableScalarImage[D <: Dim: NDSpace](_domain: Domain[D], _f: Point
     new DifferentiableScalarImage(newDomain, f, df)
   }
 
-  override def convolve(filter: Filter[D], numberOfPointsPerDim: Int)(implicit c: CreateDiscreteImageDomain[D]): DifferentiableScalarImage[D] = {
+  override def convolve(filter: Filter[D], numberOfPointsPerDim: Int)(implicit c: CreateDiscreteImageDomain[D], rng: Random): DifferentiableScalarImage[D] = {
 
     val convolvedImage = super.convolve(filter, numberOfPointsPerDim)
 

--- a/src/main/scala/scalismo/numerics/Integrator.scala
+++ b/src/main/scala/scalismo/numerics/Integrator.scala
@@ -19,8 +19,9 @@ import breeze.linalg.DenseVector
 import scalismo.common.VectorField
 import scalismo.image.ScalarImage
 import scalismo.geometry._
+import scalismo.utils.Random
 
-case class Integrator[D <: Dim: NDSpace](sampler: Sampler[D]) {
+case class Integrator[D <: Dim: NDSpace](sampler: Sampler[D])(implicit rng: Random) {
 
   def integrateScalar(img: ScalarImage[D]): Float = {
     integrateScalar(img.liftValues)

--- a/src/main/scala/scalismo/numerics/Sampler.scala
+++ b/src/main/scala/scalismo/numerics/Sampler.scala
@@ -136,7 +136,7 @@ case class UniformMeshSampler3D(mesh: TriangleMesh[_3D], numberOfPoints: Int) ex
   }
 }
 
-case class FixedPointsUniformMeshSampler3D(mesh: TriangleMesh[_3D], numberOfPoints: Int) extends Sampler[_3D] {
+case class FixedPointsUniformMeshSampler3D(mesh: TriangleMesh[_3D], numberOfPoints: Int)(implicit rng: Random) extends Sampler[_3D] {
   override val volumeOfSampleRegion = mesh.area
   val samplePoints = UniformMeshSampler3D(mesh, numberOfPoints).sample()
   override def sample()(implicit rand: Random) = samplePoints

--- a/src/main/scala/scalismo/registration/ImageMetric.scala
+++ b/src/main/scala/scalismo/registration/ImageMetric.scala
@@ -53,7 +53,7 @@ object ImageMetric {
   case class ValueAndDerivative(value: Double, derivative: DenseVector[Double])
 }
 
-case class MeanSquaresMetric[D <: Dim: NDSpace](sampler: Sampler[D]) extends ImageMetric[D] {
+case class MeanSquaresMetric[D <: Dim: NDSpace](sampler: Sampler[D])(implicit rng: Random) extends ImageMetric[D] {
 
   override val ndSpace = implicitly[NDSpace[D]]
 

--- a/src/main/scala/scalismo/registration/Registration.scala
+++ b/src/main/scala/scalismo/registration/Registration.scala
@@ -37,7 +37,8 @@ object Registration {
   def iterations[D <: Dim: NDSpace, TS <: TransformationSpace[D]](config: RegistrationConfiguration[D, TS])(
     fixedImage: ScalarImage[D],
     movingImage: DifferentiableScalarImage[D],
-    initialParameters: DenseVector[Double] = config.transformationSpace.identityTransformParameters): Iterator[RegistrationState[D, TS]] =
+    initialParameters: DenseVector[Double] = config.transformationSpace.identityTransformParameters)(
+      implicit rng: Random): Iterator[RegistrationState[D, TS]] =
     {
       val regularizer = config.regularizer
 
@@ -74,8 +75,8 @@ object Registration {
 
   def registration[D <: Dim: NDSpace, TS <: TransformationSpace[D]](configuration: RegistrationConfiguration[D, TS])(
     fixedImage: ScalarImage[D],
-    movingImage: DifferentiableScalarImage[D]): TS#T = {
-
+    movingImage: DifferentiableScalarImage[D])(
+      implicit rng: Random): TS#T = {
     val regStates = iterations(configuration)(fixedImage, movingImage)
     regStates.toSeq.last.registrationResult
   }

--- a/src/main/scala/scalismo/statisticalmodel/DiscreteLowRankGaussianProcess.scala
+++ b/src/main/scala/scalismo/statisticalmodel/DiscreteLowRankGaussianProcess.scala
@@ -194,7 +194,7 @@ case class DiscreteLowRankGaussianProcess[D <: Dim: NDSpace, Value] private[scal
    *                       kl basis.
    */
 
-  def interpolateNystrom(nNystromPoints: Int = 2 * rank): LowRankGaussianProcess[D, Value] = {
+  def interpolateNystrom(nNystromPoints: Int = 2 * rank)(implicit rng: Random): LowRankGaussianProcess[D, Value] = {
 
     val sampler = new Sampler[D] {
       override def volumeOfSampleRegion = numberOfPoints.toDouble

--- a/src/main/scala/scalismo/statisticalmodel/dataset/Crossvalidation.scala
+++ b/src/main/scala/scalismo/statisticalmodel/dataset/Crossvalidation.scala
@@ -15,10 +15,11 @@
  */
 package scalismo.statisticalmodel.dataset
 
-import scalismo.geometry.{ _3D, Vector }
+import scalismo.geometry.{ Vector, _3D }
 import scalismo.mesh.TriangleMesh
 import scalismo.numerics.UniformMeshSampler3D
-import scalismo.statisticalmodel.{ LowRankGaussianProcess, GaussianProcess, StatisticalMeshModel }
+import scalismo.statisticalmodel.{ GaussianProcess, LowRankGaussianProcess, StatisticalMeshModel }
+import scalismo.utils.Random
 
 import scala.util.Try
 
@@ -36,7 +37,11 @@ object Crossvalidation {
   /**
    * Perform a leave one out crossvalidation. See nFoldCrossvalidation for details
    */
-  def leaveOneOutCrossvalidation[A](dataCollection: DataCollection, evalFun: EvaluationFunction[A], biasModelAndRank: Option[(GaussianProcess[_3D, Vector[_3D]], Int)] = None) = {
+  def leaveOneOutCrossvalidation[A](
+    dataCollection: DataCollection,
+    evalFun: EvaluationFunction[A],
+    biasModelAndRank: Option[(GaussianProcess[_3D, Vector[_3D]], Int)] = None)(
+      implicit rng: Random) = {
     nFoldCrossvalidation(dataCollection.size, dataCollection, evalFun, biasModelAndRank)
   }
 
@@ -47,13 +52,14 @@ object Crossvalidation {
    *
    * For each testing dataset in a fold, the evalFun is called to evaluate the quality of the model built from the training set.
    *
-   * @returns a sequence the size of the chosen number of folds that contains the sequence of evaluations for each data item in the fold's testing set,
+   * @return a sequence the size of the chosen number of folds that contains the sequence of evaluations for each data item in the fold's testing set,
    * or an error if the model building for a fold failed.
    */
   def nFoldCrossvalidation[A](numFolds: Int,
     dc: DataCollection,
     evalFun: EvaluationFunction[A],
-    biasModelAndRank: Option[(GaussianProcess[_3D, Vector[_3D]], Int)] = None): Seq[Try[Seq[A]]] = {
+    biasModelAndRank: Option[(GaussianProcess[_3D, Vector[_3D]], Int)] = None)(
+      implicit rng: Random): Seq[Try[Seq[A]]] = {
 
     val folds = dc.createCrossValidationFolds(numFolds)
     val evalResultsForFolds = for (fold <- folds) yield {

--- a/src/main/scala/scalismo/statisticalmodel/dataset/DataCollection.scala
+++ b/src/main/scala/scalismo/statisticalmodel/dataset/DataCollection.scala
@@ -146,7 +146,7 @@ object DataCollection {
   }
 
   @tailrec
-  def gpaComputation(dc: DataCollection, meanShape: TriangleMesh[_3D], maxIteration: Int, haltDistance: Double)(implicit rng: Random): DataCollection = {
+  private def gpaComputation(dc: DataCollection, meanShape: TriangleMesh[_3D], maxIteration: Int, haltDistance: Double)(implicit rng: Random): DataCollection = {
 
     if (maxIteration == 0) return dc
 

--- a/src/main/scala/scalismo/statisticalmodel/dataset/ModelMetrics.scala
+++ b/src/main/scala/scalismo/statisticalmodel/dataset/ModelMetrics.scala
@@ -4,6 +4,8 @@ import scalismo.geometry._3D
 import scalismo.statisticalmodel.StatisticalMeshModel
 import scalismo.mesh.TriangleMesh
 import scalismo.mesh.MeshMetrics
+import scalismo.utils.Random
+
 import scala.util.Try
 import scala.util.Failure
 import scala.util.Success
@@ -34,7 +36,7 @@ object ModelMetrics {
    *
    */
 
-  def specificity(pcaModel: StatisticalMeshModel, data: Iterable[TriangleMesh[_3D]], nbSamples: Int): Double = {
+  def specificity(pcaModel: StatisticalMeshModel, data: Iterable[TriangleMesh[_3D]], nbSamples: Int)(implicit rng: Random): Double = {
 
     (0 until nbSamples).par.map { _ =>
       val sample = pcaModel.sample

--- a/src/main/scala/scalismo/statisticalmodel/dataset/PCAModel.scala
+++ b/src/main/scala/scalismo/statisticalmodel/dataset/PCAModel.scala
@@ -18,6 +18,8 @@ package scalismo.statisticalmodel.dataset
 
 import scalismo.statisticalmodel.{ GaussianProcess, StatisticalMeshModel }
 import scalismo.geometry._
+import scalismo.utils.Random
+
 import scala.util.Try
 
 /**
@@ -31,7 +33,7 @@ object PCAModel {
    *  Adds a bias model to the given pca model
    */
   @deprecated("Use method in StatisticalMeshModel object instead. This method and containing object wil be removed in future versions.", "0.10.0")
-  def augmentModel(pcaModel: StatisticalMeshModel, biasModel: GaussianProcess[_3D, Vector[_3D]], numBasisFunctions: Int): StatisticalMeshModel = {
+  def augmentModel(pcaModel: StatisticalMeshModel, biasModel: GaussianProcess[_3D, Vector[_3D]], numBasisFunctions: Int)(implicit rng: Random): StatisticalMeshModel = {
     StatisticalMeshModel.augmentModel(pcaModel, biasModel, numBasisFunctions)
   }
 

--- a/src/main/scala/scalismo/utils/Random.scala
+++ b/src/main/scala/scalismo/utils/Random.scala
@@ -28,7 +28,8 @@ import org.apache.commons.math3.random.MersenneTwister
  *
  * @param seed The seed for the Random number generator
  */
-case class Random(seed: Long) {
+
+private[utils] case class RandomNumberGenerator(seed: Long) {
 
   implicit val breezeRandBasis: RandBasis = new RandBasis(new ThreadLocalRandomGenerator(new MersenneTwister(seed)))
 
@@ -46,8 +47,27 @@ case class Random(seed: Long) {
 
 }
 
+@scala.annotation.implicitNotFound("missing implicit Random\nTo fix the missing implicit either use:\n\timport scalismo.utils.Random.implicitis._\n...or create a seeded random object:\n\timport scalismo.utils.Random\n\timplicit val rng = Random(1024L)")
+class Random()(implicit val rng: RandomNumberGenerator) {
+
+  def scalaRandom = rng.scalaRandom
+
+  implicit def breezeRandBasis = rng.breezeRandBasis
+
+  @deprecated("directly use breezeRandBasis and breeze.stats.distributions.Gaussian", "since v0.15")
+  def breezeRandomGaussian(mu: Double, sigma2: Double) = rng.breezeRandomGaussian(mu, sigma2)
+
+  @deprecated("directly use breezeRandBasis and breeze.stats.distributions.Uniform", "since v0.15")
+  def breezeRandomUnform(a: Double, b: Double) = rng.breezeRandomUniform(a, b)
+}
+
 object Random {
 
-  implicit val randomGenerator = Random(System.nanoTime())
+  def apply(seed: Long) = new Random()(RandomNumberGenerator(seed))
+
+  object implicits {
+    implicit val randomGenerator = new Random()(RandomNumberGenerator(System.currentTimeMillis()))
+  }
 
 }
+

--- a/src/main/scala/scalismo/utils/Random.scala
+++ b/src/main/scala/scalismo/utils/Random.scala
@@ -31,7 +31,7 @@ import org.apache.commons.math3.random.MersenneTwister
 
 private[utils] case class RandomNumberGenerator(seed: Long) {
 
-  implicit val breezeRandBasis: RandBasis = new RandBasis(new ThreadLocalRandomGenerator(new MersenneTwister(seed)))
+  implicit val breezeRandBasis: RandBasis = RandBasis.withSeed(seed.toInt)
 
   val scalaRandom: scala.util.Random = new scala.util.Random(seed)
 
@@ -47,7 +47,7 @@ private[utils] case class RandomNumberGenerator(seed: Long) {
 
 }
 
-@scala.annotation.implicitNotFound("missing implicit Random\nTo fix the missing implicit either use:\n\timport scalismo.utils.Random.implicitis._\n...or create a seeded random object:\n\timport scalismo.utils.Random\n\timplicit val rng = Random(1024L)")
+@scala.annotation.implicitNotFound("missing implicit Random\nTo fix the missing implicit either use:\n\timport scalismo.utils.Random.implicits._\n...or create a seeded random object:\n\timport scalismo.utils.Random\n\timplicit val rng = Random(1024L)")
 class Random()(implicit val rng: RandomNumberGenerator) {
 
   def scalaRandom = rng.scalaRandom
@@ -66,7 +66,7 @@ object Random {
   def apply(seed: Long) = new Random()(RandomNumberGenerator(seed))
 
   object implicits {
-    implicit val randomGenerator = new Random()(RandomNumberGenerator(System.currentTimeMillis()))
+    implicit val randomGenerator = new Random()(RandomNumberGenerator(System.nanoTime()))
   }
 
 }

--- a/src/main/scala/scalismo/utils/VantagePointTree.scala
+++ b/src/main/scala/scalismo/utils/VantagePointTree.scala
@@ -125,7 +125,7 @@ private class CandidatesEpsRegion[A](override val maxDistance: Double) extends C
 
 object VantagePointTree {
   /** build a Vantage Point tree with given metric (must be a metric!), uses random pivot elements */
-  def apply[A](data: Iterable[A], metric: Metric[A]): VantagePointTree[A] = recursiveTreeBuilder(data, metric, randomPivotSelector[A])
+  def apply[A](data: Iterable[A], metric: Metric[A])(implicit rng: Random): VantagePointTree[A] = recursiveTreeBuilder(data, metric, randomPivotSelector[A])
 
   /** build a Vantage Point tree with given metric (must be a metric!) and pivot selector */
   def apply[A](data: Iterable[A], metric: Metric[A], pivotSelector: Iterable[A] => A): VantagePointTree[A] = recursiveTreeBuilder(data, metric, pivotSelector)

--- a/src/test/scala/scalismo/geometry/GeometryTests.scala
+++ b/src/test/scala/scalismo/geometry/GeometryTests.scala
@@ -25,7 +25,7 @@ import scala.language.implicitConversions
 
 class GeometryTests extends ScalismoTestSuite {
 
-  implicit val random = Random(42)
+  implicit val random = Random(42L)
 
   val p = Point(0.1, 3.0, 1.1)
   val pGeneric: Point[_3D] = p

--- a/src/test/scala/scalismo/io/ActiveShapeModelIOTests.scala
+++ b/src/test/scala/scalismo/io/ActiveShapeModelIOTests.scala
@@ -22,10 +22,12 @@ import scalismo.ScalismoTestSuite
 import scalismo.numerics.FixedPointsUniformMeshSampler3D
 import scalismo.statisticalmodel.MultivariateNormalDistribution
 import scalismo.statisticalmodel.asm._
+import scalismo.utils.Random
 
 import scala.collection.immutable
 
 class ActiveShapeModelIOTests extends ScalismoTestSuite {
+  implicit val rng = Random(42L)
 
   private def createTmpH5File(): File = {
     val f = File.createTempFile("hdf5file", ".h5")

--- a/src/test/scala/scalismo/kernels/KernelTests.scala
+++ b/src/test/scala/scalismo/kernels/KernelTests.scala
@@ -26,6 +26,8 @@ import scalismo.{ ScalismoTestSuite, geometry }
 
 class KernelTests extends ScalismoTestSuite {
 
+  implicit val rng = Random(42L)
+
   describe("a Kernel") {
     it("yields correct multiple when  multiplied by a scalar") {
       val gk = GaussianKernel[_1D](3.5)
@@ -57,8 +59,6 @@ class KernelTests extends ScalismoTestSuite {
 
   describe("A sample covariance kernel") {
     it("can reproduce the covariance function from random samples") {
-
-      implicit val rand = Random(42)
 
       val domain = BoxDomain(Point(-5, 1, 3), Point(100, 90, 25))
 

--- a/src/test/scala/scalismo/mesh/MeshMetricsTests.scala
+++ b/src/test/scala/scalismo/mesh/MeshMetricsTests.scala
@@ -21,8 +21,11 @@ import scalismo.ScalismoTestSuite
 import scalismo.common.PointId
 import scalismo.geometry.{ Point, Vector, _3D }
 import scalismo.io.MeshIO
+import scalismo.utils.Random
 
 class MeshMetricsTests extends ScalismoTestSuite {
+
+  implicit val rng = Random(42L)
 
   val path = getClass.getResource("/facemesh.stl").getPath
   val mesh = MeshIO.readMesh(new File(path)).get
@@ -74,7 +77,6 @@ class MeshMetricsTests extends ScalismoTestSuite {
 
     it("computes the right value for a unit sphere that completely overlaps itself") {
       MeshMetrics.diceCoefficient(spheremesh, spheremesh) should be(1)
-
     }
 
     it("computes the right value for a unit sphere that is shrunk by 0.5 ") {

--- a/src/test/scala/scalismo/numerics/IntegrationTest.scala
+++ b/src/test/scala/scalismo/numerics/IntegrationTest.scala
@@ -20,10 +20,13 @@ import scalismo.common.BoxDomain
 import scalismo.geometry.Point.implicits._
 import scalismo.geometry._
 import scalismo.image.{ DifferentiableScalarImage, DiscreteImageDomain, ScalarImage }
+import scalismo.utils.Random
 
 import scala.language.implicitConversions
 
 class IntegrationTest extends ScalismoTestSuite {
+
+  implicit val rng = Random(42L)
 
   implicit def doubleToFloat(d: Double): Float = d.toFloat
 

--- a/src/test/scala/scalismo/numerics/PivotedCholeskyTest.scala
+++ b/src/test/scala/scalismo/numerics/PivotedCholeskyTest.scala
@@ -21,8 +21,11 @@ import scalismo.ScalismoTestSuite
 import scalismo.common.BoxDomain3D
 import scalismo.geometry.{ Point, Vector, _1D, _3D }
 import scalismo.kernels.{ DiagonalKernel, GaussianKernel, Kernel }
+import scalismo.utils.Random
 
 class PivotedCholeskyTest extends ScalismoTestSuite {
+
+  implicit val rng = Random(42L)
 
   describe("The Pivoted Cholesky ") {
 

--- a/src/test/scala/scalismo/numerics/RandomSVDTest.scala
+++ b/src/test/scala/scalismo/numerics/RandomSVDTest.scala
@@ -19,9 +19,12 @@ import breeze.linalg.DenseMatrix
 import breeze.linalg.svd.SVD
 import scalismo.ScalismoTestSuite
 import scalismo.geometry.{ Point, _1D }
-import scalismo.kernels.{ GaussianKernel, Kernel, DiagonalKernel }
+import scalismo.kernels.{ DiagonalKernel, GaussianKernel, Kernel }
+import scalismo.utils.Random
 
 class RandomSVDTest extends ScalismoTestSuite {
+
+  implicit val rng = Random(42L)
 
   describe("The random svd") {
 

--- a/src/test/scala/scalismo/registration/KernelTransformationTests.scala
+++ b/src/test/scala/scalismo/registration/KernelTransformationTests.scala
@@ -25,10 +25,13 @@ import scalismo.image.{ DifferentiableScalarImage, DiscreteImageDomain }
 import scalismo.kernels.{ DiagonalKernel, GaussianKernel, Kernel }
 import scalismo.numerics.{ GridSampler, Integrator, RandomSVD, UniformSampler }
 import scalismo.statisticalmodel.LowRankGaussianProcess.Eigenpair
+import scalismo.utils.Random
 
 import scala.language.implicitConversions
 
 class KernelTransformationTests extends ScalismoTestSuite {
+
+  implicit val rng = Random(42L)
 
   implicit def doubleToFloat(d: Double): Float = d.toFloat
 

--- a/src/test/scala/scalismo/registration/MetricTests.scala
+++ b/src/test/scala/scalismo/registration/MetricTests.scala
@@ -21,8 +21,11 @@ import scalismo.geometry.Point.implicits._
 import scalismo.geometry._
 import scalismo.image.DifferentiableScalarImage
 import scalismo.numerics.UniformSampler
+import scalismo.utils.Random
 
 class MetricTests extends ScalismoTestSuite {
+
+  implicit val rng = Random(42L)
 
   describe("A mean squares metric (1D)") {
     it("returns 0 if provided twice the same image") {

--- a/src/test/scala/scalismo/statisticalmodel/dataset/DataCollectionTests.scala
+++ b/src/test/scala/scalismo/statisticalmodel/dataset/DataCollectionTests.scala
@@ -30,9 +30,9 @@ import scalismo.utils.{ Benchmark, Memoize, Random }
 
 class DataCollectionTests extends ScalismoTestSuite {
 
-  describe("A datacollection") {
+  implicit val rng = Random(42L)
 
-    implicit val random = Random(42)
+  describe("A datacollection") {
 
     val transformations = for (i <- 0 until 10) yield TranslationTransform(Vector(i.toDouble, 0.0, 0.0))
     val dataItems = for ((t, i) <- transformations.zipWithIndex) yield DataItem(s"transformation-$i", t)
@@ -164,8 +164,6 @@ class DataCollectionTests extends ScalismoTestSuite {
   }
 
   describe("Generalization") {
-
-    implicit val random = Random(42)
 
     val zeroMean = Field(Fixture.dc.reference.boundingBox, (pt: Point[_3D]) => Vector(0, 0, 0))
     val matrixValuedGaussian = DiagonalKernel(GaussianKernel[_3D](25) * 20, 3)

--- a/src/test/scala/scalismo/utils/RandomTests.scala
+++ b/src/test/scala/scalismo/utils/RandomTests.scala
@@ -34,9 +34,10 @@ class RandomTests extends ScalismoTestSuite {
 
     }
 
-    it("should yield a random sequence when no implicit is defined") {
+    it("should yield a random sequence when the predefined implicit is imported") {
 
       def randomNumbersNotSeeded() = {
+        import scalismo.utils.Random.implicits._
         val r = implicitly[Random]
         val standardNormal = Gaussian(0, 1)(r.breezeRandBasis)
         val uniform = Uniform(0, 1)(r.breezeRandBasis)


### PR DESCRIPTION
Having an implicit val in the companion object of `scalismo.utils.Random` prevented the compiler from helping the developers. The compiler did not complained about a missing implicit. This resulted in hardly traceable bugs where seeding the random number generator did not lead to reproducible results.

Existing code can be adapted in three ways to use the new `Random` class:

- You have to do nothing if you defined an implicit val with a seeded `Random` object in your application.
- You have to import `scalismo.utils.Random.implicits._` if you want a random number generator that is seeded with the current time in milliseconds. This corresponds to the behavior of specifying nothing using the old version.
- If your code is a library you have to extend your function with an implicit `Random` parameter. (Or, what we do not recommend, use one of the above two options in order to define an implicit.)

Remark: The additional class `Random` and the renamed class `RandomNumberGenerator` allows us to have at a single location the verbose error message about the missing implicit object.