### PR TITLE
removed implicit random value from sampling interface. Fixes #211

### DIFF
--- a/src/main/scala/scalismo/mesh/MeshMetrics.scala
+++ b/src/main/scala/scalismo/mesh/MeshMetrics.scala
@@ -87,7 +87,7 @@ object MeshMetrics {
     val evaluationRegion = BoxDomain(minPoint(box1.origin, box2.origin), maxPoint(box1.oppositeCorner, box2.oppositeCorner))
 
     val sampler = UniformSampler[_3D](evaluationRegion, 10000)
-    val samplePts = sampler.sample()(rand).map(_._1)
+    val samplePts = sampler.sample().map(_._1)
 
     val numSamplesInA = samplePts.map(imgA).sum
     val numSamplesInB = samplePts.map(imgB).sum

--- a/src/main/scala/scalismo/numerics/Integrator.scala
+++ b/src/main/scala/scalismo/numerics/Integrator.scala
@@ -21,7 +21,7 @@ import scalismo.image.ScalarImage
 import scalismo.geometry._
 import scalismo.utils.Random
 
-case class Integrator[D <: Dim: NDSpace](sampler: Sampler[D])(implicit rng: Random) {
+case class Integrator[D <: Dim: NDSpace](sampler: Sampler[D]) {
 
   def integrateScalar(img: ScalarImage[D]): Float = {
     integrateScalar(img.liftValues)

--- a/src/main/scala/scalismo/numerics/Sampler.scala
+++ b/src/main/scala/scalismo/numerics/Sampler.scala
@@ -34,7 +34,7 @@ trait Sampler[D <: Dim] {
    * sample n points (x_1, ... x_n), yielding an sequence of (x_i, p(x_i)), i=1..n , p is the probability density function
    * according to which the points are sampled
    */
-  def sample()(implicit rand: Random): IndexedSeq[(Point[D], Double)]
+  def sample(): IndexedSeq[(Point[D], Double)]
 
   def volumeOfSampleRegion: Double
 }
@@ -44,17 +44,17 @@ case class GridSampler[D <: Dim: NDSpace](domain: DiscreteImageDomain[D]) extend
   override val numberOfPoints = domain.numberOfPoints
 
   val p = 1.0 / volumeOfSampleRegion
-  override def sample()(implicit rand: Random) = {
+  override def sample() = {
     domain.points.toIndexedSeq.map(pt => (pt, p))
   }
 }
 
-case class UniformSampler[D <: Dim: NDSpace](domain: BoxDomain[D], numberOfPoints: Int) extends Sampler[D] {
+case class UniformSampler[D <: Dim: NDSpace](domain: BoxDomain[D], numberOfPoints: Int)(implicit rand: Random) extends Sampler[D] {
 
   def volumeOfSampleRegion = domain.volume
   val p = 1.0 / domain.volume
 
-  override def sample()(implicit rand: Random) = {
+  override def sample() = {
     val ndSpace = implicitly[NDSpace[D]]
     val randGens = for (i <- (0 until ndSpace.dimensionality)) yield {
       Uniform(domain.origin(i), domain.oppositeCorner(i))(rand.breezeRandBasis)
@@ -64,13 +64,13 @@ case class UniformSampler[D <: Dim: NDSpace](domain: BoxDomain[D], numberOfPoint
   }
 }
 
-case class RandomMeshSampler3D(mesh: TriangleMesh[_3D], numberOfPoints: Int, seed: Int) extends Sampler[_3D] {
+case class RandomMeshSampler3D(mesh: TriangleMesh[_3D], numberOfPoints: Int, seed: Int)(implicit rand: Random) extends Sampler[_3D] {
 
   val p = 1.0 / mesh.area
 
   // should be replaced with real mesh volume
   val volumeOfSampleRegion = mesh.area
-  def sample()(implicit rand: Random) = {
+  def sample() = {
     val points = mesh.pointSet.points.toIndexedSeq
     val distrDim1 = Uniform(0, mesh.pointSet.numberOfPoints)(rand.breezeRandBasis)
     val pts = (0 until numberOfPoints).map(i => (points(distrDim1.draw().toInt), p))
@@ -105,12 +105,12 @@ case class PointsWithLikelyCorrespondenceSampler(gp: GaussianProcess[_3D, Vector
 
   override val volumeOfSampleRegion = 1.0
   override val numberOfPoints = pts.size
-  override def sample()(implicit rand: Random) = {
+  override def sample() = {
     println(s"Sampled: $numberOfPoints"); pts
   }
 }
 
-case class UniformMeshSampler3D(mesh: TriangleMesh[_3D], numberOfPoints: Int) extends Sampler[_3D] {
+case class UniformMeshSampler3D(mesh: TriangleMesh[_3D], numberOfPoints: Int)(implicit rand: Random) extends Sampler[_3D] {
 
   override val volumeOfSampleRegion: Double = mesh.area
 
@@ -121,7 +121,7 @@ case class UniformMeshSampler3D(mesh: TriangleMesh[_3D], numberOfPoints: Int) ex
       sum + mesh.computeTriangleArea(cell)
   }.tail.toArray
 
-  override def sample()(implicit rand: Random) = {
+  override def sample() = {
     val samplePoints = {
       for (i <- 0 until numberOfPoints) yield {
         val drawnValue = rand.scalaRandom.nextDouble() * mesh.area
@@ -139,29 +139,29 @@ case class UniformMeshSampler3D(mesh: TriangleMesh[_3D], numberOfPoints: Int) ex
 case class FixedPointsUniformMeshSampler3D(mesh: TriangleMesh[_3D], numberOfPoints: Int)(implicit rng: Random) extends Sampler[_3D] {
   override val volumeOfSampleRegion = mesh.area
   val samplePoints = UniformMeshSampler3D(mesh, numberOfPoints).sample()
-  override def sample()(implicit rand: Random) = samplePoints
+  override def sample() = samplePoints
 }
 
-case class FixedPointsMeshSampler3D(mesh: TriangleMesh[_3D], numberOfPoints: Int) extends Sampler[_3D] {
+case class FixedPointsMeshSampler3D(mesh: TriangleMesh[_3D], numberOfPoints: Int)(implicit rand: Random) extends Sampler[_3D] {
 
   val volumeOfSampleRegion = mesh.area
   val p = 1.0 / mesh.area
 
   val meshPoints = mesh.pointSet.points.toIndexedSeq
 
-  def samplePoints(rand: Random) = for (i <- 0 until numberOfPoints) yield {
+  def samplePoints = for (i <- 0 until numberOfPoints) yield {
     val idx = rand.scalaRandom.nextInt(mesh.pointSet.numberOfPoints)
     meshPoints(idx)
   }
 
   var lastSampledPoints: Option[IndexedSeq[(Point[_3D], Double)]] = None
 
-  def sample()(implicit rand: Random) = {
+  def sample() = {
 
     lastSampledPoints match {
       case Some(lastSampledPoints) => lastSampledPoints
       case None => {
-        val pts = samplePoints(rand).map(pt => (pt, p))
+        val pts = samplePoints.map(pt => (pt, p))
         lastSampledPoints = Some(pts)
         pts
       }

--- a/src/main/scala/scalismo/registration/MeanSquaresMetric.scala
+++ b/src/main/scala/scalismo/registration/MeanSquaresMetric.scala
@@ -31,7 +31,7 @@ import scalismo.utils.Random
 case class MeanSquaresMetric[D <: Dim: NDSpace](fixedImage: ScalarImage[D],
     movingImage: DifferentiableScalarImage[D],
     transformationSpace: TransformationSpace[D],
-    sampler: Sampler[D])(implicit rng: Random) extends ImageMetric[D] {
+    sampler: Sampler[D]) extends ImageMetric[D] {
 
   override val ndSpace = implicitly[NDSpace[D]]
 
@@ -53,7 +53,7 @@ case class MeanSquaresMetric[D <: Dim: NDSpace](fixedImage: ScalarImage[D],
       override val numberOfPoints: Int = sampler.numberOfPoints
       private val samples = sampler.sample()
 
-      override def sample()(implicit rand: Random): IndexedSeq[(Point[D], Double)] = samples
+      override def sample(): IndexedSeq[(Point[D], Double)] = samples
       override def volumeOfSampleRegion: Double = sampler.volumeOfSampleRegion
     }
 

--- a/src/main/scala/scalismo/statisticalmodel/DiscreteLowRankGaussianProcess.scala
+++ b/src/main/scala/scalismo/statisticalmodel/DiscreteLowRankGaussianProcess.scala
@@ -210,7 +210,7 @@ case class DiscreteLowRankGaussianProcess[D <: Dim: NDSpace, +DDomain <: Discret
    * @param nNystromPoints determines how many points of the domain are used to estimate the full
    *                       kl basis.
    */
-  def interpolateNystrom(nNystromPoints: Int = 2 * rank)(implicit rng: Random): LowRankGaussianProcess[D, Value] = {
+  def interpolateNystrom(nNystromPoints: Int = 2 * rank)(implicit rand: Random): LowRankGaussianProcess[D, Value] = {
 
     val sampler = new Sampler[D] {
       override def volumeOfSampleRegion = numberOfPoints.toDouble
@@ -220,7 +220,7 @@ case class DiscreteLowRankGaussianProcess[D <: Dim: NDSpace, +DDomain <: Discret
 
       val domainPoints = domain.points.toIndexedSeq
 
-      override def sample()(implicit rand: Random) = {
+      override def sample() = {
         val sampledPtIds = for (_ <- 0 until nNystromPoints) yield rand.scalaRandom.nextInt(domain.numberOfPoints)
         sampledPtIds.map(ptId => (domainPoints(ptId), p))
       }


### PR DESCRIPTION
The Sampling.sample was taking an implicit rand value. This in turn forced several other
methods to take an implicit, which are not random by themselves. This commit removes
this implicits and as such simplifies the code.