### PR TITLE
Made DiscreteGp covariant on DiscreteDomain

### DIFF
--- a/src/main/scala/scalismo/statisticalmodel/DiscreteGaussianProcess.scala
+++ b/src/main/scala/scalismo/statisticalmodel/DiscreteGaussianProcess.scala
@@ -27,7 +27,7 @@ import scalismo.utils.Random
  * While this is technically similar to a MultivariateNormalDistribution, we highlight with this
  * class that we represent (discrete) functions, defined on the given domain.
  */
-class DiscreteGaussianProcess[D <: Dim: NDSpace, DDomain <: DiscreteDomain[D], Value] private[scalismo] (val mean: DiscreteField[D, DDomain, Value],
+class DiscreteGaussianProcess[D <: Dim: NDSpace, +DDomain <: DiscreteDomain[D], Value] private[scalismo] (val mean: DiscreteField[D, DDomain, Value],
     val cov: DiscreteMatrixValuedPDKernel[D])(implicit val vectorizer: Vectorizer[Value]) {
   self =>
 
@@ -112,7 +112,7 @@ class DiscreteGaussianProcess[D <: Dim: NDSpace, DDomain <: DiscreteDomain[D], V
    * Discrete version of [[LowRankGaussianProcess.project(IndexedSeq[(Point[D], Vector[DO])], Double)]]
    */
 
-  def project(s: DiscreteField[D, DDomain, Value]): DiscreteField[D, DDomain, Value] = {
+  def project(s: DiscreteField[D, DiscreteDomain[D], Value]): DiscreteField[D, DDomain, Value] = {
 
     val sigma2 = 1e-5 // regularization weight to avoid numerical problems
     val noiseDist = MultivariateNormalDistribution(DenseVector.zeros[Double](outputDim), DenseMatrix.eye[Double](outputDim) * sigma2)
@@ -124,7 +124,7 @@ class DiscreteGaussianProcess[D <: Dim: NDSpace, DDomain <: DiscreteDomain[D], V
   /**
    * Returns the probability density of the given instance
    */
-  def pdf(instance: DiscreteField[D, DDomain, Value]): Double = {
+  def pdf(instance: DiscreteField[D, DiscreteDomain[D], Value]): Double = {
     val mvnormal = MultivariateNormalDistribution(DiscreteField.vectorize[D, Value](mean.data), cov.asBreezeMatrix)
     val instvec = DiscreteField.vectorize[D, Value](instance.data)
     mvnormal.pdf(instvec)
@@ -135,7 +135,7 @@ class DiscreteGaussianProcess[D <: Dim: NDSpace, DDomain <: DiscreteDomain[D], V
    *
    * If you are interested in ordinal comparisons of PDFs, use this as it is numerically more stable
    */
-  def logpdf(instance: DiscreteField[D, DDomain, Value]): Double = {
+  def logpdf(instance: DiscreteField[D, DiscreteDomain[D], Value]): Double = {
     val mvnormal = MultivariateNormalDistribution(DiscreteField.vectorize[D, Value](mean.data), cov.asBreezeMatrix)
     val instvec = DiscreteField.vectorize[D, Value](instance.data)
     mvnormal.logpdf(instvec)

--- a/src/main/scala/scalismo/statisticalmodel/DiscreteLowRankGaussianProcess.scala
+++ b/src/main/scala/scalismo/statisticalmodel/DiscreteLowRankGaussianProcess.scala
@@ -200,8 +200,6 @@ case class DiscreteLowRankGaussianProcess[D <: Dim: NDSpace, DDomain <: Discrete
     val newMean = this.mean.interpolate(interpolator)
 
     new InterpolatedLowRankGaussianProcess(Field(RealSpace[D], newMean), newKLBasis, this, interpolator)
-
-    new LowRankGaussianProcess[D, Value](newMean, newKLBasis)
   }
 
   /**

--- a/src/main/scala/scalismo/statisticalmodel/DiscreteLowRankGaussianProcess.scala
+++ b/src/main/scala/scalismo/statisticalmodel/DiscreteLowRankGaussianProcess.scala
@@ -44,7 +44,7 @@ import scalismo.utils.{ Memoize, Random }
  * @see [[DiscreteLowRankGaussianProcess]]
  */
 
-case class DiscreteLowRankGaussianProcess[D <: Dim: NDSpace, DDomain <: DiscreteDomain[D], Value] private[scalismo] (_domain: DDomain, meanVector: DenseVector[Double], variance: DenseVector[Double], basisMatrix: DenseMatrix[Double])(override implicit val vectorizer: Vectorizer[Value])
+case class DiscreteLowRankGaussianProcess[D <: Dim: NDSpace, +DDomain <: DiscreteDomain[D], Value] private[scalismo] (_domain: DDomain, meanVector: DenseVector[Double], variance: DenseVector[Double], basisMatrix: DenseMatrix[Double])(override implicit val vectorizer: Vectorizer[Value])
     extends DiscreteGaussianProcess[D, DDomain, Value](DiscreteField.createFromDenseVector[D, DDomain, Value](_domain, meanVector), basisMatrixToCov(_domain, variance, basisMatrix)) {
   self =>
 
@@ -91,14 +91,14 @@ case class DiscreteLowRankGaussianProcess[D <: Dim: NDSpace, DDomain <: Discrete
   /**
    * Returns the probability density of the given instance
    */
-  override def pdf(instance: DiscreteField[D, DDomain, Value]): Double = pdf(coefficients(instance))
+  override def pdf(instance: DiscreteField[D, DiscreteDomain[D], Value]): Double = pdf(coefficients(instance))
 
   /**
    * Returns the log of the probability density of the instance
    *
    * If you are interested in ordinal comparisons of PDFs, use this as it is numerically more stable
    */
-  override def logpdf(instance: DiscreteField[D, DDomain, Value]): Double = logpdf(coefficients(instance))
+  override def logpdf(instance: DiscreteField[D, DiscreteDomain[D], Value]): Double = logpdf(coefficients(instance))
 
   /**
    * Discrete version of [[DiscreteLowRankGaussianProcess.sample]]
@@ -133,14 +133,14 @@ case class DiscreteLowRankGaussianProcess[D <: Dim: NDSpace, DDomain <: Discrete
   /**
    * Discrete version of [[LowRankGaussianProcess.project(IndexedSeq[(Point[D], Vector[DO])], Double)]]
    */
-  override def project(s: DiscreteField[D, DDomain, Value]): DiscreteField[D, DDomain, Value] = {
+  override def project(s: DiscreteField[D, DiscreteDomain[D], Value]): DiscreteField[D, DDomain, Value] = {
     instance(coefficients(s))
   }
 
   /**
    * Discrete version of [[DiscreteLowRankGaussianProcess.coefficients(IndexedSeq[(Point[D], Vector[DO], Double)])]]
    */
-  def coefficients(s: DiscreteField[D, DDomain, Value]): DenseVector[Double] = {
+  def coefficients(s: DiscreteField[D, DiscreteDomain[D], Value]): DenseVector[Double] = {
     val sigma2 = 1e-5 // regularization weight to avoid numerical problems
     val noiseDist = MultivariateNormalDistribution(DenseVector.zeros[Double](outputDim), DenseMatrix.eye[Double](outputDim) * sigma2)
     val td = s.valuesWithIds.map { case (v, id) => (id, v, noiseDist) }.toIndexedSeq
@@ -334,9 +334,9 @@ private[scalismo] class InterpolatedLowRankGaussianProcess[D <: Dim: NDSpace, DD
 
 object DiscreteLowRankGaussianProcess {
 
-  case class Eigenpair[D <: Dim, DDomain <: DiscreteDomain[D], Value](eigenvalue: Double, eigenfunction: DiscreteField[D, DDomain, Value])
+  case class Eigenpair[D <: Dim, +DDomain <: DiscreteDomain[D], Value](eigenvalue: Double, eigenfunction: DiscreteField[D, DDomain, Value])
 
-  type KLBasis[D <: Dim, Dom <: DiscreteDomain[D], Value] = Seq[Eigenpair[D, Dom, Value]]
+  type KLBasis[D <: Dim, +Dom <: DiscreteDomain[D], Value] = Seq[Eigenpair[D, Dom, Value]]
 
   /**
    * Creates a new DiscreteLowRankGaussianProcess by discretizing the given gaussian process at the domain points.


### PR DESCRIPTION
The DiscreteGaussianProcess and DiscreteLowRankGaussianProcess were so far invariant in the domain argument. In line with the DiscreteField, it should, however be covariant, such that we can pass a ```DiscreteLowRankGP[D, DiscreteImageDomain[D], V]``` where a ```DiscreteLowRankGP[D, DiscreteDomain[D], V]``` is expected. 