### PR TITLE
Discrete field with domaintype

### DIFF
--- a/src/main/scala/scalismo/image/DiscreteImage.scala
+++ b/src/main/scala/scalismo/image/DiscreteImage.scala
@@ -24,7 +24,8 @@ import scalismo.geometry._
  * @tparam D  The dimensionality of the image
  * @tparam A The type of the pixel (usually a scalar or a vector)
  */
-class DiscreteImage[D <: Dim: NDSpace, A](domain: DiscreteImageDomain[D], values: IndexedSeq[A]) extends DiscreteField[D, A](domain, values) {
+class DiscreteImage[D <: Dim: NDSpace, A](domain: DiscreteImageDomain[D], values: IndexedSeq[A])
+    extends DiscreteField[D, DiscreteImageDomain[D], A](domain, values) {
 
   protected[this] def ndSpace: NDSpace[D] = NDSpace[D]
 

--- a/src/main/scala/scalismo/image/DiscreteScalarImage.scala
+++ b/src/main/scala/scalismo/image/DiscreteScalarImage.scala
@@ -47,7 +47,7 @@ abstract class DiscreteScalarImage[D <: Dim: NDSpace: Create, A: Scalar: ClassTa
   /** Returns a new ContinuousScalarImage by interpolating the given DiscreteScalarImage using b-spline interpolation of given order */
   def interpolate(order: Int): DifferentiableScalarImage[D]
 
-  /** Returns a continuous scalar field. If you want a nearest neighbor interpolation that returns a [[ScalarImage]], use [[interpolateGeneric(0)]] instead*/
+  /** Returns a continuous scalar field. If you want a nearest neighbor interpolation that returns a [[ScalarImage]], use [[interpolate(0)]] instead*/
   override def interpolateNearestNeighbor(): ScalarField[D, A] = {
     val ev = implicitly[Scalar[A]]
     ScalarField(RealSpace[D], this.interpolate(0) andThen ev.fromFloat _)

--- a/src/main/scala/scalismo/image/DiscreteScalarImage.scala
+++ b/src/main/scala/scalismo/image/DiscreteScalarImage.scala
@@ -47,7 +47,7 @@ abstract class DiscreteScalarImage[D <: Dim: NDSpace: Create, A: Scalar: ClassTa
   /** Returns a new ContinuousScalarImage by interpolating the given DiscreteScalarImage using b-spline interpolation of given order */
   def interpolate(order: Int): DifferentiableScalarImage[D]
 
-  /** Returns a continuous scalar field. If you want a nearest neighbor interpolation that returns a [[ScalarImage]], use [[interpolate(0)]] instead*/
+  /** Returns a continuous scalar field. If you want a nearest neighbor interpolation that returns a [[ScalarImage]], use [[interpolateGeneric(0)]] instead*/
   override def interpolateNearestNeighbor(): ScalarField[D, A] = {
     val ev = implicitly[Scalar[A]]
     ScalarField(RealSpace[D], this.interpolate(0) andThen ev.fromFloat _)

--- a/src/main/scala/scalismo/mesh/ScalarMeshField.scala
+++ b/src/main/scala/scalismo/mesh/ScalarMeshField.scala
@@ -15,7 +15,7 @@
  */
 package scalismo.mesh
 
-import scalismo.common.{ DiscreteScalarField, PointId, Scalar, ScalarArray }
+import scalismo.common._
 import scalismo.geometry._3D
 
 import scala.reflect.ClassTag
@@ -27,7 +27,8 @@ import scala.reflect.ClassTag
  * @constructor Returns a scalar mesh data given a triangle mesh and an array of values.
  * The number of values and mesh points must be equal.
  */
-case class ScalarMeshField[S: Scalar: ClassTag](mesh: TriangleMesh[_3D], override val data: ScalarArray[S]) extends DiscreteScalarField[_3D, S](mesh.pointSet, data) {
+case class ScalarMeshField[S: Scalar: ClassTag](mesh: TriangleMesh[_3D], override val data: ScalarArray[S])
+    extends DiscreteScalarField[_3D, UnstructuredPointsDomain[_3D], S](mesh.pointSet, data) {
   require(mesh.pointSet.numberOfPoints == data.size)
 
   override def values = data.iterator

--- a/src/main/scala/scalismo/statisticalmodel/DiscreteGaussianProcess.scala
+++ b/src/main/scala/scalismo/statisticalmodel/DiscreteGaussianProcess.scala
@@ -27,7 +27,7 @@ import scalismo.utils.Random
  * While this is technically similar to a MultivariateNormalDistribution, we highlight with this
  * class that we represent (discrete) functions, defined on the given domain.
  */
-class DiscreteGaussianProcess[D <: Dim: NDSpace, Value] private[scalismo] (val mean: DiscreteField[D, Value],
+class DiscreteGaussianProcess[D <: Dim: NDSpace, DDomain <: DiscreteDomain[D], Value] private[scalismo] (val mean: DiscreteField[D, DDomain, Value],
     val cov: DiscreteMatrixValuedPDKernel[D])(implicit val vectorizer: Vectorizer[Value]) {
   self =>
 
@@ -37,7 +37,7 @@ class DiscreteGaussianProcess[D <: Dim: NDSpace, Value] private[scalismo] (val m
 
   val outputDim = vectorizer.dim
 
-  def sample()(implicit rand: Random): DiscreteField[D, Value] = {
+  def sample()(implicit rand: Random): DiscreteField[D, DDomain, Value] = {
     // define the mean and kernel matrix for the given points and construct the
     // corresponding MV Normal distribution, from which we then sample
 
@@ -49,7 +49,7 @@ class DiscreteGaussianProcess[D <: Dim: NDSpace, Value] private[scalismo] (val m
     val sampleVec = mvNormal.sample
 
     // The sample is a vector. We convert it back to a discreteVectorField.
-    DiscreteField.createFromDenseVector[D, Value](domain, sampleVec)
+    DiscreteField.createFromDenseVector[D, DDomain, Value](domain, sampleVec)
   }
 
   /**
@@ -63,13 +63,13 @@ class DiscreteGaussianProcess[D <: Dim: NDSpace, Value] private[scalismo] (val m
    * The marginal distribution for the points specified by the given point ids.
    * Note that this is again a DiscreteGaussianProcess.
    */
-  def marginal(pointIds: Seq[PointId])(implicit domainCreator: UnstructuredPointsDomain.Create[D]): DiscreteGaussianProcess[D, Value] = {
+  def marginal(pointIds: Seq[PointId])(implicit domainCreator: UnstructuredPointsDomain.Create[D]): DiscreteGaussianProcess[D, UnstructuredPointsDomain[D], Value] = {
     val domainPts = domain.points.toIndexedSeq
 
     val newPts = pointIds.map(pointId => domainPts(pointId.id)).toIndexedSeq
     val newDomain = domainCreator.create(newPts)
 
-    val newMean = DiscreteField[D, Value](newDomain, pointIds.toIndexedSeq.map(id => mean(id)))
+    val newMean = DiscreteField[D, UnstructuredPointsDomain[D], Value](newDomain, pointIds.toIndexedSeq.map(id => mean(id)))
     val newCov = (i: PointId, j: PointId) => {
       cov(pointIds(i.id), pointIds(j.id))
     }
@@ -112,7 +112,7 @@ class DiscreteGaussianProcess[D <: Dim: NDSpace, Value] private[scalismo] (val m
    * Discrete version of [[LowRankGaussianProcess.project(IndexedSeq[(Point[D], Vector[DO])], Double)]]
    */
 
-  def project(s: DiscreteField[D, Value]): DiscreteField[D, Value] = {
+  def project(s: DiscreteField[D, DDomain, Value]): DiscreteField[D, DDomain, Value] = {
 
     val sigma2 = 1e-5 // regularization weight to avoid numerical problems
     val noiseDist = MultivariateNormalDistribution(DenseVector.zeros[Double](outputDim), DenseMatrix.eye[Double](outputDim) * sigma2)
@@ -124,7 +124,7 @@ class DiscreteGaussianProcess[D <: Dim: NDSpace, Value] private[scalismo] (val m
   /**
    * Returns the probability density of the given instance
    */
-  def pdf(instance: DiscreteField[D, Value]): Double = {
+  def pdf(instance: DiscreteField[D, DDomain, Value]): Double = {
     val mvnormal = MultivariateNormalDistribution(DiscreteField.vectorize[D, Value](mean.data), cov.asBreezeMatrix)
     val instvec = DiscreteField.vectorize[D, Value](instance.data)
     mvnormal.pdf(instvec)
@@ -135,7 +135,7 @@ class DiscreteGaussianProcess[D <: Dim: NDSpace, Value] private[scalismo] (val m
    *
    * If you are interested in ordinal comparisons of PDFs, use this as it is numerically more stable
    */
-  def logpdf(instance: DiscreteField[D, Value]): Double = {
+  def logpdf(instance: DiscreteField[D, DDomain, Value]): Double = {
     val mvnormal = MultivariateNormalDistribution(DiscreteField.vectorize[D, Value](mean.data), cov.asBreezeMatrix)
     val instvec = DiscreteField.vectorize[D, Value](instance.data)
     mvnormal.logpdf(instvec)
@@ -145,22 +145,22 @@ class DiscreteGaussianProcess[D <: Dim: NDSpace, Value] private[scalismo] (val m
 
 object DiscreteGaussianProcess {
 
-  def apply[D <: Dim: NDSpace, Value](mean: DiscreteField[D, Value], cov: DiscreteMatrixValuedPDKernel[D])(implicit vectorizer: Vectorizer[Value]): DiscreteGaussianProcess[D, Value] = {
-    new DiscreteGaussianProcess[D, Value](mean, cov)
+  def apply[D <: Dim: NDSpace, DDomain <: DiscreteDomain[D], Value](mean: DiscreteField[D, DDomain, Value], cov: DiscreteMatrixValuedPDKernel[D])(implicit vectorizer: Vectorizer[Value]): DiscreteGaussianProcess[D, DDomain, Value] = {
+    new DiscreteGaussianProcess[D, DDomain, Value](mean, cov)
   }
 
-  def apply[D <: Dim: NDSpace, Value](domain: DiscreteDomain[D], gp: GaussianProcess[D, Value])(implicit vectorizer: Vectorizer[Value]): DiscreteGaussianProcess[D, Value] = {
+  def apply[D <: Dim: NDSpace, DDomain <: DiscreteDomain[D], Value](domain: DDomain, gp: GaussianProcess[D, Value])(implicit vectorizer: Vectorizer[Value]): DiscreteGaussianProcess[D, DDomain, Value] = {
     val domainPoints = domain.points.toIndexedSeq
 
-    val discreteMean = DiscreteField(domain, domainPoints.map(pt => gp.mean(pt)))
+    val discreteMean = DiscreteField[D, DDomain, Value](domain, domainPoints.map(pt => gp.mean(pt)))
 
     val k = (i: PointId, j: PointId) => gp.cov(domainPoints(i.id), domainPoints(j.id))
     val discreteCov = DiscreteMatrixValuedPDKernel(domain, k, gp.outputDim)
 
-    new DiscreteGaussianProcess[D, Value](discreteMean, discreteCov)
+    new DiscreteGaussianProcess[D, DDomain, Value](discreteMean, discreteCov)
   }
 
-  def regression[D <: Dim: NDSpace, Value](discreteGp: DiscreteGaussianProcess[D, Value], trainingData: IndexedSeq[(Int, Value, MultivariateNormalDistribution)])(implicit vectorizer: Vectorizer[Value]): DiscreteGaussianProcess[D, Value] = {
+  def regression[D <: Dim: NDSpace, DDomain <: DiscreteDomain[D], Value](discreteGp: DiscreteGaussianProcess[D, DDomain, Value], trainingData: IndexedSeq[(Int, Value, MultivariateNormalDistribution)])(implicit vectorizer: Vectorizer[Value]): DiscreteGaussianProcess[D, DDomain, Value] = {
 
     // TODO, this is somehow a hack to reuse the code written for the general GP regression. We should think if that has disadvantages
     // TODO We should think whether we can do it in  a conceptually more clean way.

--- a/src/main/scala/scalismo/statisticalmodel/GaussianProcess.scala
+++ b/src/main/scala/scalismo/statisticalmodel/GaussianProcess.scala
@@ -40,7 +40,7 @@ class GaussianProcess[D <: Dim: NDSpace, Value] protected (val mean: Field[D, Va
    *
    * Sample values of the Gaussian process evaluated at the given points.
    */
-  def sampleAtPoints(domain: DiscreteDomain[D])(implicit rand: Random): DiscreteField[D, Value] = {
+  def sampleAtPoints[DDomain <: DiscreteDomain[D]](domain: DDomain)(implicit rand: Random): DiscreteField[D, DDomain, Value] = {
     this.marginal(domain).sample()
   }
 
@@ -48,8 +48,8 @@ class GaussianProcess[D <: Dim: NDSpace, Value] protected (val mean: Field[D, Va
    * Compute the marginal distribution for the given points. The result is again a Gaussian process, whose domain
    * is defined by the given points.
    */
-  def marginal(domain: DiscreteDomain[D]): DiscreteGaussianProcess[D, Value] = {
-    val meanField = DiscreteField(domain, domain.points.toIndexedSeq.map(pt => mean(pt)))
+  def marginal[DDomain <: DiscreteDomain[D]](domain: DDomain): DiscreteGaussianProcess[D, DDomain, Value] = {
+    val meanField = DiscreteField[D, DDomain, Value](domain, domain.points.toIndexedSeq.map(pt => mean(pt)))
     val pts = domain.points.toIndexedSeq
     def newCov(i: PointId, j: PointId): DenseMatrix[Double] = {
       cov(pts(i.id), pts(j.id))

--- a/src/main/scala/scalismo/statisticalmodel/LowRankGaussianProcess.scala
+++ b/src/main/scala/scalismo/statisticalmodel/LowRankGaussianProcess.scala
@@ -76,11 +76,11 @@ class LowRankGaussianProcess[D <: Dim: NDSpace, Value](mean: Field[D, Value],
   /**
    * A random sample evaluated at the given points
    */
-  override def sampleAtPoints(domain: DiscreteDomain[D])(implicit rand: Random): DiscreteField[D, Value] = {
+  override def sampleAtPoints[DDomain <: DiscreteDomain[D]](domain: DDomain)(implicit rand: Random): DiscreteField[D, DDomain, Value] = {
     // TODO check that points are part of the domain
     val aSample = sample()
     val values = domain.points.map(pt => aSample(pt))
-    DiscreteField(domain, values.toIndexedSeq)
+    DiscreteField[D, DDomain, Value](domain, values.toIndexedSeq)
   }
 
   /**
@@ -169,8 +169,8 @@ class LowRankGaussianProcess[D <: Dim: NDSpace, Value](mean: Field[D, Value],
   /**
    * Discretize the gaussian process on the given points.
    */
-  def discretize(domain: DiscreteDomain[D]): DiscreteLowRankGaussianProcess[D, Value] = {
-    DiscreteLowRankGaussianProcess(domain, this)
+  def discretize[DDomain <: DiscreteDomain[D]](domain: DDomain): DiscreteLowRankGaussianProcess[D, DDomain, Value] = {
+    DiscreteLowRankGaussianProcess[D, DDomain, Value](domain, this)
   }
 
 }

--- a/src/main/scala/scalismo/statisticalmodel/StatisticalMeshModel.scala
+++ b/src/main/scala/scalismo/statisticalmodel/StatisticalMeshModel.scala
@@ -37,7 +37,7 @@ import scala.util.{ Failure, Success, Try }
  *
  * @see [[DiscreteLowRankGaussianProcess]]
  */
-case class StatisticalMeshModel private (referenceMesh: TriangleMesh[_3D], gp: DiscreteLowRankGaussianProcess[_3D, Vector[_3D]]) {
+case class StatisticalMeshModel private (referenceMesh: TriangleMesh[_3D], gp: DiscreteLowRankGaussianProcess[_3D, UnstructuredPointsDomain[_3D], Vector[_3D]]) {
 
   /** @see [[scalismo.statisticalmodel.DiscreteLowRankGaussianProcess.rank]] */
   val rank = gp.rank
@@ -117,7 +117,7 @@ case class StatisticalMeshModel private (referenceMesh: TriangleMesh[_3D], gp: D
    */
   def project(mesh: TriangleMesh[_3D]) = {
     val displacements = referenceMesh.pointSet.points.zip(mesh.pointSet.points).map({ case (refPt, tgtPt) => tgtPt - refPt }).toIndexedSeq
-    val dvf = DiscreteField(referenceMesh.pointSet, displacements)
+    val dvf = DiscreteField[_3D, UnstructuredPointsDomain[_3D], Vector[_3D]](referenceMesh.pointSet, displacements)
     warpReference(gp.project(dvf))
   }
 
@@ -126,7 +126,7 @@ case class StatisticalMeshModel private (referenceMesh: TriangleMesh[_3D], gp: D
    */
   def coefficients(mesh: TriangleMesh[_3D]): DenseVector[Double] = {
     val displacements = referenceMesh.pointSet.points.zip(mesh.pointSet.points).map({ case (refPt, tgtPt) => tgtPt - refPt }).toIndexedSeq
-    val dvf = DiscreteField(referenceMesh.pointSet, displacements)
+    val dvf = DiscreteField[_3D, UnstructuredPointsDomain[_3D], Vector[_3D]](referenceMesh.pointSet, displacements)
     gp.coefficients(dvf)
   }
 
@@ -172,7 +172,7 @@ case class StatisticalMeshModel private (referenceMesh: TriangleMesh[_3D], gp: D
       val data = newIthBasis.map(_.toArray).flatten.toArray
       newBasisMat(::, i) := DenseVector(data)
     }
-    val newGp = new DiscreteLowRankGaussianProcess[_3D, Vector[_3D]](gp.domain.transform(rigidTransform), newMean, gp.variance, newBasisMat)
+    val newGp = new DiscreteLowRankGaussianProcess[_3D, UnstructuredPointsDomain[_3D], Vector[_3D]](gp.domain.transform(rigidTransform), newMean, gp.variance, newBasisMat)
 
     new StatisticalMeshModel(newRef, newGp)
 
@@ -186,11 +186,11 @@ case class StatisticalMeshModel private (referenceMesh: TriangleMesh[_3D], gp: D
     val newRef = referenceMesh.pointSet.transform(t)
     val newMean = gp.mean.pointsWithValues.map { case (refPt, meanVec) => (refPt - t(refPt)) + meanVec }
     val newMeanVec = DenseVector(newMean.map(_.toArray).flatten.toArray)
-    val newGp = new DiscreteLowRankGaussianProcess[_3D, Vector[_3D]](newRef, newMeanVec, gp.variance, gp.basisMatrix)
+    val newGp = new DiscreteLowRankGaussianProcess[_3D, UnstructuredPointsDomain[_3D], Vector[_3D]](newRef, newMeanVec, gp.variance, gp.basisMatrix)
     new StatisticalMeshModel(TriangleMesh3D(newRef, referenceMesh.triangulation), newGp)
   }
 
-  private def warpReference(vectorPointData: DiscreteField[_3D, Vector[_3D]]) = {
+  private def warpReference(vectorPointData: DiscreteField[_3D, UnstructuredPointsDomain[_3D], Vector[_3D]]) = {
     val newPoints = vectorPointData.pointsWithValues.map { case (pt, v) => pt + v }
     TriangleMesh3D(UnstructuredPointsDomain(newPoints.toIndexedSeq), referenceMesh.triangulation)
   }
@@ -216,7 +216,7 @@ object StatisticalMeshModel {
     meanVector: DenseVector[Double],
     variance: DenseVector[Double],
     basisMatrix: DenseMatrix[Double]) = {
-    val gp = new DiscreteLowRankGaussianProcess[_3D, Vector[_3D]](referenceMesh.pointSet, meanVector, variance, basisMatrix)
+    val gp = new DiscreteLowRankGaussianProcess[_3D, UnstructuredPointsDomain[_3D], Vector[_3D]](referenceMesh.pointSet, meanVector, variance, basisMatrix)
     new StatisticalMeshModel(referenceMesh, gp)
   }
 
@@ -225,7 +225,7 @@ object StatisticalMeshModel {
    *
    */
   def createUsingPCA(referenceMesh: TriangleMesh[_3D], fields: Seq[Field[_3D, Vector[_3D]]]): StatisticalMeshModel = {
-    val dgp: DiscreteLowRankGaussianProcess[_3D, Vector[_3D]] = DiscreteLowRankGaussianProcess.createUsingPCA(referenceMesh.pointSet, fields)
+    val dgp: DiscreteLowRankGaussianProcess[_3D, UnstructuredPointsDomain[_3D], Vector[_3D]] = DiscreteLowRankGaussianProcess.createUsingPCA(referenceMesh.pointSet, fields)
     new StatisticalMeshModel(referenceMesh, dgp)
   }
 
@@ -273,7 +273,7 @@ object StatisticalMeshModel {
       U(::, i) := U(::, i) * (1.0 / d(i))
     }
 
-    val r = model.gp.copy[_3D, Vector[_3D]](meanVector = model.gp.meanVector + discretizedBiasModel.meanVector, variance = breeze.numerics.pow(d, 2), basisMatrix = U)
+    val r = model.gp.copy[_3D, UnstructuredPointsDomain[_3D], Vector[_3D]](meanVector = model.gp.meanVector + discretizedBiasModel.meanVector, variance = breeze.numerics.pow(d, 2), basisMatrix = U)
     StatisticalMeshModel(model.referenceMesh, r)
   }
 

--- a/src/main/scala/scalismo/statisticalmodel/asm/ActiveShapeModel.scala
+++ b/src/main/scala/scalismo/statisticalmodel/asm/ActiveShapeModel.scala
@@ -16,7 +16,7 @@
 package scalismo.statisticalmodel.asm
 
 import breeze.linalg.{ DenseVector, convert }
-import scalismo.common.{ UnstructuredPointsDomain3D, PointId }
+import scalismo.common.{ PointId, UnstructuredPointsDomain, UnstructuredPointsDomain3D }
 import scalismo.geometry.{ Point, _3D }
 import scalismo.image.DiscreteScalarImage
 import scalismo.mesh.TriangleMesh
@@ -67,7 +67,7 @@ object ActiveShapeModel {
  * the Shape Model, and a set of sample features at the profile points.
  *
  */
-case class ASMSample(mesh: TriangleMesh[_3D], featureField: DiscreteFeatureField[_3D], featureExtractor: FeatureExtractor)
+case class ASMSample(mesh: TriangleMesh[_3D], featureField: DiscreteFeatureField[_3D, UnstructuredPointsDomain[_3D]], featureExtractor: FeatureExtractor)
 
 case class ActiveShapeModel(statisticalModel: StatisticalMeshModel, profiles: Profiles, preprocessor: ImagePreprocessor, featureExtractor: FeatureExtractor) {
 
@@ -78,7 +78,7 @@ case class ActiveShapeModel(statisticalModel: StatisticalMeshModel, profiles: Pr
     val smean = statisticalModel.mean
     val meanProfilePoints = profiles.data.map(p => smean.pointSet.point(p.pointId))
     val meanFeatures = profiles.data.map(_.distribution.mean)
-    val featureField = DiscreteFeatureField(new UnstructuredPointsDomain3D(meanProfilePoints), meanFeatures)
+    val featureField = DiscreteFeatureField[_3D, UnstructuredPointsDomain[_3D]](new UnstructuredPointsDomain3D(meanProfilePoints), meanFeatures)
     ASMSample(smean, featureField, featureExtractor)
   }
 
@@ -89,7 +89,7 @@ case class ActiveShapeModel(statisticalModel: StatisticalMeshModel, profiles: Pr
     val sampleMesh = statisticalModel.sample()
     val randomProfilePoints = profiles.data.map(p => sampleMesh.pointSet.point(p.pointId))
     val randomFeatures = profiles.data.map(_.distribution.sample)
-    val featureField = DiscreteFeatureField(new UnstructuredPointsDomain3D(randomProfilePoints), randomFeatures)
+    val featureField = DiscreteFeatureField[_3D, UnstructuredPointsDomain[_3D]](new UnstructuredPointsDomain3D(randomProfilePoints), randomFeatures)
     ASMSample(sampleMesh, featureField, featureExtractor)
   }
 
@@ -101,7 +101,7 @@ case class ActiveShapeModel(statisticalModel: StatisticalMeshModel, profiles: Pr
     val smean = statisticalModel.mean
     val meanProfilePoints = profiles.data.map(p => smean.pointSet.point(p.pointId))
     val randomFeatures = profiles.data.map(_.distribution.sample)
-    val featureField = DiscreteFeatureField(new UnstructuredPointsDomain3D(meanProfilePoints), randomFeatures)
+    val featureField = DiscreteFeatureField[_3D, UnstructuredPointsDomain[_3D]](new UnstructuredPointsDomain3D(meanProfilePoints), randomFeatures)
     ASMSample(smean, featureField, featureExtractor)
   }
 

--- a/src/main/scala/scalismo/statisticalmodel/asm/Profiles.scala
+++ b/src/main/scala/scalismo/statisticalmodel/asm/Profiles.scala
@@ -42,8 +42,8 @@ case class Profiles(private[scalismo] val data: immutable.IndexedSeq[Profile]) e
  *
  */
 
-class DiscreteFeatureField[D <: Dim: NDSpace](domain: DiscreteDomain[D], _values: IndexedSeq[DenseVector[Double]])
-    extends DiscreteField[D, DenseVector[Double]](domain, _values) {
+class DiscreteFeatureField[D <: Dim: NDSpace, DDomain <: DiscreteDomain[D]](domain: DDomain, _values: IndexedSeq[DenseVector[Double]])
+    extends DiscreteField[D, DDomain, DenseVector[Double]](domain, _values) {
 
   override def apply(id: PointId) = _values(id.id)
 
@@ -58,5 +58,5 @@ class DiscreteFeatureField[D <: Dim: NDSpace](domain: DiscreteDomain[D], _values
 }
 
 object DiscreteFeatureField {
-  def apply[D <: Dim: NDSpace](domain: DiscreteDomain[D], values: IndexedSeq[DenseVector[Double]]) = new DiscreteFeatureField[D](domain, values)
+  def apply[D <: Dim: NDSpace, DDomain <: DiscreteDomain[D]](domain: DDomain, values: IndexedSeq[DenseVector[Double]]) = new DiscreteFeatureField[D, DDomain](domain, values)
 }

--- a/src/test/scala/scalismo/statisticalmodel/GaussianProcessTests.scala
+++ b/src/test/scala/scalismo/statisticalmodel/GaussianProcessTests.scala
@@ -424,7 +424,7 @@ class GaussianProcessTests extends ScalismoTestSuite {
       val dgp2 = dgp1.marginal(Seq(1))
       val dgp3 = f.discreteLowRankGp.marginal(Seq(1))
 
-      DiscreteField.vectorize[_3D, Vector[_3D]](dgp2.mean) should equal(DiscreteField.vectorize[_3D, Vector[_3D]](dgp3.mean))
+      DiscreteField.vectorize[_3D, UnstructuredPointsDomain[_3D], Vector[_3D]](dgp2.mean) should equal(DiscreteField.vectorize[_3D, UnstructuredPointsDomain[_3D], Vector[_3D]](dgp3.mean))
       dgp2.cov.asBreezeMatrix should equal(dgp3.cov.asBreezeMatrix)
       dgp2.domain should equal(dgp3.domain)
     }
@@ -435,7 +435,7 @@ class GaussianProcessTests extends ScalismoTestSuite {
       val domain = UnstructuredPointsDomain(f.discretizationPoints)
       val dgp1 = f.lowRankGp.marginal(domain).marginal(Seq(0, 1, 2))
       val dgp2 = f.discreteLowRankGp.marginal(Seq(0, 1, 2))
-      DiscreteField.vectorize[_3D, Vector[_3D]](dgp1.mean) should equal(DiscreteField.vectorize[_3D, Vector[_3D]](dgp2.mean))
+      DiscreteField.vectorize[_3D, UnstructuredPointsDomain[_3D], Vector[_3D]](dgp1.mean) should equal(DiscreteField.vectorize[_3D, UnstructuredPointsDomain[_3D], Vector[_3D]](dgp2.mean))
       dgp1.cov.asBreezeMatrix should equal(dgp2.cov.asBreezeMatrix)
       dgp1.domain should equal(dgp2.domain)
     }


### PR DESCRIPTION
A DiscreteField is defined using a DiscreteDomain and a set of values, which correspond to the values at the points of the domain. So far the information about the concrete type of the DiscreteDomain was not available
in the DiscreteField. It was only know that it was a subtype of DiscreteField. By introducing the concrete Domain as a type parameter into DiscreteField, i.e. by defining
```
class DiscreteField[D <: Dim, DDomain <: DiscreteDomain[D], A](val domain: DDomain, val data: IndexedSeq[A])
```
we can retain this information. This makes it possible that methods defined on discrete fields can exploit more information about the domain, such as for example that it is defined on a regular grid. A typical example is an interpolation method, which can be much
more efficiently implemented if the underlying domain is an image domain.