### PR TITLE
Moved mesh.interpolator to common.interpolation

### DIFF
--- a/src/main/scala/scalismo/mesh/BarycentricCoordinates.scala
+++ b/src/main/scala/scalismo/mesh/BarycentricCoordinates.scala
@@ -15,8 +15,8 @@
  */
 package scalismo.mesh
 
-import scalismo.common.interpolation.ValueInterpolator
 import scalismo.geometry.{ Point, Vector, _2D, _3D }
+import scalismo.numerics.ValueInterpolator
 import scalismo.utils.Random
 
 import scala.annotation.switch

--- a/src/main/scala/scalismo/mesh/BarycentricCoordinates.scala
+++ b/src/main/scala/scalismo/mesh/BarycentricCoordinates.scala
@@ -15,7 +15,8 @@
  */
 package scalismo.mesh
 
-import scalismo.geometry.{ Point, _2D, _3D, Vector }
+import scalismo.common.interpolation.ValueInterpolator
+import scalismo.geometry.{ Point, Vector, _2D, _3D }
 import scalismo.utils.Random
 
 import scala.annotation.switch
@@ -29,7 +30,7 @@ case class BarycentricCoordinates(a: Double, b: Double, c: Double) {
   }
 
   /** perform bcc interpolation: interpolate vertex values within triangle, needs Interpolation[T] */
-  def interpolateProperty[@specialized(Float, Double) A](v1: A, v2: A, v3: A)(implicit blender: Interpolator[A]): A = {
+  def interpolateProperty[@specialized(Float, Double) A](v1: A, v2: A, v3: A)(implicit blender: ValueInterpolator[A]): A = {
     blender.barycentricInterpolation(v1, a, v2, b, v3, c)
   }
 }

--- a/src/main/scala/scalismo/mesh/LineContourProperty.scala
+++ b/src/main/scala/scalismo/mesh/LineContourProperty.scala
@@ -1,7 +1,7 @@
 package scalismo.mesh
 
 import scalismo.common.PointId
-import scalismo.common.interpolation.ValueInterpolator
+import scalismo.numerics.ValueInterpolator
 
 /**
  * Created by marcel on 15.09.15.

--- a/src/main/scala/scalismo/mesh/LineContourProperty.scala
+++ b/src/main/scala/scalismo/mesh/LineContourProperty.scala
@@ -1,6 +1,7 @@
 package scalismo.mesh
 
 import scalismo.common.PointId
+import scalismo.common.interpolation.ValueInterpolator
 
 /**
  * Created by marcel on 15.09.15.
@@ -29,7 +30,7 @@ case class MappedContourProperty[A, B](values: LineContourProperty[A], f: A => B
   override def onContour(lineId: LineId, bcc: LineCoordinates): B = f(values.onContour(lineId, bcc))
 }
 
-case class ContourPointProperty[A](topology: LineList, pointData: IndexedSeq[A])(implicit val interpolator: Interpolator[A])
+case class ContourPointProperty[A](topology: LineList, pointData: IndexedSeq[A])(implicit val interpolator: ValueInterpolator[A])
     extends LineContourProperty[A] {
 
   require(topology.pointIds.forall(id => pointData.isDefinedAt(id.id)), "Line topology is not compatible with data")
@@ -45,7 +46,7 @@ case class ContourPointProperty[A](topology: LineList, pointData: IndexedSeq[A])
     bcc.interpolateProperty(v1, v2)
   }
 
-  def map[B](f: A => B)(implicit interpolator: Interpolator[B]): ContourPointProperty[B] = {
+  def map[B](f: A => B)(implicit interpolator: ValueInterpolator[B]): ContourPointProperty[B] = {
     val newData = pointData map f
     ContourPointProperty(topology, newData)
   }
@@ -53,7 +54,7 @@ case class ContourPointProperty[A](topology: LineList, pointData: IndexedSeq[A])
 
 object ContourPointProperty {
 
-  def averagedPointProperty[A](linetopology: LineList, property: LineContourProperty[A])(implicit ops: Interpolator[A]): ContourPointProperty[A] = {
+  def averagedPointProperty[A](linetopology: LineList, property: LineContourProperty[A])(implicit ops: ValueInterpolator[A]): ContourPointProperty[A] = {
     def averager(data: IndexedSeq[A]): A = {
       data.size match {
         case 0 => throw new Exception("averaging over empty set")
@@ -64,7 +65,7 @@ object ContourPointProperty {
     sampleContourProperty(linetopology, property, averager)
   }
 
-  def sampleContourProperty[A](lineTopology: LineList, property: LineContourProperty[A], reducer: IndexedSeq[A] => A)(implicit ops: Interpolator[A]): ContourPointProperty[A] = {
+  def sampleContourProperty[A](lineTopology: LineList, property: LineContourProperty[A], reducer: IndexedSeq[A] => A)(implicit ops: ValueInterpolator[A]): ContourPointProperty[A] = {
 
     // get all data for a single vertex:
     def getVertex(pointId: PointId): A = {

--- a/src/main/scala/scalismo/mesh/LineCoordinates.scala
+++ b/src/main/scala/scalismo/mesh/LineCoordinates.scala
@@ -16,10 +16,12 @@
 
 package scalismo.mesh
 
+import scalismo.common.interpolation.ValueInterpolator
+
 case class LineCoordinates(a: Double) {
 
   /** perform bcc interpolation: interpolate vertex values within line, needs Interpolation[T] */
