### PR TITLE
corrected conversion of vtk scalar types.

### DIFF
--- a/src/test/scala/scalismo/io/MeshIOTests.scala
+++ b/src/test/scala/scalismo/io/MeshIOTests.scala
@@ -111,9 +111,13 @@ class MeshIOTests extends ScalismoTestSuite {
       val writeTry = MeshIO.writeScalarMeshField(f.meshData, tmpFile)
 
       val readTry = MeshIO.readScalarMeshFieldAsType[Float](tmpFile)
+      readTry.recover { case (t: Throwable) => { t.getMessage(); t.printStackTrace(); } }
       assert(readTry.isSuccess)
 
-      readTry.get.data == ScalarArray(f.mesh.pointSet.pointIds.map(_.id).toArray)
+      for ((origDatum, newDatum) <- f.meshData.data.zip(readTry.get.data)) {
+        origDatum.toFloat should equal(newDatum)
+      }
+
     }
 
   }

--- a/src/test/scala/scalismo/io/MeshIOTests.scala
+++ b/src/test/scala/scalismo/io/MeshIOTests.scala
@@ -19,12 +19,13 @@ import java.io.File
 
 import scalismo.ScalismoTestSuite
 import scalismo.common.{ Scalar, ScalarArray }
-import scalismo.mesh.ScalarMeshField
+import scalismo.geometry._3D
+import scalismo.mesh.{ ScalarMeshField, TriangleMesh }
 
 import scala.language.implicitConversions
 import scala.reflect.ClassTag
 import scala.reflect.runtime.universe.TypeTag
-import scala.util.Try
+import scala.util.{ Failure, Success, Try }
 
 class MeshIOTests extends ScalismoTestSuite {
 
@@ -77,9 +78,9 @@ class MeshIOTests extends ScalismoTestSuite {
   describe("ScalarMeshField IO") {
 
     object Fixture {
-      val path = getClass.getResource("/facemesh.stl").getPath
-      val mesh = MeshIO.readMesh(new File(path)).get
-      val meshData = ScalarMeshField(mesh, ScalarArray(mesh.pointSet.pointIds.map(_.id).toArray))
+      val path: String = getClass.getResource("/facemesh.stl").getPath
+      val mesh: TriangleMesh[_3D] = MeshIO.readMesh(new File(path)).get
+      val meshData: ScalarMeshField[Int] = ScalarMeshField(mesh, ScalarArray(mesh.pointSet.pointIds.map(_.id).toArray))
     }
 
     def sameWriteRead[S: Scalar: TypeTag: ClassTag](): Try[ScalarMeshField[S]] = {
@@ -108,14 +109,18 @@ class MeshIOTests extends ScalismoTestSuite {
     it("can read and cast a ScalarMeshField") {
       val f = Fixture
       val tmpFile = File.createTempFile("scalarMesh", ".vtk")
-      val writeTry = MeshIO.writeScalarMeshField(f.meshData, tmpFile)
+      tmpFile.deleteOnExit()
+      MeshIO.writeScalarMeshField(f.meshData, tmpFile)
 
-      val readTry = MeshIO.readScalarMeshFieldAsType[Float](tmpFile)
-      readTry.recover { case (t: Throwable) => { t.getMessage(); t.printStackTrace(); } }
-      assert(readTry.isSuccess)
-
-      for ((origDatum, newDatum) <- f.meshData.data.zip(readTry.get.data)) {
-        origDatum.toFloat should equal(newDatum)
+      MeshIO.readScalarMeshFieldAsType[Float](tmpFile) match {
+        case Success(meshData) =>
+          for ((origDatum, newDatum) <- f.meshData.data.zip(meshData.data)) {
+            origDatum.toFloat should equal(newDatum)
+          }
+        case Failure(t) =>
+          println(t.getMessage)
+          t.printStackTrace()
+          throw t
       }
 
     }


### PR DESCRIPTION
The previous implementation of the conversion from vtk Scalar Arrays to the corresponding
Scalismo ScalarArray was based on casts of the array (using asInstanceOf). While this compiles,
the containing types is not actually converted and accessing it leads to ClassCastExceptions at
runtime. This commit does an explicit conversion of the elements, which fixes this problem.
The corresponding test was also improved, in order to capture this mistake.