### PR TITLE
Added support for Scala 2.12

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -12,7 +12,7 @@ import sbtbuildinfo.Plugin._
 
 object BuildSettings {
   val buildOrganization = "ch.unibas.cs.gravis"
-  val buildVersion = "0.10.0"
+  val buildVersion = "0.10.1"
   val buildScalaVersion = "2.12.4"
   val publishURL = Resolver.file("file", new File("/export/contrib/statismo/repo/public"))
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -13,14 +13,14 @@ import sbtbuildinfo.Plugin._
 object BuildSettings {
   val buildOrganization = "ch.unibas.cs.gravis"
   val buildVersion = "0.10.0"
-  val buildScalaVersion = "2.10.5"
+  val buildScalaVersion = "2.12.4"
   val publishURL = Resolver.file("file", new File("/export/contrib/statismo/repo/public"))
 
   val buildSettings = Defaults.defaultSettings ++ Seq(
     organization := buildOrganization,
     version := buildVersion,
     scalaVersion := buildScalaVersion,
-    crossScalaVersions := Seq("2.10.5", "2.11.7"),
+    crossScalaVersions := Seq("2.10.5", "2.11.7", "2.12.4"),
     javacOptions ++= Seq("-source", "1.6", "-target", "1.6"),
     scalacOptions ++= Seq("-encoding", "UTF-8", "-Xlint", "-deprecation", "-unchecked", "-feature", "-target:jvm-1.6"),
     shellPrompt := ShellPrompt.buildShellPrompt)
@@ -65,10 +65,11 @@ object Resolvers {
 
 object Dependencies {
   import BuildSettings.scalismoPlatform
-  val scalatest = "org.scalatest" %% "scalatest" % "2.2+" % "test"
-  val breezeMath = "org.scalanlp" %% "breeze" % "0.11.2"
-  val breezeNative = "org.scalanlp" %% "breeze-natives" % "0.11.2"
-  val sprayJson = "io.spray" %% "spray-json" % "1.2.6"
+
+  val scalatest = "org.scalatest" %% "scalatest" % "3.0.1" % "test"
+  val breezeMath = "org.scalanlp" %% "breeze" % "0.13"
+  val breezeNative = "org.scalanlp" %% "breeze-natives" % "0.13"
+  val sprayJson = "io.spray" %% "spray-json" % "1.3.3"
   val scalismoNativeStub = "ch.unibas.cs.gravis" % "scalismo-native-stub" % "3.0.+"
   val scalismoNativeImpl = "ch.unibas.cs.gravis" % s"scalismo-native-$scalismoPlatform" % "3.0.+" % "test"
   val spire = "org.spire-math" %% "spire" % "0.9.0"

--- a/src/main/scala/scalismo/geometry/SquareMatrix.scala
+++ b/src/main/scala/scalismo/geometry/SquareMatrix.scala
@@ -190,7 +190,7 @@ object SquareMatrix {
   }
 
   def inv[D <: Dim: NDSpace](m: SquareMatrix[D]): SquareMatrix[D] = {
-    val bm = m.toBreezeMatrix
+    val bm = m.toBreezeMatrix.map(_.toDouble)
     val bmInv: DenseMatrix[Double] = breeze.linalg.inv(bm)
     new SquareMatrix[D](bmInv.data.map(_.toFloat))
   }

--- a/src/main/scala/scalismo/statisticalmodel/DiscreteLowRankGaussianProcess.scala
+++ b/src/main/scala/scalismo/statisticalmodel/DiscreteLowRankGaussianProcess.scala
@@ -367,7 +367,8 @@ object DiscreteLowRankGaussianProcess {
 
     def demean(X: DenseMatrix[Float]): (DenseMatrix[Double], DenseVector[Double]) = {
       val X0 = X.map(_.toDouble) // will be the demeaned result matrix
-      val m: DenseVector[Double] = breeze.stats.mean(X0(::, *)).toDenseVector
+      val m: DenseVector[Double] = breeze.stats.mean(X0(::, *)).inner
+
       for (i <- 0 until X0.rows) {
         X0(i, ::) := X0(i, ::) - m.t
       }
@@ -417,7 +418,7 @@ object DiscreteLowRankGaussianProcess {
     assert(QtL.cols == errorDistributions.size * dim)
     assert(QtL.rows == gp.rank)
     for ((errDist, i) <- errorDistributions.zipWithIndex) {
-      QtL(::, i * dim until (i + 1) * dim) := QtL(::, i * dim until (i + 1) * dim) * breeze.linalg.inv(errDist.cov.toBreezeMatrix)
+      QtL(::, i * dim until (i + 1) * dim) := QtL(::, i * dim until (i + 1) * dim) * breeze.linalg.inv(errDist.cov.toBreezeMatrix.map(_.toDouble))
     }
 
     val M = QtL * Q + DenseMatrix.eye[Double](gp.rank)

--- a/src/main/scala/scalismo/statisticalmodel/GaussianProcess.scala
+++ b/src/main/scala/scalismo/statisticalmodel/GaussianProcess.scala
@@ -124,7 +124,7 @@ object GaussianProcess {
       K(i * outputDim until (i + 1) * outputDim, i * outputDim until (i + 1) * outputDim) += errorDist.cov.toBreezeMatrix
     }
 
-    val K_inv = breeze.linalg.inv(K)
+    val K_inv = breeze.linalg.inv(K.map(_.toDouble))
 
     def xstar(x: Point[D]) = { Kernel.computeKernelVectorFor[D, DO](x, xs, gp.cov) }
 

--- a/src/main/scala/scalismo/statisticalmodel/LowRankGaussianProcess.scala
+++ b/src/main/scala/scalismo/statisticalmodel/LowRankGaussianProcess.scala
@@ -284,7 +284,8 @@ object LowRankGaussianProcess {
     assert(QtL.cols == errorDistributions.size * dim)
     assert(QtL.rows == gp.rank)
     for ((errDist, i) <- errorDistributions.zipWithIndex) {
-      QtL(::, i * dim until (i + 1) * dim) := QtL(::, i * dim until (i + 1) * dim) * breeze.linalg.inv(errDist.cov.toBreezeMatrix)
+      QtL(::, i * dim until (i + 1) * dim) := QtL(::, i * dim until (i + 1) * dim) * breeze.linalg.inv(errDist.cov.toBreezeMatrix.map(_.toDouble))
+
     }
 
     val M = QtL * Q + DenseMatrix.eye[Double](gp.klBasis.size)

--- a/src/test/scala/scalismo/statisticalmodel/MultivariateNormalDistributionTests.scala
+++ b/src/test/scala/scalismo/statisticalmodel/MultivariateNormalDistributionTests.scala
@@ -79,14 +79,14 @@ class MultivariateNormalDistributionTests extends ScalismoTestSuite {
   describe("The mahalanobis distance") {
     it("is 0 if the mean is used") {
       val mu = DenseVector(2f, 1.0f)
-      val cov = DenseMatrix.create[Float](2, 2, Array(1, 0, 0, 1))
+      val cov = DenseMatrix.create[Float](2, 2, Array(1f, 0f, 0f, 1f))
       val mvn = new MultivariateNormalDistribution(mu, cov)
       mvn.mahalanobisDistance(mu) should be(0.0 +- 1e-5)
     }
 
     it("yields the same as the squared norm if mean 0 and identity cov is used") {
       val mu = DenseVector(0f, 0f)
-      val cov = DenseMatrix.create[Float](2, 2, Array(1, 0, 0, 1))
+      val cov = DenseMatrix.create[Float](2, 2, Array(1f, 0f, 0f, 1f))
       val mvn = new MultivariateNormalDistribution(mu, cov)
       val x = DenseVector(3f, 7f)
       mvn.mahalanobisDistance(x) should be(breeze.linalg.norm(x, 2))
@@ -94,7 +94,7 @@ class MultivariateNormalDistributionTests extends ScalismoTestSuite {
 
     it("increases with distance from the mean") {
       val mu = DenseVector(3f, 0f)
-      val cov = DenseMatrix.create[Float](2, 2, Array(1, 0, 0, 1))
+      val cov = DenseMatrix.create[Float](2, 2, Array(1f, 0f, 0f, 1f))
       val mvn = new MultivariateNormalDistribution(mu, cov)
       for (i <- 1 until 10) {
         mvn.mahalanobisDistance(mu + DenseVector(1f, i.toFloat)) should be > mvn.mahalanobisDistance(mu + DenseVector(1f, (i - 1).toFloat))


### PR DESCRIPTION
As scalismo v0.10 is used as the basis for ScalismoLab, it is important that it can be compiled with the latest Scala version. This PR adds support for Scala 2.12.4 to the release-0.10 branch. 