-  def interpolateProperty[A](v1: A, v2: A)(implicit blender: Interpolator[A]): A = {
+  def interpolateProperty[A](v1: A, v2: A)(implicit blender: ValueInterpolator[A]): A = {
     blender.blend(v1, v2, a)
   }
 

--- a/src/main/scala/scalismo/mesh/LineCoordinates.scala
+++ b/src/main/scala/scalismo/mesh/LineCoordinates.scala
@@ -16,7 +16,7 @@
 
 package scalismo.mesh
 
-import scalismo.common.interpolation.ValueInterpolator
+import scalismo.numerics.ValueInterpolator
 
 case class LineCoordinates(a: Double) {
 

--- a/src/main/scala/scalismo/mesh/MeshSurfaceProperty.scala
+++ b/src/main/scala/scalismo/mesh/MeshSurfaceProperty.scala
@@ -16,7 +16,7 @@
 package scalismo.mesh
 
 import scalismo.common.PointId
-import scalismo.common.interpolation.ValueInterpolator
+import scalismo.numerics.ValueInterpolator
 
 import scala.reflect.ClassTag
 

--- a/src/main/scala/scalismo/mesh/MeshSurfaceProperty.scala
+++ b/src/main/scala/scalismo/mesh/MeshSurfaceProperty.scala
@@ -16,6 +16,7 @@
 package scalismo.mesh
 
 import scalismo.common.PointId
+import scalismo.common.interpolation.ValueInterpolator
 
 import scala.reflect.ClassTag
 
@@ -47,7 +48,7 @@ case class ConstantProperty[A](triangulation: TriangleList, value: A)
 }
 
 /** property defined per vertex, with interpolation */
-case class SurfacePointProperty[A](triangulation: TriangleList, pointData: IndexedSeq[A])(implicit val interpolator: Interpolator[A])
+case class SurfacePointProperty[A](triangulation: TriangleList, pointData: IndexedSeq[A])(implicit val interpolator: ValueInterpolator[A])
     extends MeshSurfaceProperty[A] {
 
   /** access surface property at vertex point */
@@ -63,12 +64,12 @@ case class SurfacePointProperty[A](triangulation: TriangleList, pointData: Index
     bcc.interpolateProperty(v1, v2, v3)
   }
 
-  def mapPoints[B](f: A => B)(implicit interpolator: Interpolator[B]) = SurfacePointProperty(triangulation, pointData.map(f))
+  def mapPoints[B](f: A => B)(implicit interpolator: ValueInterpolator[B]) = SurfacePointProperty(triangulation, pointData.map(f))
 }
 
 object SurfacePointProperty {
   /** average an arbitrary surface property at each vertex point */
-  def averagedPointProperty[A](property: MeshSurfaceProperty[A])(implicit interpolator: Interpolator[A]): SurfacePointProperty[A] = {
+  def averagedPointProperty[A](property: MeshSurfaceProperty[A])(implicit interpolator: ValueInterpolator[A]): SurfacePointProperty[A] = {
     def averager(data: IndexedSeq[A]): A = {
       data.size match {
         case 0 => throw new Exception("averaging over empty set")
@@ -86,7 +87,7 @@ object SurfacePointProperty {
    * @param interpolator interpolator
    * @return surface property which is backed by the sampled and reduced values at each vertex
    */
-  def sampleSurfaceProperty[A](property: MeshSurfaceProperty[A], reducer: IndexedSeq[A] => A)(implicit interpolator: Interpolator[A]): SurfacePointProperty[A] = {
+  def sampleSurfaceProperty[A](property: MeshSurfaceProperty[A], reducer: IndexedSeq[A] => A)(implicit interpolator: ValueInterpolator[A]): SurfacePointProperty[A] = {
     val triangulation = property.triangulation
     // get all data for a single vertex:
     def getVertex(pointId: PointId): A = {
@@ -120,7 +121,7 @@ case class TriangleProperty[A](triangulation: TriangleList, triangleData: Indexe
 
 object TriangleProperty {
   /** extract TriangleProperty from the average value of the vertices around each triangle */
-  def fromAveragedPoints[A](property: MeshSurfaceProperty[A])(implicit blender: Interpolator[A]): TriangleProperty[A] = {
+  def fromAveragedPoints[A](property: MeshSurfaceProperty[A])(implicit blender: ValueInterpolator[A]): TriangleProperty[A] = {
     val triangleData = for (t <- property.triangulation.triangleIds) yield {
       val v1 = property(t, BarycentricCoordinates.v0)
       val v2 = property(t, BarycentricCoordinates.v1)

--- a/src/main/scala/scalismo/numerics/ValueInterpolator.scala
+++ b/src/main/scala/scalismo/numerics/ValueInterpolator.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package scalismo.common.interpolation
+package scalismo.numerics
 
 import scalismo.geometry.Vector._
 import scalismo.geometry._
@@ -51,7 +51,7 @@ trait ValueInterpolator[@specialized(Double, Float) A] {
     var mix: A = first
     var n = 1
     for (next <- rest) {
-      mix = blend(mix, next, n / (n + 1))
+      mix = blend(mix, next, n.toDouble / (n + 1))
       n += 1
     }
     mix


### PR DESCRIPTION
As ```scalismo.mesh.interpolator``` is of more common interest than only for interpolating values defined on meshes, it was moved to common.interpolation and its name was changed to ```ValueInterpolator``` such that it is not confused with more complex interpolators such as image interpolators..

Other minor changes:
* The coefficients for defining the convex combination were changed
  from Float to Double
* Introduced convenience method for obtaining the implict instance (via apply)