### PR TITLE
Integrating Vertex Color (For discussion only)

### DIFF
--- a/src/main/scala/scalismo/color/ColorSpaceOperations.scala
+++ b/src/main/scala/scalismo/color/ColorSpaceOperations.scala
@@ -16,7 +16,7 @@
 
 package scalismo.color
 
-import scalismo.geometry.{Dim, NDSpace, Vector}
+import scalismo.geometry.{ Dim, NDSpace, Vector }
 
 import scala.annotation.tailrec
 

--- a/src/main/scala/scalismo/color/ColorSpaceOperations.scala
+++ b/src/main/scala/scalismo/color/ColorSpaceOperations.scala
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2016 University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.color
+
+import scalismo.geometry.{Dim, NDSpace, Vector}
+
+import scala.annotation.tailrec
+
+/** vector space operations for a pixel type, necessary for filtering */
+trait ColorSpaceOperations[@specialized(Double, Float) A] {
+  /** blending using vector space operations */
+  def blend(v: A, w: A, l: Double): A = add(scale(v, l), scale(w, 1.0 - l))
+
+  /** add two pixels */
+  def add(pix1: A, pix2: A): A
+
+  /** scalar multiplication */
+  def scale(pix: A, l: Double): A
+
+  /** dot product */
+  def dot(pix1: A, pix2: A): Double
+
+  /** channel-wise multiplication */
+  def multiply(pix1: A, pix2: A): A
+
+  /** zero element */
+  def zero: A
+
+  /** check if zero */
+  def isZero(pix: A): Boolean = zero == pix
+
+  /** squared norm, derived from dot product */
+  def normSq(pix: A): Double = dot(pix, pix)
+
+  /** dimensionality of underlying vector space */
+  def dimensionality: Int
+
+  /** linear combination of vectors */
+  @tailrec
+  final def linearCombination(first: (A, Double), rest: (A, Double)*): A = {
+    val (v, f: Double) = first
+    if (rest.nonEmpty) {
+      val (v1, f1: Double) = rest.head
+      val combined = add(scale(v, f), scale(v1, f1))
+      linearCombination((combined, 1.0), rest.tail: _*) // Seq to varargs: _*
+    } else {
+      scale(v, f)
+    }
+  }
+}
+
+object ColorSpaceOperations {
+
+  /** implicit implementation of ColorSpaceOperations for plain Float */
+  implicit val floatColorSpace = new ColorSpaceOperations[Float] {
+    override def add(pix1: Float, pix2: Float): Float = pix1 + pix2
+    override def multiply(pix1: Float, pix2: Float): Float = pix1 * pix2
+    override def dot(pix1: Float, pix2: Float): Double = pix1 * pix2
+    override def scale(pix: Float, l: Double): Float = (pix * l).toFloat
+    override val zero: Float = 0f
+    override val dimensionality = 1
+  }
+
+  /** implicit implementation of ColorSpaceOperations for plain Double */
+  implicit val doubleColorSpace = new ColorSpaceOperations[Double] {
+    override def add(pix1: Double, pix2: Double): Double = pix1 + pix2
+    override def multiply(pix1: Double, pix2: Double): Double = pix1 * pix2
+    override def dot(pix1: Double, pix2: Double): Double = pix1 * pix2
+    override def scale(pix: Double, l: Double): Double = pix * l
+    override val zero: Double = 0.0
+    override val dimensionality = 1
+  }
+
+  /** implementation for vectors of arbitrary dimension */
+  implicit def vecColorSpaceND[D <: Dim: NDSpace] = new ColorSpaceOperations[Vector[D]] {
+    override def add(pix1: Vector[D], pix2: Vector[D]): Vector[D] = pix1 + pix2
+    override def multiply(pix1: Vector[D], pix2: Vector[D]): Vector[D] = pix1 :* pix2
+    override def dot(pix1: Vector[D], pix2: Vector[D]): Double = pix1 dot pix2
+    override def scale(pix: Vector[D], l: Double): Vector[D] = pix * l
+    override val zero: Vector[D] = Vector.zeros[D]
+    override val dimensionality: Int = NDSpace[D].dimensionality
+  }
+
+  /** implementation for type A wrapped in Option[A] */
+  implicit def optionSpace[A](implicit ops: ColorSpaceOperations[A]) = new ColorSpaceOperations[Option[A]] {
+    override def add(pix1: Option[A], pix2: Option[A]): Option[A] = for (p1 <- pix1; p2 <- pix2) yield ops.add(p1, p2)
+    override def multiply(pix1: Option[A], pix2: Option[A]): Option[A] = for (p1 <- pix1; p2 <- pix2) yield ops.multiply(p1, p2)
+    override def dot(pix1: Option[A], pix2: Option[A]): Double = (for (p1 <- pix1; p2 <- pix2) yield ops.dot(p1, p2)).getOrElse(0.0)
+    override def scale(pix: Option[A], l: Double): Option[A] = for (p1 <- pix) yield ops.scale(p1, l)
+    override val zero: Option[A] = Some(ops.zero)
+    override val dimensionality: Int = ops.dimensionality
+  }
+
+  /** implicit conversions to work with infix operator notations for ColorSpaceOperations[A] */
+  object implicits {
+    import scala.language.implicitConversions
+
+    implicit def toVector[A](color: A)(implicit space: ColorSpaceOperations[A]): ColorSpaceVector[A] = new ColorSpaceVector[A](color)
+
+    implicit def toColor[A](vector: ColorSpaceVector[A]): A = vector.color
+
+    class ColorSpaceVector[A](val color: A)(implicit space: ColorSpaceOperations[A]) {
+      val dimensionality: Int = space.dimensionality
+
+      def +(other: A): A = space.add(color, other)
+
+      def -(other: A): A = space.add(color, space.scale(other, -1.0))
+
+      def *(factor: Double): A = space.scale(color, factor)
+
+      def /(factor: Double): A = space.scale(color, 1.0 / factor)
+
+      def *:(factor: Double): A = space.scale(color, factor)
+
+      def dot(other: A): Double = space.dot(color, other)
+
+      def multiply(other: A): A = space.multiply(color, other)
+
+      def x(other: A): A = space.multiply(color, other)
+
+      def normSq: Double = space.normSq(color)
+
+      def unary_- : A = space.scale(color, -1.0)
+
+      def isZero: Boolean = space.isZero(color)
+    }
+  }
+}

--- a/src/main/scala/scalismo/color/RGB.scala
+++ b/src/main/scala/scalismo/color/RGB.scala
@@ -22,7 +22,7 @@ import breeze.linalg.DenseVector
 import scalismo.common.{ ComponentRepresentation, Vectorizer }
 import scalismo.geometry.Vector._
 import scalismo.geometry.{ Vector, _3D }
-import scalismo.mesh.Interpolator
+import scalismo.numerics.ValueInterpolator
 
 import scala.annotation.switch
 
@@ -166,7 +166,7 @@ object RGB {
     override val dimensionality = 3
   }
 
-  implicit object RGBInterpolator extends Interpolator[RGB] {
+  implicit object RGBInterpolator extends ValueInterpolator[RGB] {
     override def blend(obj1: RGB, obj2: RGB, l: Double): RGB = RGB(
       obj1.r * l + (1f - l) * obj2.r,
       obj1.g * l + (1f - l) * obj2.g,

--- a/src/main/scala/scalismo/color/RGB.scala
+++ b/src/main/scala/scalismo/color/RGB.scala
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2016 University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.color
+
+import java.awt.Color
+
+import breeze.linalg.DenseVector
+import scalismo.common.{ComponentRepresentation, Vectorizer}
+import scalismo.geometry.Vector._
+import scalismo.geometry.{Vector, _3D}
+import scalismo.mesh.Interpolator
+
+import scala.annotation.switch
+
+case class RGB(r: Double, g: Double, b: Double) {
+  def isInBounds: Boolean = r >= 0.0 && r <= 1.0 && g >= 0.0 && g <= 1.0 && b >= 0.0 && b <= 1.0
+
+  def sum: Double = r + g + b
+
+  /** clamp all values to valid range [0, 1] */
+  def clamped: RGB = {
+    def clamp(f: Double): Double = math.min(1.0, math.max(0.0, f))
+    if (!isInBounds)
+      RGB(clamp(r), clamp(g), clamp(b))
+    else
+      this
+  }
+
+  /** average intensity value */
+  def gray: Double = sum / 3.0
+
+  /** l2 norm of color rgb values */
+  def norm: Double = math.sqrt(math.pow(r, 2) + math.pow(g, 2) + math.pow(b, 2))
+
+  def luminance: Double = 0.3 * r + 0.59 * g + 0.11 * b
+
+  /** addition of another RGB */
+  def +(other: RGB): RGB = new RGB(r + other.r, g + other.g, b + other.b)
+
+  /** subtraction of another RGB */
+  def -(other: RGB): RGB = new RGB(r - other.r, g - other.g, b - other.b)
+
+  /** scaling with scalar number */
+  def *(f: Double): RGB = new RGB(r * f, g * f, b * f)
+
+  /** scaling with scalar number */
+  def *:(f: Double): RGB = new RGB(r * f, g * f, b * f)
+
+  /** scaling with scalar number */
+  def /(f: Double): RGB = this * (1.0f / f)
+
+  /** dot product */
+  def dot(other: RGB): Double = r * other.r + g * other.g + b * other.b
+
+  /** component-wise multiplication */
+  def x(other: RGB): RGB = RGB(r * other.r, g * other.g, b * other.b)
+
+  /** component-wise division */
+  def /(other: RGB): RGB = RGB(r / other.r, g / other.g, b / other.b)
+
+  /** applies f to all channels */
+  def map(f: Double => Double): RGB = new RGB(f(r), f(g), f(b))
+
+  /** blend with RGBA: RGBA pixel overlay, this color as basis */
+  def blend(color: RGBA): RGB = {
+    val a = color.a
+    val na = 1.0f - color.a
+    new RGB(
+      na * r + a * color.r,
+      na * g + a * color.g,
+      na * b + a * color.b)
+  }
+
+  /** convert to RGBA with full opacity */
+  def toRGBA: RGBA = RGBA(r, g, b, 1.0)
+
+  /** convert to Tuple */
+  def toTuple: (Double, Double, Double) = (r, g, b)
+
+  /** convert to standard Vector[_3D] */
+  def toVector = Vector(r, g, b)
+
+  /** convert to AWT default color
+    * expects a clamped color value */
+  def toAWTColor: Color = new java.awt.Color(r.toFloat, g.toFloat, b.toFloat)
+}
+
+object RGB {
+
+  val White: RGB = RGB(1.0, 1.0, 1.0)
+  val Black: RGB = RGB(0.0, 0.0, 0.0)
+
+  def apply(color: RGBA): RGB = new RGB(color.r, color.g, color.b)
+  def apply(gray: Double): RGB = new RGB(gray, gray, gray)
+  def apply(tuple: (Double, Double, Double)) = new RGB(tuple._1, tuple._2, tuple._3)
+  def apply(vector3D: Vector[_3D]) = new RGB(vector3D.x, vector3D.y, vector3D.z)
+  def apply(awtColor: Color) = new RGB(fromInt8(awtColor.getRed), fromInt8(awtColor.getGreen), fromInt8(awtColor.getBlue))
+
+  implicit object RGBComponents extends ComponentRepresentation[RGB] with Vectorizer[RGB] {
+
+    override def fromArray(arr: Array[Double]): RGB = {
+      require(arr.length == size)
+      RGB(arr(0), arr(1), arr(2))
+    }
+
+    override def toArray(color: RGB): Array[Double] = Array(color.r, color.g, color.b)
+
+    override def intoArray(color: RGB, array: Array[Double]): Array[Double] = {
+      require(array.length == 3)
+      array(0) = color.r
+      array(1) = color.g
+      array(2) = color.b
+      array
+    }
+
+    override val size: Int = 3
+
+    override def component(color: RGB, index: Int): Double = (index: @switch) match {
+      case 0 => color.r
+      case 1 => color.g
+      case 2 => color.b
+      case _ => throw new Exception(s"invalid index ($index) in RGB vectorizer")
+    }
+
+    override def fromComponents(comp: (Int) => Double): RGB = RGB(comp(0), comp(1), comp(2))
+
+    override def dim: Int = 3
+
+    override def vectorize(v: RGB): DenseVector[Double] = DenseVector(v.r,v.g,v.b)
+
+    override def unvectorize(d: DenseVector[Double]): RGB = RGB(d(0),d(1),d(2))
+  }
+
+  implicit object RGBOperations extends ColorSpaceOperations[RGB] {
+    /** add two pixels */
+    override def add(pix1: RGB, pix2: RGB): RGB = pix1 + pix2
+
+    /** scalar multiplication */
+    override def scale(pix: RGB, l: Double): RGB = pix * l
+
+    /** dot product */
+    override def dot(pix1: RGB, pix2: RGB): Double = pix1.dot(pix2)
+
+    /** channel-wise multiplication */
+    override def multiply(pix1: RGB, pix2: RGB): RGB = pix1 x pix2
+
+    /** zero element */
+    override def zero: RGB = Black
+
+    override val dimensionality = 3
+  }
+
+  implicit object RGBInterpolator extends Interpolator[RGB] {
+    override def blend(obj1: RGB, obj2: RGB, l: Double): RGB = RGB(
+      obj1.r * l + (1f - l) * obj2.r,
+      obj1.g * l + (1f - l) * obj2.g,
+      obj1.b * l + (1f - l) * obj2.b
+    )
+
+    override def average(first: RGB, rest: RGB*): RGB = {
+      var r = first.r
+      var g = first.g
+      var b = first.b
+      rest.foreach { c =>
+        r += c.r
+        g += c.g
+        b += c.b
+      }
+      val n = rest.size + 1
+      RGB(r / n, g / n, b / n)
+    }
+
+    override def barycentricInterpolation(v1: RGB, f1: Double, v2: RGB, f2: Double, v3: RGB, f3: Double): RGB = {
+      RGB(
+        v1.r * f1 + v2.r * f2 + v3.r * f3,
+        v1.g * f1 + v2.g * f2 + v3.g * f3,
+        v1.b * f1 + v2.b * f2 + v3.b * f3)
+    }
+  }
+
+  private def toInt8(value: Double): Int = (value * 255.0).toInt
+
+  private def fromInt8(intValue: Int): Double = intValue / 255.0
+}

--- a/src/main/scala/scalismo/color/RGB.scala
+++ b/src/main/scala/scalismo/color/RGB.scala
@@ -19,9 +19,9 @@ package scalismo.color
 import java.awt.Color
 
 import breeze.linalg.DenseVector
-import scalismo.common.{ComponentRepresentation, Vectorizer}
+import scalismo.common.{ ComponentRepresentation, Vectorizer }
 import scalismo.geometry.Vector._
-import scalismo.geometry.{Vector, _3D}
+import scalismo.geometry.{ Vector, _3D }
 import scalismo.mesh.Interpolator
 
 import scala.annotation.switch
@@ -94,8 +94,10 @@ case class RGB(r: Double, g: Double, b: Double) {
   /** convert to standard Vector[_3D] */
   def toVector = Vector(r, g, b)
 
-  /** convert to AWT default color
-    * expects a clamped color value */
+  /**
+   * convert to AWT default color
+   * expects a clamped color value
+   */
   def toAWTColor: Color = new java.awt.Color(r.toFloat, g.toFloat, b.toFloat)
 }
 
@@ -140,9 +142,9 @@ object RGB {
 
     override def dim: Int = 3
 
-    override def vectorize(v: RGB): DenseVector[Double] = DenseVector(v.r,v.g,v.b)
+    override def vectorize(v: RGB): DenseVector[Double] = DenseVector(v.r, v.g, v.b)
 
-    override def unvectorize(d: DenseVector[Double]): RGB = RGB(d(0),d(1),d(2))
+    override def unvectorize(d: DenseVector[Double]): RGB = RGB(d(0), d(1), d(2))
   }
 
   implicit object RGBOperations extends ColorSpaceOperations[RGB] {

--- a/src/main/scala/scalismo/color/RGBA.scala
+++ b/src/main/scala/scalismo/color/RGBA.scala
@@ -20,7 +20,7 @@ import java.awt.Color
 
 import breeze.linalg.DenseVector
 import scalismo.common.{ ComponentRepresentation, Vectorizer }
-import scalismo.mesh.Interpolator
+import scalismo.numerics.ValueInterpolator
 
 import scala.annotation.switch
 
@@ -173,7 +173,7 @@ object RGBA {
     override val dimensionality = 4
   }
 
-  implicit object RGBAInterpolator extends Interpolator[RGBA] {
+  implicit object RGBAInterpolator extends ValueInterpolator[RGBA] {
     override def blend(obj1: RGBA, obj2: RGBA, l: Double): RGBA = RGBA(
       obj1.r * l + (1.0 - l) * obj2.r,
       obj1.g * l + (1.0 - l) * obj2.g,

--- a/src/main/scala/scalismo/color/RGBA.scala
+++ b/src/main/scala/scalismo/color/RGBA.scala
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2016 University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.color
+
+import java.awt.Color
+
+import breeze.linalg.DenseVector
+import scalismo.common.{ComponentRepresentation, Vectorizer}
+import scalismo.mesh.Interpolator
+
+import scala.annotation.switch
+
+case class RGBA(r: Double, g: Double, b: Double, a: Double) {
+
+  def isInBounds: Boolean = r >= 0.0 && r <= 1.0 && g >= 0.0 && g <= 1.0 && b >= 0.0 && b <= 1.0 && a >= 0.0 && a <= 1.0
+
+  /** clamp all values to valid range [0, 1] */
+  def clamped: RGBA = {
+    def clamp(f: Double): Double = math.min(1.0, math.max(0.0, f))
+    if (!isInBounds)
+      RGBA(clamp(r), clamp(g), clamp(b), clamp(a))
+    else
+      this
+  }
+
+  /** average intensity value */
+  def gray: Double = (r + g + b) / 3.0
+
+  /** applies f to all channels */
+  def map(f: Double => Double): RGBA = new RGBA(f(r), f(g), f(b), f(a))
+
+  /** addition */
+  def +(other: RGBA): RGBA = RGBA(r + other.r, g + other.g, b + other.b, a + other.a)
+
+  /** subtraction */
+  def -(other: RGBA): RGBA = RGBA(r - other.r, g - other.g, b - other.b, a - other.a)
+
+  /** scaling */
+  def *(f: Double): RGBA = RGBA(r * f, g * f, b * f, a * f)
+
+  /** scaling with scalar number */
+  def *:(f: Double): RGBA = new RGBA(r * f, g * f, b * f, a * f)
+
+  /** scaling */
+  def /(f: Double): RGBA = this * (1.0 / f)
+
+  /** dot product */
+  def dot(other: RGBA): Double = r * other.r + g * other.g + b * other.b + a * other.a
+
+  /** component-wise multiplication */
+  def x(other: RGBA): RGBA = RGBA(r * other.r, g * other.g, b * other.b, a * other.a)
+
+  /** component-wise division */
+  def /(other: RGBA): RGBA = RGBA(r / other.r, g / other.g, b / other.b, a / other.a)
+
+  /** convert to RGB */
+  def toRGB: RGB = RGB(r, g, b)
+
+  /** convert to Tuple */
+  def toTuple: (Double, Double, Double, Double) = (r, g, b, a)
+
+  /** apply an operation to RGB part, keep alpha channel */
+  def mapRGB(f: RGB => RGB): RGBA = RGBA(f(toRGB), a)
+
+  /** remove transparency */
+  def noAlpha: RGBA = copy(a = 1.0)
+
+  /** treat non-opaque pixels as not available */
+  def toOptionRGB: Option[RGB] = if (a > 0.99) Some(toRGB) else None
+
+  /** blending of two colors: this over that (see "over" in alpha blending) */
+  def over(that: RGBA): RGBA = {
+    val ma = 1.0 - a
+    val ao = a + that.a * ma
+    RGBA(
+      r * a + that.r * that.a * ma,
+      g * a + that.g * that.a * ma,
+      b * a + that.b * that.a * ma,
+      ao
+    )
+  }
+
+  /** convert to AWT default color
+    * expects a clamped color value */
+  def toAWTColor: Color = new java.awt.Color(r.toFloat, g.toFloat, b.toFloat, a.toFloat)
+}
+
+object RGBA {
+
+  val White: RGBA = RGBA(1.0, 1.0, 1.0, 1.0)
+  val Black: RGBA = RGBA(0.0, 0.0, 0.0, 1.0)
+
+  val WhiteTransparent: RGBA = RGBA(1.0, 1.0, 1.0, 0.0)
+  val BlackTransparent: RGBA = RGBA(0.0, 0.0, 0.0, 0.0)
+
+  def apply(color: RGB): RGBA = new RGBA(color.r, color.g, color.b, 1.0)
+  def apply(color: RGB, a: Double): RGBA = new RGBA(color.r, color.g, color.b, a)
+  def apply(r: Double, g: Double, b: Double): RGBA = new RGBA(r, g, b, 1.0)
+  def apply(gray: Double): RGBA = new RGBA(gray, gray, gray, 1.0)
+  def apply(gray: Double, a: Double): RGBA = new RGBA(gray, gray, gray, a)
+  def apply(tuple: (Double, Double, Double, Double)) = new RGBA(tuple._1, tuple._2, tuple._3, tuple._4)
+  def apply(awtColor: Color): RGBA = RGBA(fromInt8(awtColor.getRed), fromInt8(awtColor.getGreen), fromInt8(awtColor.getBlue), fromInt8(awtColor.getAlpha))
+
+  /** implementation of the Vectorizer interface for RGBA */
+  implicit object RGBAComponents extends ComponentRepresentation[RGBA] with Vectorizer[RGBA] {
+    override def fromArray(arr: Array[Double]): RGBA = {
+      require(arr.length == size)
+      RGBA(arr(0), arr(1), arr(2), arr(3))
+    }
+
+    override def toArray(color: RGBA): Array[Double] = Array(color.r, color.g, color.b, color.a)
+
+    override def intoArray(color: RGBA, array: Array[Double]): Array[Double] = {
+      require(array.length == 4)
+      array(0) = color.r
+      array(1) = color.g
+      array(2) = color.b
+      array(3) = color.a
+      array
+    }
+
+    override val size: Int = 4
+
+    override def component(color: RGBA, index: Int): Double = (index: @switch) match {
+      case 0 => color.r
+      case 1 => color.g
+      case 2 => color.b
+      case 3 => color.a
+      case _ => throw new Exception(s"invalid index ($index) in RGBA vectorizer")
+    }
+
+    override def fromComponents(comp: (Int) => Double): RGBA = RGBA(comp(0), comp(1), comp(2), comp(3))
+
+    override def dim: Int = 4
+
+    override def vectorize(v: RGBA): DenseVector[Double] = DenseVector(v.r, v.g, v.b, v.a)
+
+    override def unvectorize(d: DenseVector[Double]): RGBA = RGBA(d(0), d(1), d(2), d(3))
+  }
+
+  implicit object RGBAOperations extends ColorSpaceOperations[RGBA] {
+    /** add two pixels */
+    override def add(pix1: RGBA, pix2: RGBA): RGBA = pix1 + pix2
+
+    /** scalar multiplication */
+    override def scale(pix: RGBA, l: Double): RGBA = pix * l
+
+    /** dot product */
+    override def dot(pix1: RGBA, pix2: RGBA): Double = pix1 dot pix2
+
+    /** channel-wise multiplication */
+    override def multiply(pix1: RGBA, pix2: RGBA): RGBA = pix1 x pix2
+
+    /** zero element */
+    override def zero: RGBA = BlackTransparent
+
+    override val dimensionality = 4
+  }
+
+  implicit object RGBAInterpolator extends Interpolator[RGBA] {
+    override def blend(obj1: RGBA, obj2: RGBA, l: Double): RGBA = RGBA(
+      obj1.r * l + (1.0 - l) * obj2.r,
+      obj1.g * l + (1.0 - l) * obj2.g,
+      obj1.b * l + (1.0 - l) * obj2.b,
+      obj1.a * l + (1.0 - l) * obj2.a
+    )
+
+    override def average(first: RGBA, rest: RGBA*): RGBA = {
+      var r = first.r
+      var g = first.g
+      var b = first.b
+      var a = first.a
+      rest.foreach { c =>
+        r += c.r
+        g += c.g
+        b += c.b
+        a += c.a
+      }
+      val n = rest.size + 1.0
+      RGBA(r / n, g / n, b / n, a / n)
+    }
+
+    override def barycentricInterpolation(v1: RGBA, f1: Double, v2: RGBA, f2: Double, v3: RGBA, f3: Double): RGBA = {
+      RGBA(
+        v1.r * f1 + v2.r * f2 + v3.r * f3,
+        v1.g * f1 + v2.g * f2 + v3.g * f3,
+        v1.b * f1 + v2.b * f2 + v3.b * f3,
+        v1.a * f1 + v2.a * f2 + v3.a * f3)
+    }
+  }
+
+  private def toInt8(value: Double): Int = (value * 255.0).toInt
+
+  private def fromInt8(intValue: Int): Double = intValue / 255.0
+}

--- a/src/main/scala/scalismo/color/RGBA.scala
+++ b/src/main/scala/scalismo/color/RGBA.scala
@@ -19,7 +19,7 @@ package scalismo.color
 import java.awt.Color
 
 import breeze.linalg.DenseVector
-import scalismo.common.{ComponentRepresentation, Vectorizer}
+import scalismo.common.{ ComponentRepresentation, Vectorizer }
 import scalismo.mesh.Interpolator
 
 import scala.annotation.switch
@@ -94,8 +94,10 @@ case class RGBA(r: Double, g: Double, b: Double, a: Double) {
     )
   }
 
-  /** convert to AWT default color
-    * expects a clamped color value */
+  /**
+   * convert to AWT default color
+   * expects a clamped color value
+   */
   def toAWTColor: Color = new java.awt.Color(r.toFloat, g.toFloat, b.toFloat, a.toFloat)
 }
 

--- a/src/main/scala/scalismo/common/ComponentRepresentation.scala
+++ b/src/main/scala/scalismo/common/ComponentRepresentation.scala
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2016 University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package scalismo.common
+
+import scalismo.geometry.{Vector, _2D, _3D}
+
+import scala.annotation.switch
+
+/** Vectorizer linearize an object to and from an Array */
+trait ComponentRepresentation[A] {
+
+  /** Length of array linked to type T */
+  val size: Int
+
+  /** access specific components directly, with slow default */
+  def component(color: A, index: Int): Double
+
+  /** Create an instance from an array */
+  def fromArray(arr: Array[Double]): A
+
+  def fromComponents(comp: Int => Double): A
+
+  /** Generate a new array for instance */
+  def toArray(color: A): Array[Double] = intoArray(color, new Array[Double](size))
+
+  /** vectorize into an existing array, returns array */
+  def intoArray(color: A, array: Array[Double]): Array[Double] = {
+    require(array.length >= size, "target Array is too small")
+    var i = 0
+    while (i < size) {
+      array(i) = component(color, i)
+      i += 1
+    }
+    array
+  }
+}
+
+object ComponentRepresentation {
+
+  def apply[A](implicit vec: ComponentRepresentation[A]): ComponentRepresentation[A] = vec
+
+  implicit object VectorComponents2D extends ComponentRepresentation[Vector[_2D]] {
+    override def fromArray(arr: Array[Double]): Vector[_2D] = Vector(arr(0), arr(1))
+    override def toArray(value: Vector[_2D]): Array[Double] = Array(value.x, value.y)
+    override val size: Int = 2
+    override def intoArray(vec: Vector[_2D], array: Array[Double]): Array[Double] = {
+      require(array.length >= size)
+      array(0) = vec.x
+      array(1) = vec.y
+      array
+    }
+    override def component(color: Vector[_2D], index: Int): Double = (index: @switch) match {
+      case 0 => color.x
+      case 1 => color.y
+      case _ => throw new Exception(s"index ($index) out of bounds, Vector[_2D] can only handle 0 and 1")
+    }
+
+    override def fromComponents(comp: (Int) => Double): Vector[_2D] = Vector(comp(0), comp(1))
+  }
+
+  implicit object VectorComponents3D extends ComponentRepresentation[Vector[_3D]] {
+    override def fromArray(arr: Array[Double]): Vector[_3D] = Vector(arr(0), arr(1), arr(2))
+    override def toArray(value: Vector[_3D]): Array[Double] = Array(value.x, value.y, value.z)
+    override val size: Int = 3
+    override def intoArray(vec: Vector[_3D], array: Array[Double]): Array[Double] = {
+      require(array.length >= size)
+      array(0) = vec.x
+      array(1) = vec.y
+      array(2) = vec.z
+      array
+    }
+    override def component(color: Vector[_3D], index: Int): Double = (index: @switch) match {
+      case 0 => color.x
+      case 1 => color.y
+      case 2 => color.z
+      case _ => throw new Exception(s"index ($index) out of bounds, Vector[_3D] can only handle 0, 1 and 2")
+    }
+    override def fromComponents(comp: (Int) => Double): Vector[_3D] = Vector(comp(0), comp(1), comp(2))
+  }
+}

--- a/src/main/scala/scalismo/common/ComponentRepresentation.scala
+++ b/src/main/scala/scalismo/common/ComponentRepresentation.scala
@@ -16,7 +16,7 @@
 
 package scalismo.common
 
-import scalismo.geometry.{Vector, _2D, _3D}
+import scalismo.geometry.{ Vector, _2D, _3D }
 
 import scala.annotation.switch
 

--- a/src/main/scala/scalismo/io/MeshIO.scala
+++ b/src/main/scala/scalismo/io/MeshIO.scala
@@ -15,10 +15,10 @@
  */
 package scalismo.io
 
-import java.io.{File, IOException}
+import java.io.{ File, IOException }
 
-import scalismo.color.RGBA
-import scalismo.common.{PointId, Scalar, UnstructuredPointsDomain}
+import scalismo.color.{ RGB, RGBA }
+import scalismo.common.{ PointId, Scalar, UnstructuredPointsDomain }
 import scalismo.geometry._
 import scalismo.mesh._
 import scalismo.geometry.Point._
@@ -29,7 +29,7 @@ import vtk._
 
 import scala.reflect.ClassTag
 import scala.reflect.runtime.universe.TypeTag
-import scala.util.{Failure, Success, Try}
+import scala.util.{ Failure, Success, Try }
 
 object MeshIO {
   /**
@@ -139,6 +139,7 @@ object MeshIO {
       case f if f.endsWith(".h5") => writeHDF5(mesh, file)
       case f if f.endsWith(".vtk") => writeVTK(mesh, file)
       case f if f.endsWith(".stl") => writeSTL(mesh, file)
+      case f if f.endsWith(".ply") => writePLY(mesh, file)
       case _ =>
         Failure(new IOException("Unknown file type received" + filename))
     }
@@ -191,6 +192,45 @@ object MeshIO {
     val err = writeVTKPdAsSTL(vtkPd, file)
     vtkPd.Delete()
     err
+  }
+
+  def writePLY(surface: TriangleMesh[_3D], file: File): Try[Unit] = {
+    val vtkPd = MeshConversion.meshToVtkPolyData(surface)
+
+    surface match {
+      case colorMesh: VertexColorMesh3D => {
+
+        val vtkColors = new vtkUnsignedCharArray()
+        vtkColors.SetNumberOfComponents(3);
+
+        // Add the three colors we have created to the array
+        for (id <- colorMesh.pointSet.pointIds) {
+          val color = colorMesh.color(id)
+          vtkColors.InsertNextTuple3((color.r * 255).toShort, (color.g * 255).toShort, (color.b * 255).toShort)
+        }
+        vtkColors.SetName("RGB")
+        vtkPd.GetPointData().SetScalars(vtkColors)
+
+      }
+      case _ => {}
+    }
+    val writer = new vtkPLYWriter()
+    writer.SetFileName(file.getAbsolutePath)
+    writer.SetArrayName("RGB")
+    writer.SetComponent(0)
+    writer.SetInputData(vtkPd)
+    writer.SetColorModeToDefault()
+    writer.SetFileTypeToBinary()
+    writer.Update()
+
+    val succOrFailure = if (writer.GetErrorCode() != 0) {
+      Failure(new IOException(s"could not write file ${file.getAbsolutePath} (received error code ${writer.GetErrorCode})"))
+    } else {
+      Success(())
+    }
+    writer.Delete()
+    vtkPd.Delete()
+    succOrFailure
   }
 
   private def writeVTKPdasVTK(vtkPd: vtkPolyData, file: File): Try[Unit] = {
@@ -289,36 +329,45 @@ object MeshIO {
     }
 
     val vtkPd = plyReader.GetOutput()
-    val meshGeometry = MeshConversion.vtkPolyDataToTriangleMesh(vtkPd)
 
-    // FIXME should be depending on the array
-    val mesh = vtkPd.GetPointData().GetArrayName(0) match {
-      case "RGBA" => {
-        val s = vtkPd.GetPointData().GetArray(0)
-        val colors = for (i <- 0 until s.GetNumberOfTuples()) yield {
-          val rgba = s.GetTuple4(i)
-          RGBA(rgba(0), rgba(1), rgba(2), rgba(3))
+    val mesh = for {
+      meshGeometry <- MeshConversion.vtkPolyDataToTriangleMesh(vtkPd)
+    } yield {
+      getColorArray(vtkPd) match {
+        case Some(("RGBA", colorArray)) => {
+          val colors = for (i <- 0 until colorArray.GetNumberOfTuples()) yield {
+            val rgba = colorArray.GetTuple4(i)
+            RGBA(rgba(0) / 255.0, rgba(1) / 255.0, rgba(2) / 255.0, rgba(3))
+          }
+          VertexColorMesh3D(meshGeometry, new SurfacePointProperty[RGBA](meshGeometry.triangulation, colors))
         }
-        // FIXME this should not be a get
-        VertexColorMesh3D(meshGeometry.get, new SurfacePointProperty[RGBA](meshGeometry.get.triangulation, colors.toIndexedSeq))
-      }
-      case "RGB" => {
-        val s = vtkPd.GetPointData().GetArray(0)
-        val colors = for (i <- 0 until s.GetNumberOfTuples()) yield {
-          val rgba = s.GetTuple3(i)
-          RGBA(rgba(0), rgba(1), rgba(2), 1.0)
+        case Some(("RGB", colorArray)) => {
+          val colors = for (i <- 0 until colorArray.GetNumberOfTuples()) yield {
+            val rgb = colorArray.GetTuple3(i)
+            RGBA(RGB(rgb(0) / 255.0, rgb(1) / 255.0, rgb(2) / 255.0))
+          }
+          VertexColorMesh3D(meshGeometry, new SurfacePointProperty[RGBA](meshGeometry.triangulation, colors))
         }
-        // FIXME this should not be a get
-        VertexColorMesh3D(meshGeometry.get, new SurfacePointProperty[RGBA](meshGeometry.get.triangulation, colors.toIndexedSeq))
+        case Some(_) => meshGeometry
+        case None => meshGeometry
       }
-      case _ => meshGeometry.get
     }
-
     plyReader.Delete()
     vtkPd.Delete()
-    Success(mesh)
+
+    mesh
   }
 
+  private def getColorArray(polyData: vtkPolyData): Option[(String, vtkDataArray)] = {
+    if (polyData.GetPointData() == null || polyData.GetPointData().GetNumberOfArrays() == 0) None
+    else {
+      val pointData = polyData.GetPointData()
+      val pointDataArrays = for (i <- 0 until pointData.GetNumberOfArrays()) yield {
+        (pointData.GetArrayName(i), pointData.GetArray(i))
+      }
+      pointDataArrays.find { case (name, array) => name == "RGB" || name == "RGBA" }
+    }
+  }
 
   def readHDF5(file: File): Try[TriangleMesh[_3D]] = {
 

--- a/src/main/scala/scalismo/mesh/TriangleMesh.scala
+++ b/src/main/scala/scalismo/mesh/TriangleMesh.scala
@@ -15,9 +15,11 @@
  */
 package scalismo.mesh
 
+import scalismo.color.RGBA
 import scalismo.common._
 import scalismo.geometry._
 import scalismo.geometry.Vector._
+import scalismo.registration.Transformation
 import scalismo.utils.Random
 
 import scala.language.implicitConversions
@@ -198,6 +200,28 @@ object TriangleMesh3D {
     TriangleMesh3D(UnstructuredPointsDomain(points.toIndexedSeq), topology)
   }
 }
+
+
+/**
+  * colored mesh with color per vertex
+  */
+case class VertexColorMesh3D(pointSet : UnstructuredPointsDomain[_3D],
+                             triangulation : TriangleList,
+                             color: SurfacePointProperty[RGBA]) extends TriangleMesh[_3D] {
+
+  require(this.triangulation == color.triangulation)
+
+  override def transform(transform: (Point[_3D]) => Point[_3D]): VertexColorMesh3D = {
+    copy(pointSet = pointSet.transform(transform))
+  }
+}
+
+object VertexColorMesh3D {
+  def apply(triangleMesh : TriangleMesh[_3D], color : SurfacePointProperty[RGBA]) : VertexColorMesh3D = {
+    VertexColorMesh3D(triangleMesh.pointSet, triangleMesh.triangulation, color)
+  }
+}
+
 
 case class TriangleMesh2D(pointSet: UnstructuredPointsDomain[_2D], triangulation: TriangleList) extends TriangleMesh[_2D] {
   val position = SurfacePointProperty(triangulation, pointSet.points.toIndexedSeq)

--- a/src/main/scala/scalismo/mesh/TriangleMesh.scala
+++ b/src/main/scala/scalismo/mesh/TriangleMesh.scala
@@ -201,13 +201,12 @@ object TriangleMesh3D {
   }
 }
 
-
 /**
-  * colored mesh with color per vertex
-  */
-case class VertexColorMesh3D(pointSet : UnstructuredPointsDomain[_3D],
-                             triangulation : TriangleList,
-                             color: SurfacePointProperty[RGBA]) extends TriangleMesh[_3D] {
+ * colored mesh with color per vertex
+ */
+case class VertexColorMesh3D(pointSet: UnstructuredPointsDomain[_3D],
+    triangulation: TriangleList,
+    color: SurfacePointProperty[RGBA]) extends TriangleMesh[_3D] {
 
   require(this.triangulation == color.triangulation)
 
@@ -217,11 +216,10 @@ case class VertexColorMesh3D(pointSet : UnstructuredPointsDomain[_3D],
 }
 
 object VertexColorMesh3D {
-  def apply(triangleMesh : TriangleMesh[_3D], color : SurfacePointProperty[RGBA]) : VertexColorMesh3D = {
+  def apply(triangleMesh: TriangleMesh[_3D], color: SurfacePointProperty[RGBA]): VertexColorMesh3D = {
     VertexColorMesh3D(triangleMesh.pointSet, triangleMesh.triangulation, color)
   }
 }
-
 
 case class TriangleMesh2D(pointSet: UnstructuredPointsDomain[_2D], triangulation: TriangleList) extends TriangleMesh[_2D] {
   val position = SurfacePointProperty(triangulation, pointSet.points.toIndexedSeq)


### PR DESCRIPTION
This PR shows my initial efforts to support VertexColor in Scalismo, by moving concepts from scalismo-faces into Scalismo. The PR is meant as a platform to continue the discussion started in issue #235.

In this version, the VTK PLYReader is used, instead of the one from scalismo-faces. The reason for this is that using the PLY Reader from scalismo-faces would require to port also all the concepts related to texture. If we want to do this, and whether such an integration makes sense is up for discussion.