### PR TITLE
fixed most compiler warnings

### DIFF
--- a/src/main/scala/scalismo/color/RGB.scala
+++ b/src/main/scala/scalismo/color/RGB.scala
@@ -194,7 +194,7 @@ object RGB {
     }
   }
 
-  private def toInt8(value: Double): Int = (value * 255.0).toInt
+  //private def toInt8(value: Double): Int = (value * 255.0).toInt
 
   private def fromInt8(intValue: Int): Double = intValue / 255.0
 }

--- a/src/main/scala/scalismo/color/RGBA.scala
+++ b/src/main/scala/scalismo/color/RGBA.scala
@@ -205,7 +205,7 @@ object RGBA {
     }
   }
 
-  private def toInt8(value: Double): Int = (value * 255.0).toInt
+  //private def toInt8(value: Double): Int = (value * 255.0).toInt
 
   private def fromInt8(intValue: Int): Double = intValue / 255.0
 }

--- a/src/main/scala/scalismo/common/DiscreteField.scala
+++ b/src/main/scala/scalismo/common/DiscreteField.scala
@@ -71,9 +71,9 @@ class DiscreteField[D <: Dim, +DDomain <: DiscreteDomain[D], A](val domain: DDom
 object DiscreteField {
   def apply[D <: Dim, DDomain <: DiscreteDomain[D], A](domain: DDomain, data: IndexedSeq[A]): DiscreteField[D, DDomain, A] = new DiscreteField[D, DDomain, A](domain, data)
 
+
   private[scalismo] def createFromDenseVector[D <: Dim, DDomain <: DiscreteDomain[D], A](domain: DDomain, d: DenseVector[Double])(implicit vectorizer: Vectorizer[A]) = {
     val dim = vectorizer.dim
-    val nElem = d.length / dim
     val data = d.toArray.grouped(dim).map(e => vectorizer.unvectorize(DenseVector(e))).toIndexedSeq
     new DiscreteField[D, DDomain, A](domain, data)
   }

--- a/src/main/scala/scalismo/common/Field.scala
+++ b/src/main/scala/scalismo/common/Field.scala
@@ -16,7 +16,6 @@
 package scalismo.common
 
 import scalismo.geometry._
-import spire.math.Numeric
 
 import scala.reflect.ClassTag
 

--- a/src/main/scala/scalismo/geometry/Dim.scala
+++ b/src/main/scala/scalismo/geometry/Dim.scala
@@ -15,7 +15,6 @@
  */
 package scalismo.geometry
 
-import scalismo.mesh.{ TriangleMesh, LineMesh$ }
 
 /** a marker trait only meant to distinguish the dimension */
 sealed trait Dim

--- a/src/main/scala/scalismo/geometry/IntVector.scala
+++ b/src/main/scala/scalismo/geometry/IntVector.scala
@@ -16,10 +16,9 @@
 package scalismo.geometry
 
 import breeze.linalg.DenseVector
-import spire.algebra.{ Rng, Field }
+import spire.algebra.{ Rng }
 
 import scala.language.implicitConversions
-import scala.reflect.ClassTag
 
 sealed abstract class IntVector[D <: Dim: NDSpace] {
   def apply(a: Int): Int
@@ -110,7 +109,7 @@ object IntVector {
   def apply(x: Int, y: Int): IntVector2D = IntVector2D(x, y)
   def apply(x: Int, y: Int, z: Int): IntVector3D = IntVector3D(x, y, z)
 
-  def zeros[D <: Dim: NDSpace](implicit builder: Create[D]) = {
+  def zeros[D <: Dim: NDSpace] = {
     IntVector(Array.fill(NDSpace[D].dimensionality)(0))
   }
 

--- a/src/main/scala/scalismo/geometry/Landmark.scala
+++ b/src/main/scala/scalismo/geometry/Landmark.scala
@@ -15,8 +15,6 @@
  */
 package scalismo.geometry
 
-import breeze.linalg.DenseVector
-import scalismo.io.LandmarkIO
 import scalismo.registration.Transformation
 import scalismo.statisticalmodel.MultivariateNormalDistribution
 

--- a/src/main/scala/scalismo/geometry/Point.scala
+++ b/src/main/scala/scalismo/geometry/Point.scala
@@ -161,7 +161,7 @@ object Point {
 
   def origin[D <: Dim: NDSpace](implicit builder: Create[D]) = builder.createPoint(Array.fill(NDSpace[D].dimensionality)(0.0))
 
-  def fromBreezeVector[D <: Dim: NDSpace](breeze: DenseVector[Double])(implicit builder: Create[D]): Point[D] = {
+  def fromBreezeVector[D <: Dim: NDSpace](breeze: DenseVector[Double]): Point[D] = {
     val dim = NDSpace[D].dimensionality
     require(breeze.size == dim, s"Invalid size of breeze vector (${breeze.size} != $dim)")
     Point.apply[D](breeze.data)

--- a/src/main/scala/scalismo/geometry/Vector.scala
+++ b/src/main/scala/scalismo/geometry/Vector.scala
@@ -240,7 +240,7 @@ object Vector {
 
   def zeros[D <: Dim: NDSpace](implicit builder: Create[D]): Vector[D] = builder.zero
 
-  def fromBreezeVector[D <: Dim: NDSpace](breeze: DenseVector[Double])(implicit builder: Create[D]): Vector[D] = {
+  def fromBreezeVector[D <: Dim: NDSpace](breeze: DenseVector[Double]): Vector[D] = {
     val dim = implicitly[NDSpace[D]].dimensionality
     require(breeze.size == dim, s"Invalid size of breeze vector (${breeze.size} != $dim)")
     Vector.apply[D](breeze.data)

--- a/src/main/scala/scalismo/image/DiscreteImageDomain.scala
+++ b/src/main/scala/scalismo/image/DiscreteImageDomain.scala
@@ -157,18 +157,18 @@ abstract class DiscreteImageDomain[D <: Dim: NDSpace] extends DiscreteDomain[D] 
 object DiscreteImageDomain {
 
   /** Create a new discreteImageDomain with given origin, spacing and size*/
-  def apply[D <: Dim](origin: Point[D], spacing: Vector[D], size: IntVector[D])(implicit evDim: NDSpace[D], evCreate: CreateDiscreteImageDomain[D]) = {
+  def apply[D <: Dim](origin: Point[D], spacing: Vector[D], size: IntVector[D])(implicit evCreate: CreateDiscreteImageDomain[D]) = {
     evCreate.createImageDomain(origin, spacing, size)
   }
 
   /** Create a new discreteImageDomain with given image box (i.e. a box that determines the area where the image is defined) and size */
-  def apply[D <: Dim](imageBox: BoxDomain[D], size: IntVector[D])(implicit evDim: NDSpace[D], evCreate: CreateDiscreteImageDomain[D]): DiscreteImageDomain[D] = {
+  def apply[D <: Dim](imageBox: BoxDomain[D], size: IntVector[D])(implicit evCreate: CreateDiscreteImageDomain[D]): DiscreteImageDomain[D] = {
     val spacing = imageBox.extent.mapWithIndex({ case (ithExtent, i) => ithExtent / size(i) })
     evCreate.createImageDomain(imageBox.origin, spacing, size)
   }
 
   /** Create a new discreteImageDomain with given image box (i.e. a box that determines the area where the image is defined) and size */
-  def apply[D <: Dim](imageBox: BoxDomain[D], spacing: Vector[D])(implicit evDim: NDSpace[D], evCreate: CreateDiscreteImageDomain[D]): DiscreteImageDomain[D] = {
+  def apply[D <: Dim : NDSpace](imageBox: BoxDomain[D], spacing: Vector[D])(implicit evCreate: CreateDiscreteImageDomain[D]): DiscreteImageDomain[D] = {
     val sizeFractional = imageBox.extent.mapWithIndex({ case (ithExtent, i) => ithExtent / spacing(i) })
     val size = IntVector.apply[D](sizeFractional.toArray.map(s => Math.ceil(s).toInt))
     evCreate.createImageDomain(imageBox.origin, spacing, size)
@@ -178,7 +178,7 @@ object DiscreteImageDomain {
    * Create a discreteImageDomain where the points are defined as transformations of the indices (from (0,0,0) to (size - 1, size - 1 , size -1)
    * This makes it possible to define image regions which are not aligned to the coordinate axis.
    */
-  private[scalismo] def apply[D <: Dim](size: IntVector[D], transform: AnisotropicSimilarityTransformation[D])(implicit evDim: NDSpace[D], evCreateRot: CreateDiscreteImageDomain[D]) = {
+  private[scalismo] def apply[D <: Dim](size: IntVector[D], transform: AnisotropicSimilarityTransformation[D])(implicit evCreateRot: CreateDiscreteImageDomain[D]) = {
     evCreateRot.createWithTransform(size, transform)
   }
 
@@ -251,8 +251,6 @@ case class DiscreteImageDomain1D(size: IntVector[_1D], indexToPhysicalCoordinate
 
 case class DiscreteImageDomain2D(size: IntVector[_2D], indexToPhysicalCoordinateTransform: AnisotropicSimilarityTransformation[_2D]) extends DiscreteImageDomain[_2D] {
 
-  private val inverseAnisotropicTransform = indexToPhysicalCoordinateTransform.inverse
-
   override val origin = {
     val p = indexToPhysicalCoordinateTransform(Point(0, 0))
     Point2D(p(0), p(1))
@@ -300,8 +298,6 @@ case class DiscreteImageDomain2D(size: IntVector[_2D], indexToPhysicalCoordinate
 }
 
 case class DiscreteImageDomain3D(size: IntVector[_3D], indexToPhysicalCoordinateTransform: AnisotropicSimilarityTransformation[_3D]) extends DiscreteImageDomain[_3D] {
-
-  private val inverseAnisotropicTransform = indexToPhysicalCoordinateTransform.inverse
 
   override val origin = {
     val p = indexToPhysicalCoordinateTransform(Point(0, 0, 0))

--- a/src/main/scala/scalismo/image/Image.scala
+++ b/src/main/scala/scalismo/image/Image.scala
@@ -21,11 +21,8 @@ import scalismo.geometry._
 import scalismo.numerics.Integrator
 import scalismo.registration.{ CanDifferentiate, Transformation }
 
-import scala.language.implicitConversions
 import scala.reflect.ClassTag
 import scalismo.numerics.GridSampler
-
-import scalismo.utils.Random
 
 /**
  * An image whose values are scalar.
@@ -80,7 +77,7 @@ class ScalarImage[D <: Dim: NDSpace] protected (override val domain: Domain[D], 
    * @param  numberOfPointsPerDim Number of points to be used to approximate the filter. Depending on the
    * support size of the filter and the Frequency of the image, increasing this value can help avoid artifacts (at the cost of heavier computation)
    */
-  def convolve(filter: Filter[D], numberOfPointsPerDim: Int)(implicit c: CreateDiscreteImageDomain[D], rng: Random): ScalarImage[D] = {
+  def convolve(filter: Filter[D], numberOfPointsPerDim: Int)(implicit c: CreateDiscreteImageDomain[D]): ScalarImage[D] = {
 
     val dim = implicitly[NDSpace[D]].dimensionality
     val supportSpacing = filter.support.extent * (1f / numberOfPointsPerDim.toFloat)
@@ -183,7 +180,7 @@ class DifferentiableScalarImage[D <: Dim: NDSpace](_domain: Domain[D], _f: Point
     new DifferentiableScalarImage(newDomain, f, df)
   }
 
-  override def convolve(filter: Filter[D], numberOfPointsPerDim: Int)(implicit c: CreateDiscreteImageDomain[D], rng: Random): DifferentiableScalarImage[D] = {
+  override def convolve(filter: Filter[D], numberOfPointsPerDim: Int)(implicit c: CreateDiscreteImageDomain[D]): DifferentiableScalarImage[D] = {
 
     val convolvedImage = super.convolve(filter, numberOfPointsPerDim)
 

--- a/src/main/scala/scalismo/io/FastReadOnlyNiftiVolume.scala
+++ b/src/main/scala/scalismo/io/FastReadOnlyNiftiVolume.scala
@@ -22,7 +22,7 @@ import java.nio.{ ByteBuffer, MappedByteBuffer }
 
 import scalismo.common.{ Scalar, ScalarArray }
 import scalismo.io.FastReadOnlyNiftiVolume.NiftiHeader
-import spire.math.{ UByte, UInt, ULong, UShort }
+import spire.math.{ UByte, UInt, UShort }
 
 import scala.reflect.ClassTag
 import scala.reflect.runtime.universe.{ TypeTag, typeOf }

--- a/src/main/scala/scalismo/io/LandmarkIO.scala
+++ b/src/main/scala/scalismo/io/LandmarkIO.scala
@@ -24,7 +24,7 @@ import spray.json.DefaultJsonProtocol._
 import spray.json._
 
 import scala.io.Source
-import scala.language.{ implicitConversions, reflectiveCalls }
+import scala.language.{ implicitConversions }
 import scala.util.{ Failure, Try }
 
 object LandmarkIO {

--- a/src/main/scala/scalismo/io/MeshIO.scala
+++ b/src/main/scala/scalismo/io/MeshIO.scala
@@ -21,9 +21,6 @@ import scalismo.color.{RGB, RGBA}
 import scalismo.common.{PointId, Scalar, UnstructuredPointsDomain}
 import scalismo.geometry._
 import scalismo.mesh._
-import scalismo.geometry.Point._
-import scalismo.geometry.Vector._
-import scalismo.io.MeshIO.getColorArray
 import scalismo.mesh.TriangleMesh._
 import scalismo.utils.MeshConversion
 import vtk._

--- a/src/main/scala/scalismo/io/StatismoIO.scala
+++ b/src/main/scala/scalismo/io/StatismoIO.scala
@@ -59,7 +59,6 @@ object StatismoIO {
    */
   def readModelCatalog(file: File): Try[ModelCatalog] = {
     import scala.collection.JavaConverters._
-    val filename = file.getAbsoluteFile
 
     def flatten[A](xs: Seq[Try[A]]): Try[Seq[A]] = Try(xs.map(_.get))
 
@@ -268,12 +267,6 @@ object StatismoIO {
     // the data in ndarray is stored row-major, but DenseMatrix stores it column major. We therefore
     // do switch dimensions and transpose
     DenseMatrix.create(array.dims(1).toInt, array.dims(0).toInt, array.data.map(_.toDouble)).t
-  }
-
-  private def ndDoubleArrayToDoubleMatrix(array: NDArray[Double])(implicit dummy: DummyImplicit): DenseMatrix[Double] = {
-    // the data in ndarray is stored row-major, but DenseMatrix stores it column major. We therefore
-    // do switch dimensions and transpose
-    DenseMatrix.create(array.dims(1).toInt, array.dims(0).toInt, array.data).t
   }
 
   private def ndIntArrayToIntMatrix(array: NDArray[Int]) = {

--- a/src/main/scala/scalismo/kernels/DiscreteMatrixValuedPDKernel.scala
+++ b/src/main/scala/scalismo/kernels/DiscreteMatrixValuedPDKernel.scala
@@ -18,7 +18,7 @@ package scalismo.kernels
 
 import breeze.linalg.DenseMatrix
 import scalismo.common.{ PointId, DiscreteDomain }
-import scalismo.geometry.{ NDSpace, Dim, SquareMatrix }
+import scalismo.geometry.{ NDSpace, Dim }
 
 /**
  *  Discrete representation of a MatrixValuedPDKernel.
@@ -51,8 +51,6 @@ class DiscreteMatrixValuedPDKernel[D <: Dim: NDSpace] private[scalismo] (
     val xs = domain.points.toIndexedSeq
 
     val K = DenseMatrix.zeros[Double](xs.size * outputDim, xs.size * outputDim)
-    val xiWithIndex = xs.zipWithIndex.par
-    val xjWithIndex = xs.zipWithIndex
     for { i <- xs.indices; j <- 0 to i } {
       val kxixj = k(PointId(i), PointId(j))
       var di = 0

--- a/src/main/scala/scalismo/mesh/Mesh.scala
+++ b/src/main/scala/scalismo/mesh/Mesh.scala
@@ -15,10 +15,10 @@
  */
 package scalismo.mesh
 
-import scalismo.common.{ PointId, RealSpace, UnstructuredPointsDomain }
+import scalismo.common.{ PointId, RealSpace }
 import scalismo.geometry._
 import scalismo.image.{ DifferentiableScalarImage, ScalarImage }
-import scalismo.mesh.boundingSpheres.{ SurfaceSpatialIndex, TriangleMesh3DSpatialIndex }
+import scalismo.mesh.boundingSpheres.{ TriangleMesh3DSpatialIndex }
 
 /**
  * Defines utility functions on [[TriangleMesh]] instances

--- a/src/main/scala/scalismo/mesh/MeshBoundaryPredicates.scala
+++ b/src/main/scala/scalismo/mesh/MeshBoundaryPredicates.scala
@@ -19,9 +19,6 @@ import breeze.linalg.CSCMatrix
 import scalismo.common.PointId
 import scalismo.geometry.Dim
 
-import scala.collection.mutable
-import scala.collection.Map
-
 /**
  * MeshBoundary is a property to test if points or an edge between two points is on the boundary of the mesh.
  */

--- a/src/main/scala/scalismo/mesh/MeshSurfaceProperty.scala
+++ b/src/main/scala/scalismo/mesh/MeshSurfaceProperty.scala
@@ -18,8 +18,6 @@ package scalismo.mesh
 import scalismo.common.PointId
 import scalismo.numerics.ValueInterpolator
 
-import scala.reflect.ClassTag
-
 /**
  * general property defined on the surface of a mesh
  * accessible through the parameterization given by the triangulation of the mesh: TriangleId and BarycentricCoordinates inside the triangle

--- a/src/main/scala/scalismo/mesh/VertexColorMesh3D.scala
+++ b/src/main/scala/scalismo/mesh/VertexColorMesh3D.scala
@@ -1,6 +1,6 @@
 package scalismo.mesh
 
-import scalismo.color.{ RGB, RGBA }
+import scalismo.color.{ RGBA }
 import scalismo.geometry.{ Point, _3D }
 
 /**

--- a/src/main/scala/scalismo/mesh/kdtree/Metric.scala
+++ b/src/main/scala/scalismo/mesh/kdtree/Metric.scala
@@ -65,7 +65,7 @@ private[scalismo] object Metric {
     }
   }
 
-  implicit def metricFromCoordVectorD[D <: Dim: NDSpace](implicit n: Numeric[Double]) = new Metric[Point[D], Double] {
+  implicit def metricFromCoordVectorD[D <: Dim: NDSpace] = new Metric[Point[D], Double] {
     val dim = implicitly[NDSpace[D]].dimensionality
     def distance(x: Point[D], y: Point[D]): Double = {
       var i = 0

--- a/src/main/scala/scalismo/mesh/kdtree/Region.scala
+++ b/src/main/scala/scalismo/mesh/kdtree/Region.scala
@@ -18,8 +18,6 @@ package scalismo.mesh.kdtree
 
 import scala.language.implicitConversions
 
-import scala.math.Ordering.Implicits._
-
 private[scalismo] sealed trait Region[A] {
   def overlapsWith(other: Region[A])(implicit ord: DimensionalOrdering[A]): Boolean
   def contains(p: A)(implicit ord: DimensionalOrdering[A]): Boolean

--- a/src/main/scala/scalismo/numerics/Integrator.scala
+++ b/src/main/scala/scalismo/numerics/Integrator.scala
@@ -19,7 +19,6 @@ import breeze.linalg.DenseVector
 import scalismo.common.VectorField
 import scalismo.image.ScalarImage
 import scalismo.geometry._
-import scalismo.utils.Random
 
 case class Integrator[D <: Dim: NDSpace](sampler: Sampler[D]) {
 

--- a/src/main/scala/scalismo/numerics/RandomSVD.scala
+++ b/src/main/scala/scalismo/numerics/RandomSVD.scala
@@ -15,11 +15,10 @@
  */
 package scalismo.numerics
 
-import breeze.linalg.qr.QR
 import breeze.linalg.svd.SVD
-import breeze.linalg.{ DenseMatrix, DenseVector, diag, norm }
+import breeze.linalg.{ DenseMatrix, DenseVector }
 import breeze.stats.distributions.Gaussian
-import scalismo.utils.{ Benchmark, Random }
+import scalismo.utils.{ Random }
 
 /**
  * Implementation of a Randomized approach for SVD,

--- a/src/main/scala/scalismo/numerics/Sampler.scala
+++ b/src/main/scala/scalismo/numerics/Sampler.scala
@@ -16,7 +16,6 @@
 package scalismo.numerics
 
 import breeze.stats.distributions.Uniform
-import org.apache.commons.math3.random.MersenneTwister
 import java.util
 
 import scalismo.common.BoxDomain

--- a/src/main/scala/scalismo/package.scala
+++ b/src/main/scala/scalismo/package.scala
@@ -14,10 +14,7 @@
  * limitations under the License.
  */
 
-import java.util.concurrent
-import java.util.concurrent.{ Executors, TimeUnit }
 import javax.swing.SwingUtilities
-
 import scalismo.support.nativelibs._
 import vtk.vtkObjectBase
 

--- a/src/main/scala/scalismo/registration/GaussianProcessTransformationSpace.scala
+++ b/src/main/scala/scalismo/registration/GaussianProcessTransformationSpace.scala
@@ -15,7 +15,7 @@
  */
 package scalismo.registration
 
-import scalismo.geometry.{ Dim, Point, Vector, _3D }
+import scalismo.geometry.{ Dim, Point, Vector }
 import scalismo.statisticalmodel.LowRankGaussianProcess
 import scalismo.statisticalmodel.LowRankGaussianProcess.Eigenpair
 import TransformationSpace.ParameterVector

--- a/src/main/scala/scalismo/registration/LandmarkRegistration.scala
+++ b/src/main/scala/scalismo/registration/LandmarkRegistration.scala
@@ -224,7 +224,7 @@ object LandmarkRegistration {
     (t, phi, s)
   }
 
-  private def computeRigidNDTransformParams[D <: Dim](landmarks: Seq[(Point[D], Point[D])], center: Point[D], similarityFlag: Boolean = false): (DenseVector[Double], DenseMatrix[Double], Double) = {
+  private def computeRigidNDTransformParams[D <: Dim](landmarks: Seq[(Point[D], Point[D])], center: Point[D], similarityFlag: Boolean): (DenseVector[Double], DenseMatrix[Double], Double) = {
 
     //  see Umeyama: Least squares estimation of transformation parameters between two point patterns
 

--- a/src/main/scala/scalismo/registration/MeanHuberLossMetric.scala
+++ b/src/main/scala/scalismo/registration/MeanHuberLossMetric.scala
@@ -19,7 +19,6 @@ package scalismo.registration
 import scalismo.geometry.{ Dim, NDSpace }
 import scalismo.image.{ DifferentiableScalarImage, ScalarImage }
 import scalismo.numerics._
-import scalismo.utils.Random
 
 /**
  * Image to image metric which applies the Huber Loss function to the pointwise pixel difference.

--- a/src/main/scala/scalismo/registration/MeanPointwiseLossMetric.scala
+++ b/src/main/scala/scalismo/registration/MeanPointwiseLossMetric.scala
@@ -22,7 +22,6 @@ import scalismo.geometry.{ Dim, NDSpace, Point }
 import scalismo.image.{ DifferentiableScalarImage, ScalarImage }
 import scalismo.numerics._
 import scalismo.registration.RegistrationMetric.ValueAndDerivative
-import scalismo.utils.Random
 
 /**
  * Image to image metric which applies a loss function to the pointwise pixel difference.

--- a/src/main/scala/scalismo/registration/MeanSquaresMetric.scala
+++ b/src/main/scala/scalismo/registration/MeanSquaresMetric.scala
@@ -16,13 +16,9 @@
 
 package scalismo.registration
 
-import breeze.linalg.DenseVector
-import scalismo.common.Domain
-import scalismo.geometry.{ Dim, NDSpace, Point }
+import scalismo.geometry.{ Dim, NDSpace }
 import scalismo.image.{ DifferentiableScalarImage, ScalarImage }
-import scalismo.numerics.{ Integrator, Sampler }
-import scalismo.registration.RegistrationMetric.ValueAndDerivative
-import scalismo.utils.Random
+import scalismo.numerics.{ Sampler }
 
 /**
  * The mean squares image to image metric.

--- a/src/main/scala/scalismo/registration/MutualInformationMetric.scala
+++ b/src/main/scala/scalismo/registration/MutualInformationMetric.scala
@@ -16,14 +16,13 @@
 
 package scalismo.registration
 
-import breeze.linalg.{ DenseMatrix, DenseVector, sum }
+import breeze.linalg.{ DenseVector }
 import breeze.numerics._
 import scalismo.geometry._
 import scalismo.image.{ DifferentiableScalarImage, DiscreteImageDomain, ScalarImage }
 import scalismo.numerics._
 import scalismo.registration.RegistrationMetric.ValueAndDerivative
-import scalismo.registration._
-import scalismo.utils.{ Benchmark, Memoize, Random }
+import scalismo.utils.{ Memoize, Random }
 
 /**
  * Implementation of the Mutual Information Metric, described in the following paper:
@@ -249,8 +248,6 @@ case class MutualInformationMetric[D <: Dim: NDSpace](fixedImage: ScalarImage[D]
   def derivative(params: DenseVector[Double]): DenseVector[Double] = {
 
     val samplePoints = sampler.sample().map(_._1)
-
-    val transform: Transformation[D] = transformationSpace.transformForParameters(params)
 
     /** creating and filling derivative vector (gradient) */
 

--- a/src/main/scala/scalismo/registration/Registration.scala
+++ b/src/main/scala/scalismo/registration/Registration.scala
@@ -17,11 +17,9 @@
 package scalismo.registration
 
 import TransformationSpace.ParameterVector
-import breeze.linalg.{ DenseVector, convert }
-import scalismo.geometry.{ _3D, Point, NDSpace, Dim }
-import scalismo.image.{ DifferentiableScalarImage, ScalarImage }
+import breeze.linalg.{ DenseVector }
+import scalismo.geometry.{ Dim }
 import scalismo.numerics._
-import scalismo.utils.Random
 
 /**
  * Implementation of a gradient-based registration algorithm, whose cost function is defined by the sum
@@ -35,7 +33,7 @@ import scalismo.utils.Random
 case class Registration[D <: Dim](metric: RegistrationMetric[D],
     regularizer: Regularizer[D],
     regularizationWeight: Double,
-    optimizer: Optimizer)(implicit rng: Random) {
+    optimizer: Optimizer) {
 
   /**
    * Representation of the current state of the registration.

--- a/src/main/scala/scalismo/registration/RegistrationMetric.scala
+++ b/src/main/scala/scalismo/registration/RegistrationMetric.scala
@@ -16,13 +16,9 @@
 
 package scalismo.registration
 
-import scalismo.common.Domain
 import scalismo.geometry._
 import scalismo.image.{ DifferentiableScalarImage, ScalarImage }
-import scalismo.numerics.{ Integrator, Sampler }
-import scalismo.utils.Random
 
-import scala.language.higherKinds
 import breeze.linalg.DenseVector
 import scalismo.registration.RegistrationMetric.ValueAndDerivative
 

--- a/src/main/scala/scalismo/registration/TransformationSpace.scala
+++ b/src/main/scala/scalismo/registration/TransformationSpace.scala
@@ -347,7 +347,7 @@ object RotationSpace {
    * Factory method to create a D dimensional parametric transformation space generating rotations around the indicated centre
    *  Only _2D and _3D dimensions are supported
    */
-  def apply[D <: Dim](centre: Point[D])(implicit evDim: NDSpace[D], evCreateRot: CreateRotationSpace[D]) = {
+  def apply[D <: Dim : NDSpace](centre: Point[D])(implicit evCreateRot: CreateRotationSpace[D]) = {
     evCreateRot.createRotationSpace(centre)
   }
 
@@ -492,7 +492,7 @@ object RotationTransform {
    *  Factory method to create a D-dimensional rotation transform given the rotation matrix and the rotation center.
    *  Only dimensions _2D and _3D are supported.
    */
-  def apply[D <: Dim](rotMatrix: SquareMatrix[D], centre: Point[D])(implicit evDim: NDSpace[D], evCreateRot: Create[D]) = {
+  def apply[D <: Dim : NDSpace](rotMatrix: SquareMatrix[D], centre: Point[D])(implicit evCreateRot: Create[D]) = {
     evCreateRot.createRotationTransform(rotMatrix, centre)
   }
 
@@ -500,7 +500,7 @@ object RotationTransform {
    *  Factory method to create a D-dimensional rotation transform around the origin.
    *  Only dimensions _2D and _3D are supported.
    */
-  def apply[D <: Dim](rotMatrix: SquareMatrix[D])(implicit evDim: NDSpace[D], evCreateRot: Create[D]) = {
+  def apply[D <: Dim : NDSpace](rotMatrix: SquareMatrix[D])(implicit  evCreateRot: Create[D]) = {
     val centre = Point[D](DenseVector.zeros[Double](implicitly[NDSpace[D]].dimensionality).data)
     evCreateRot.createRotationTransform(rotMatrix, centre)
   }

--- a/src/main/scala/scalismo/sampling/MarkovChain.scala
+++ b/src/main/scala/scalismo/sampling/MarkovChain.scala
@@ -15,8 +15,6 @@
  */
 package scalismo.sampling
 
-import scalismo.sampling.loggers.ChainStateLogger
-
 /** basic Markov Chain trait: provides a next sample */
 trait MarkovChain[A] {
   /** next sample in chain */

--- a/src/main/scala/scalismo/sampling/proposals/CombinedProposal.scala
+++ b/src/main/scala/scalismo/sampling/proposals/CombinedProposal.scala
@@ -16,12 +16,11 @@
 package scalismo.sampling.proposals
 
 import scalismo.sampling.{ ProposalGenerator, TransitionProbability }
-import scalismo.utils.Random
 
 /**
  * Container for multiple ProposalGenerators stacked together, applied one after the other
  */
-class CombinedProposal[A](val proposals: IndexedSeq[ProposalGenerator[A] with TransitionProbability[A]])(implicit rnd: Random)
+class CombinedProposal[A](val proposals: IndexedSeq[ProposalGenerator[A] with TransitionProbability[A]])
     extends ProposalGenerator[A] with TransitionProbability[A] {
 
   override def propose(current: A): A = {
@@ -45,5 +44,5 @@ class CombinedProposal[A](val proposals: IndexedSeq[ProposalGenerator[A] with Tr
 }
 
 object CombinedProposal {
-  def apply[A](proposals: IndexedSeq[(ProposalGenerator[A] with TransitionProbability[A])])(implicit rnd: Random) = new CombinedProposal[A](proposals)
+  def apply[A](proposals: IndexedSeq[(ProposalGenerator[A] with TransitionProbability[A])]) = new CombinedProposal[A](proposals)
 }

--- a/src/main/scala/scalismo/statisticalmodel/GaussianProcess.scala
+++ b/src/main/scala/scalismo/statisticalmodel/GaussianProcess.scala
@@ -17,7 +17,6 @@ package scalismo.statisticalmodel
 
 import breeze.linalg._
 import scalismo.common._
-import scalismo.geometry.Vector
 import scalismo.geometry._
 import scalismo.kernels._
 import scalismo.utils.Random

--- a/src/main/scala/scalismo/statisticalmodel/LowRankGaussianProcess.scala
+++ b/src/main/scala/scalismo/statisticalmodel/LowRankGaussianProcess.scala
@@ -19,9 +19,8 @@ import breeze.linalg.svd.SVD
 import breeze.linalg.{ DenseMatrix, DenseVector, diag }
 import breeze.stats.distributions.Gaussian
 import scalismo.common._
-import scalismo.geometry.{ Dim, NDSpace, Point, SquareMatrix, Vector }
+import scalismo.geometry.{ Dim, NDSpace, Point, Vector }
 import scalismo.kernels.{ Kernel, MatrixValuedPDKernel }
-import scalismo.numerics.PivotedCholesky.RelativeTolerance
 import scalismo.numerics.Sampler
 import scalismo.registration.RigidTransformation
 import scalismo.statisticalmodel.LowRankGaussianProcess.{ Eigenpair, KLBasis }
@@ -194,7 +193,7 @@ object LowRankGaussianProcess {
    */
   def approximateGP[D <: Dim: NDSpace, Value](gp: GaussianProcess[D, Value],
     sampler: Sampler[D],
-    numBasisFunctions: Int)(implicit vectorizer: Vectorizer[Value], rand: Random) = {
+    numBasisFunctions: Int)(implicit vectorizer: Vectorizer[Value]) = {
     val kltBasis: KLBasis[D, Value] = Kernel.computeNystromApproximation[D, Value](gp.cov, sampler)
     new LowRankGaussianProcess[D, Value](gp.mean, kltBasis.take(numBasisFunctions))
   }
@@ -208,7 +207,7 @@ object LowRankGaussianProcess {
    * @
    */
   def approximateGP[D <: Dim: NDSpace, Value](gp: GaussianProcess[D, Value],
-    sampler: Sampler[D])(implicit vectorizer: Vectorizer[Value], rand: Random) = {
+    sampler: Sampler[D])(implicit vectorizer: Vectorizer[Value]) = {
     val kltBasis: KLBasis[D, Value] = Kernel.computeNystromApproximation[D, Value](gp.cov, sampler)
     new LowRankGaussianProcess[D, Value](gp.mean, kltBasis)
   }

--- a/src/main/scala/scalismo/statisticalmodel/MultivariateNormalDistribution.scala
+++ b/src/main/scala/scalismo/statisticalmodel/MultivariateNormalDistribution.scala
@@ -69,9 +69,6 @@ case class MultivariateNormalDistribution(mean: DenseVector[Double], cov: DenseM
    */
   override def principalComponents: Seq[(DenseVector[Double], Double)] = {
     val SVD(uMat, sigma2s, utMat) = breeze.linalg.svd.reduced(cov.map(_.toDouble))
-    val sigma2spInv = sigma2s.map(s => if (s < 1e-6) 0 else 1.0 / s)
-    val sigmaMat = breeze.linalg.diag(sigma2s.map(math.sqrt))
-    val covInv = uMat * breeze.linalg.diag(sigma2spInv) * uMat.t
 
     for (i <- 0 until uMat.cols) yield {
       (uMat(::, i).toDenseVector, sigma2s(i))

--- a/src/main/scala/scalismo/statisticalmodel/asm/ActiveShapeModel.scala
+++ b/src/main/scala/scalismo/statisticalmodel/asm/ActiveShapeModel.scala
@@ -34,7 +34,7 @@ object ActiveShapeModel {
   /**
    * Train an active shape model using an existing PCA model
    */
-  def trainModel(statisticalModel: StatisticalMeshModel, trainingData: TrainingData, preprocessor: ImagePreprocessor, featureExtractor: FeatureExtractor, sampler: TriangleMesh[_3D] => Sampler[_3D])(implicit rand: Random): ActiveShapeModel = {
+  def trainModel(statisticalModel: StatisticalMeshModel, trainingData: TrainingData, preprocessor: ImagePreprocessor, featureExtractor: FeatureExtractor, sampler: TriangleMesh[_3D] => Sampler[_3D]): ActiveShapeModel = {
 
     val sampled = sampler(statisticalModel.referenceMesh).sample.map(_._1).to[immutable.IndexedSeq]
     val pointIds = sampled.map(statisticalModel.referenceMesh.pointSet.findClosestPoint(_).id)

--- a/src/main/scala/scalismo/statisticalmodel/dataset/Crossvalidation.scala
+++ b/src/main/scala/scalismo/statisticalmodel/dataset/Crossvalidation.scala
@@ -30,10 +30,6 @@ object Crossvalidation {
 
   type EvaluationFunction[A] = (StatisticalMeshModel, TriangleMesh[_3D]) => A
 
-  private def projectIntoModel(model: StatisticalMeshModel, mesh: TriangleMesh[_3D]): TriangleMesh[_3D] = {
-    model.project(mesh)
-  }
-
   /**
    * Perform a leave one out crossvalidation. See nFoldCrossvalidation for details
    */

--- a/src/main/scala/scalismo/statisticalmodel/dataset/DataCollection.scala
+++ b/src/main/scala/scalismo/statisticalmodel/dataset/DataCollection.scala
@@ -17,12 +17,11 @@ package scalismo.statisticalmodel.dataset
 
 import java.io.File
 
-import scalismo.common.{ RealSpace, UnstructuredPointsDomain }
 import scalismo.geometry._
 import scalismo.io.MeshIO
 import scalismo.mesh._
 import scalismo.registration.{ LandmarkRegistration, Transformation }
-import scalismo.utils.{ Memoize, Random }
+import scalismo.utils.{ Random }
 
 import scala.annotation.tailrec
 
@@ -153,7 +152,6 @@ object DataCollection {
     val referencePoints = dc.reference.pointSet.points.toIndexedSeq
     val numberOfPoints = referencePoints.size
     val referenceCenterOfMass = referencePoints.foldLeft(Point3D(0, 0, 0))((acc, pt) => acc + (pt.toVector / numberOfPoints))
-    val numberOfShapes = dc.size
 
     val meanShapePoints = meanShape.pointSet.points.toIndexedSeq
 

--- a/src/main/scala/scalismo/utils/Conversions.scala
+++ b/src/main/scala/scalismo/utils/Conversions.scala
@@ -167,8 +167,6 @@ object MeshConversion {
     val polys = newPd.GetPolys()
     val numPolys = polys.GetNumberOfCells()
 
-    val vtkType = newPd.GetPoints().GetDataType()
-
     val points = vtkConvertPoints[_3D](newPd)
 
     val idList = new vtkIdList()

--- a/src/main/scala/scalismo/utils/Random.scala
+++ b/src/main/scala/scalismo/utils/Random.scala
@@ -15,8 +15,7 @@
  */
 package scalismo.utils
 
-import breeze.stats.distributions.{ ThreadLocalRandomGenerator, RandBasis }
-import org.apache.commons.math3.random.MersenneTwister
+import breeze.stats.distributions.{ RandBasis }
 
 /**
  * A thin wrapper around different random number generators.

--- a/src/test/scala/scalismo/geometry/GeometryTests.scala
+++ b/src/test/scala/scalismo/geometry/GeometryTests.scala
@@ -21,8 +21,6 @@ import scalismo.registration._
 import scalismo.statisticalmodel.MultivariateNormalDistribution
 import scalismo.utils.Random
 
-import scala.language.implicitConversions
-
 class GeometryTests extends ScalismoTestSuite {
 
   implicit val random = Random(42L)
@@ -69,7 +67,6 @@ class GeometryTests extends ScalismoTestSuite {
       }
 
       it("can map a function p.map(f).map(g) == 0 (f: x => 2.0+x, g: x => x-2.0)") {
-        val z = Point[D](Array.fill(NDSpace[D].dimensionality)(0))
         val f = (x: Double) => 2.0 + x
         val g = (x: Double) => x - 2.0
         (pt.map(f).map(g) - pt).norm should be < 1e-4
@@ -124,7 +121,7 @@ class GeometryTests extends ScalismoTestSuite {
       }
 
       it("can map a function v.map(f).map(g) == 0 (f: x => 2.0+x, g: x => x-2.0)") {
-        val z = Vector[D](Array.fill(NDSpace[D].dimensionality)(0.0))
+
         val f = (x: Double) => 2.0 + x
         val g = (x: Double) => x - 2.0
         (v.map(f).map(g) - v).norm should be < 1e-4
@@ -226,7 +223,6 @@ class GeometryTests extends ScalismoTestSuite {
       }
 
       it("can map a function p.map(f).map(g) == 0 (f: x => 2 + x, g: x => x - 2)") {
-        val z = IntVector[D](Array.fill(NDSpace[D].dimensionality)(0))
         val f = (x: Int) => 2 + x
         val g = (x: Int) => x - 2
         ind.map(f).map(g) should equal(ind)

--- a/src/test/scala/scalismo/io/LandmarkIOTests.scala
+++ b/src/test/scala/scalismo/io/LandmarkIOTests.scala
@@ -18,7 +18,6 @@ package scalismo.io
 import java.io.{ ByteArrayOutputStream, File, InputStream }
 
 import breeze.linalg.DenseVector
-import breeze.math.MutableOptimizationSpace.DenseDoubleOptimizationSpace
 import scalismo.ScalismoTestSuite
 import scalismo.geometry._
 import scalismo.statisticalmodel.MultivariateNormalDistribution
@@ -42,8 +41,6 @@ class LandmarkIOTests extends ScalismoTestSuite {
     val jsonName = "/landmarks.json"
     def jsonStream() = getClass.getResourceAsStream(jsonName)
 
-    val jsonComplexName = "/landmarks2.json"
-    def jsonComplexStream() = getClass.getResourceAsStream(jsonComplexName)
     /*
      * LEGACY LANDMARKS (csv format)
      */

--- a/src/test/scala/scalismo/io/MeshIOTests.scala
+++ b/src/test/scala/scalismo/io/MeshIOTests.scala
@@ -22,7 +22,6 @@ import scalismo.common.{ Scalar, ScalarArray }
 import scalismo.geometry._3D
 import scalismo.mesh.{ ScalarMeshField, TriangleMesh }
 
-import scala.language.implicitConversions
 import scala.reflect.ClassTag
 import scala.reflect.runtime.universe.TypeTag
 import scala.util.{ Failure, Success, Try }

--- a/src/test/scala/scalismo/kernels/KernelTests.scala
+++ b/src/test/scala/scalismo/kernels/KernelTests.scala
@@ -15,14 +15,14 @@
  */
 package scalismo.kernels
 
-import scalismo.common.{ BoxDomain, Field, RealSpace, VectorField }
+import scalismo.common.{ BoxDomain, Field, RealSpace }
 import scalismo.geometry.Point.implicits._
 import scalismo.geometry.{ Point, Vector, _1D, _3D }
 import scalismo.numerics.UniformSampler
 import scalismo.registration.Transformation
 import scalismo.statisticalmodel.{ GaussianProcess, LowRankGaussianProcess }
 import scalismo.utils.Random
-import scalismo.{ ScalismoTestSuite, geometry }
+import scalismo.{ ScalismoTestSuite }
 
 class KernelTests extends ScalismoTestSuite {
 

--- a/src/test/scala/scalismo/mesh/MeshBoundaryTests.scala
+++ b/src/test/scala/scalismo/mesh/MeshBoundaryTests.scala
@@ -289,7 +289,6 @@ class MeshBoundaryTests extends ScalismoTestSuite {
 
         b.triangleIsOnBoundary(TriangleId(0)) shouldBe true
       }
-
     }
 
   }

--- a/src/test/scala/scalismo/mesh/MeshSurfaceDistanceTests.scala
+++ b/src/test/scala/scalismo/mesh/MeshSurfaceDistanceTests.scala
@@ -28,15 +28,15 @@ class MeshSurfaceDistanceTests extends ScalismoTestSuite {
 
   def rgen(offset: Double = 0.0, scale: Double = 1.0) = rnd.scalaRandom.nextDouble() * scale + offset
 
-  def randomPoint(offset: Double = 0.0, scale: Double = 1.0)(implicit rnd: Random): Point[_3D] = {
+  def randomPoint(offset: Double = 0.0, scale: Double = 1.0): Point[_3D] = {
     Point(rgen(offset, scale), rgen(offset, scale), rgen(offset, scale))
   }
 
-  def randomVector(offset: Double = 0.0, scale: Double = 1.0)(implicit rnd: Random): Vector[_3D] = {
+  def randomVector(offset: Double = 0.0, scale: Double = 1.0): Vector[_3D] = {
     Vector(rgen(offset, scale), rgen(offset, scale), rgen(offset, scale))
   }
 
-  private def randomTriangle(offset: Double = 0.0, scale: Double = 1.0): Triangle = {
+  private def randomTriangle(offset: Double, scale: Double): Triangle = {
     val a = randomVector(offset, scale)
     val b = randomVector(offset, scale)
     val c = randomVector(offset, scale)
@@ -291,8 +291,6 @@ class MeshSurfaceDistanceTests extends ScalismoTestSuite {
         val c = randomVector()
         Triangle(a, b, c, b - a, c - a, (b - a).crossproduct(c - a))
       }
-
-      val points = triangles.flatMap(t => Array(t.a.toPoint, t.b.toPoint, t.c.toPoint))
 
       val sd = DiscreteSpatialIndex.fromMesh(TriangleMesh3D(
         triangles.flatMap(t => Seq(t.a.toPoint, t.b.toPoint, t.c.toPoint)),

--- a/src/test/scala/scalismo/mesh/MeshTests.scala
+++ b/src/test/scala/scalismo/mesh/MeshTests.scala
@@ -81,7 +81,11 @@ class MeshTests extends ScalismoTestSuite {
     it("can have an empty cell list") {
       val pts = IndexedSeq(Point(0.0, 0.0, 0.0), Point(1.0, 1.0, 1.0), Point(1.0, 1.0, 5.0))
       val cells = IndexedSeq[TriangleCell]()
-      val mesh = TriangleMesh3D(UnstructuredPointsDomain(pts), TriangleList(cells)) // would throw exception on fail
+      try {
+        TriangleMesh3D(UnstructuredPointsDomain(pts), TriangleList(cells)) // would throw exception on fail
+      } catch {
+        case e: Exception => fail("It should be possible to create triangleMesh with an empty cell list")
+      }
     }
   }
 }

--- a/src/test/scala/scalismo/mesh/RegionQueryTest.scala
+++ b/src/test/scala/scalismo/mesh/RegionQueryTest.scala
@@ -18,9 +18,9 @@ package scalismo.mesh
 import java.io.File
 
 import scalismo.ScalismoTestSuite
-import scalismo.common.{ BoxDomain, PointId, UnstructuredPointsDomain }
+import scalismo.common.{ BoxDomain, UnstructuredPointsDomain }
 import scalismo.geometry._
-import scalismo.image.{ DiscreteImageDomain, DiscreteImageDomain2D }
+import scalismo.image.{ DiscreteImageDomain }
 import scalismo.io.MeshIO
 
 class RegionQueryTest extends ScalismoTestSuite {

--- a/src/test/scala/scalismo/numerics/IntegrationTest.scala
+++ b/src/test/scala/scalismo/numerics/IntegrationTest.scala
@@ -64,9 +64,6 @@ class IntegrationTest extends ScalismoTestSuite {
 
       val img = ScalarImage(BoxDomain(-1.0f, 1.0f), (x: Point[_1D]) => 1.0)
 
-      val region1 = BoxDomain(-1.0f, 1.0f)
-      val region2 = BoxDomain(-8.0f, 8.0f)
-
       val numPoints = 200
       val grid1 = DiscreteImageDomain(Point(-1.0), Vector(2.0 / numPoints), IntVector(numPoints))
       val grid2 = DiscreteImageDomain(Point(-8.0), Vector(16.0 / numPoints), IntVector(numPoints))

--- a/src/test/scala/scalismo/numerics/PivotedCholeskyTest.scala
+++ b/src/test/scala/scalismo/numerics/PivotedCholeskyTest.scala
@@ -19,7 +19,7 @@ package scalismo.numerics
 import breeze.linalg.DenseVector
 import scalismo.ScalismoTestSuite
 import scalismo.common.BoxDomain3D
-import scalismo.geometry.{ Point, Vector, _1D, _3D }
+import scalismo.geometry.{ Point, _1D, _3D }
 import scalismo.kernels.{ DiagonalKernel, GaussianKernel, Kernel }
 import scalismo.utils.Random
 

--- a/src/test/scala/scalismo/registration/RegistrationTests.scala
+++ b/src/test/scala/scalismo/registration/RegistrationTests.scala
@@ -19,11 +19,11 @@ import java.io.File
 
 import breeze.linalg.DenseVector
 import scalismo.{ ScalismoTestSuite, numerics }
-import scalismo.common.{ Field, PointId, RealSpace }
+import scalismo.common.{ Field, NearestNeighborInterpolator, PointId, RealSpace }
 import scalismo.geometry._
 import scalismo.io.{ ImageIO, MeshIO }
 import scalismo.kernels.{ DiagonalKernel, GaussianKernel }
-import scalismo.numerics.{ GradientDescentOptimizer, LBFGSOptimizer, UniformSampler }
+import scalismo.numerics.{ LBFGSOptimizer, UniformSampler }
 import scalismo.statisticalmodel.{ GaussianProcess, LowRankGaussianProcess }
 import scalismo.utils.Random
 
@@ -260,7 +260,7 @@ class RegistrationTests extends ScalismoTestSuite {
       val gp = GaussianProcess(Field(RealSpace[_2D], (_: Point[_2D]) => Vector.zeros[_2D]), DiagonalKernel(GaussianKernel[_2D](50.0) * 50.0, 2))
       val sampler = UniformSampler(domain.boundingBox, numberOfPoints = 200)
       val lowRankGp = LowRankGaussianProcess.approximateGP(gp, sampler, numBasisFunctions = 3)
-      val nnInterpolatedGp = lowRankGp.discretize(domain).interpolateNearestNeighbor
+      val nnInterpolatedGp = lowRankGp.discretize(domain).interpolate(NearestNeighborInterpolator())
 
       val transformationSpace = GaussianProcessTransformationSpace(nnInterpolatedGp)
       val gpParams = DenseVector.ones[Double](lowRankGp.rank)

--- a/src/test/scala/scalismo/registration/TransformationTests.scala
+++ b/src/test/scala/scalismo/registration/TransformationTests.scala
@@ -187,18 +187,17 @@ class TransformationTests extends ScalismoTestSuite {
       }
     }
 
-    it("a rigid transformation yields the same result as the composition of rotation and translation") {
+    it("a rigid transformation yields the same result as the rigid transform composed of rotation and translation") {
 
       val parameterVector = DenseVector[Double](1.5, 1.0, 3.5, Math.PI, -Math.PI / 2.0, -Math.PI)
       val translationParams = DenseVector(1.5, 1.0, 3.5)
       val rotation = RotationSpace[_3D](Point(0f, 0f, 0f)).transformForParameters(DenseVector(Math.PI, -Math.PI / 2.0, -Math.PI))
       val translation = TranslationSpace[_3D].transformForParameters(translationParams)
 
-      val composed = translation compose rotation
       val rigid = RigidTransformationSpace[_3D]().transformForParameters(parameterVector)
 
       val transformedRigid = mesh.transform(rigid)
-      val transformedComposed = mesh.transform(rigid)
+      val transformedComposed = mesh.transform(translation compose rotation)
 
       val diffNormMax = transformedRigid.pointSet.points.zip(transformedComposed.pointSet.points).map { case (p1, p2) => (p1 - p2).norm }.max
       assert(diffNormMax < 0.00001)

--- a/src/test/scala/scalismo/sampling/proposals/MixtureTests.scala
+++ b/src/test/scala/scalismo/sampling/proposals/MixtureTests.scala
@@ -19,7 +19,7 @@ package scalismo.sampling.proposals
 import scalismo.ScalismoTestSuite
 import scalismo.sampling.evaluators.GaussianEvaluator
 import scalismo.sampling.proposals.MixtureProposal.{ SymmetricProposalGenerator, SymmetricProposalGeneratorWithTransition }
-import scalismo.sampling.{ ProposalGenerator, SymmetricTransitionRatio, TransitionProbability, proposals }
+import scalismo.sampling.{ ProposalGenerator, SymmetricTransitionRatio, TransitionProbability }
 import scalismo.utils.Random
 
 class MixtureTests extends ScalismoTestSuite {
@@ -43,11 +43,6 @@ class MixtureTests extends ScalismoTestSuite {
 
     val symProposal = new ProposalGenerator[Double] with SymmetricTransitionRatio[Double] {
       override def propose(current: Double): Double = current
-    }
-
-    val transProposal = new ProposalGenerator[Double] with TransitionProbability[Double] {
-      override def propose(current: Double): Double = current
-      override def logTransitionProbability(from: Double, to: Double): Double = 0.0
     }
 
     val symTransProposal = new ProposalGenerator[Double] with TransitionProbability[Double] with SymmetricTransitionRatio[Double] {
@@ -80,15 +75,15 @@ class MixtureTests extends ScalismoTestSuite {
       import MixtureProposal.implicits._
 
       it("is a plain ProposalGenerator for plain proposals") {
-        val mixture: ProposalGenerator[Double] = MixtureProposal(0.25 *: plainProposal + plainProposal * 0.75)
+        MixtureProposal(0.25 *: plainProposal + plainProposal * 0.75): ProposalGenerator[Double]
       }
 
       it("preserves symmetry of proposals") {
-        val mixture: SymmetricProposalGenerator[Double] = MixtureProposal(0.25 *: symProposal + symProposal * 0.75)
+        MixtureProposal(0.25 *: symProposal + symProposal * 0.75): SymmetricProposalGenerator[Double]
       }
 
       it("preserves symmetry and transition probability of proposals") {
-        val mixture: SymmetricProposalGeneratorWithTransition[Double] = MixtureProposal(0.25 *: symTransProposal + symTransProposal * 0.75)
+        MixtureProposal(0.25 *: symTransProposal + symTransProposal * 0.75): SymmetricProposalGeneratorWithTransition[Double]
       }
 
       it("discards symmetry if a proposal is not symmetric") {

--- a/src/test/scala/scalismo/statisticalmodel/ActiveShapeModelTests.scala
+++ b/src/test/scala/scalismo/statisticalmodel/ActiveShapeModelTests.scala
@@ -8,7 +8,7 @@ import scalismo.geometry.{ Point, _3D }
 import scalismo.io.{ ImageIO, MeshIO, StatismoIO }
 import scalismo.mesh.{ MeshMetrics, TriangleMesh }
 import scalismo.numerics.{ Sampler, UniformMeshSampler3D }
-import scalismo.registration.{ LandmarkRegistration, RigidTransformationSpace }
+import scalismo.registration.{ LandmarkRegistration }
 import scalismo.statisticalmodel.asm._
 import scalismo.statisticalmodel.dataset.DataCollection
 import scalismo.utils.Random

--- a/src/test/scala/scalismo/statisticalmodel/GaussianProcessTests.scala
+++ b/src/test/scala/scalismo/statisticalmodel/GaussianProcessTests.scala
@@ -15,8 +15,6 @@
  */
 package scalismo.statisticalmodel
 
-import _root_.java.io.File
-
 import breeze.linalg.{ DenseMatrix, DenseVector }
 import breeze.stats.distributions.Gaussian
 import scalismo.ScalismoTestSuite
@@ -24,7 +22,6 @@ import scalismo.common._
 import scalismo.geometry.Point.implicits._
 import scalismo.geometry._
 import scalismo.image.DiscreteImageDomain
-import scalismo.io.StatismoIO
 import scalismo.kernels.{ DiagonalKernel, GaussianKernel, MatrixValuedPDKernel }
 import scalismo.numerics.{ GridSampler, UniformSampler }
 import scalismo.utils.Random
@@ -455,7 +452,7 @@ class GaussianProcessTests extends ScalismoTestSuite {
 
     it("yields the same values on the discrete points when interpolated with nearest neighbor") {
       val f = Fixture
-      val interpolatedGP = f.discreteLowRankGp.interpolateNearestNeighbor
+      val interpolatedGP = f.discreteLowRankGp.interpolate(NearestNeighborInterpolator())
       val gaussRNG = Gaussian(0, 1)(random.breezeRandBasis)
       val coeffs = DenseVector.rand(interpolatedGP.rank, gaussRNG)
 
@@ -468,7 +465,7 @@ class GaussianProcessTests extends ScalismoTestSuite {
       val f = Fixture
 
       val orignalLowRankPosterior = f.lowRankGp.posterior(f.trainingDataLowRankGP)
-      val interpolatedGPPosterior = f.discreteLowRankGp.interpolateNearestNeighbor.posterior(f.trainingDataLowRankGP)
+      val interpolatedGPPosterior = f.discreteLowRankGp.interpolate(NearestNeighborInterpolator()).posterior(f.trainingDataLowRankGP)
 
       val gaussRNG = Gaussian(0, 1)(random.breezeRandBasis)
       val coeffs = DenseVector.rand(orignalLowRankPosterior.rank, gaussRNG)

--- a/src/test/scala/scalismo/statisticalmodel/MultivariateNormalDistributionTests.scala
+++ b/src/test/scala/scalismo/statisticalmodel/MultivariateNormalDistributionTests.scala
@@ -17,7 +17,6 @@ package scalismo.statisticalmodel
 
 import breeze.linalg.{ DenseMatrix, DenseVector }
 import scalismo.ScalismoTestSuite
-import scalismo.geometry._
 import scalismo.utils.Random
 
 class MultivariateNormalDistributionTests extends ScalismoTestSuite {
@@ -117,7 +116,7 @@ class MultivariateNormalDistributionTests extends ScalismoTestSuite {
       val variance = 5.0
       val stddev = math.sqrt(variance)
       val mvn = new MultivariateNormalDistribution(DenseVector(0.0), DenseMatrix.create[Double](1, 1, Array(variance)))
-      mvn.mahalanobisDistance(DenseVector(math.sqrt(variance))) should be(1.0 +- 1e-5)
+      mvn.mahalanobisDistance(DenseVector(stddev)) should be(1.0 +- 1e-5)
     }
   }
 

--- a/src/test/scala/scalismo/statisticalmodel/dataset/DataCollectionTests.scala
+++ b/src/test/scala/scalismo/statisticalmodel/dataset/DataCollectionTests.scala
@@ -18,15 +18,15 @@ package scalismo.statisticalmodel.dataset
 import java.io.File
 
 import scalismo.ScalismoTestSuite
-import scalismo.common.{ Vectorizer, Field, VectorField }
+import scalismo.common.{ Field }
 import scalismo.geometry._
 import scalismo.io.MeshIO
-import scalismo.kernels.{ Kernel, DiagonalKernel, GaussianKernel }
+import scalismo.kernels.{ DiagonalKernel, GaussianKernel }
 import scalismo.mesh.{ TriangleMesh, MeshMetrics }
 import scalismo.numerics.UniformMeshSampler3D
 import scalismo.registration.{ LandmarkRegistration, TranslationTransform }
 import scalismo.statisticalmodel.{ LowRankGaussianProcess, GaussianProcess, StatisticalMeshModel }
-import scalismo.utils.{ Benchmark, Memoize, Random }
+import scalismo.utils.{ Random }
 
 class DataCollectionTests extends ScalismoTestSuite {
 

--- a/src/test/scala/scalismo/utils/ConversionTests.scala
+++ b/src/test/scala/scalismo/utils/ConversionTests.scala
@@ -20,8 +20,6 @@ import scalismo.ScalismoTestSuite
 import scalismo.geometry._2D
 import scalismo.io.{ ImageIO, MeshIO }
 
-import scala.language.implicitConversions
-
 class ConversionTests extends ScalismoTestSuite {
 
   describe("a Mesh ") {

--- a/src/test/scala/scalismo/utils/MemoizationTests.scala
+++ b/src/test/scala/scalismo/utils/MemoizationTests.scala
@@ -17,8 +17,6 @@ package scalismo.utils
 
 import scalismo.ScalismoTestSuite
 
-import scala.language.implicitConversions
-
 class MemoizationTests extends ScalismoTestSuite {
   describe("a Function ") {
 
@@ -28,14 +26,14 @@ class MemoizationTests extends ScalismoTestSuite {
 
     it("yields the same results after memoizing") {
       val testFunMemoized = Memoize(testFun, 100000)
-      for (x <- -2 * Math.PI until 2 * Math.PI by 0.1)
-        testFun(x) should be(testFunMemoized(x))
+      for (x <- BigDecimal(-2.0 * Math.PI) until (2.0 * Math.PI) by 0.1)
+        testFun(x.doubleValue()) should be(testFunMemoized(x.doubleValue()))
     }
 
     it("evaluates faster after memoization") {
-      def time[A](a: => A): Double = {
+      def time[A](a: () => A): Double = {
         val now = System.nanoTime
-        val result = a
+        a()
         System.nanoTime() - now
       }
 
@@ -46,10 +44,10 @@ class MemoizationTests extends ScalismoTestSuite {
 
       val slowFunMemoized = Memoize(slowTestFun, 10)
       val timeSlowFun = time {
-        for (i <- 0 until 10) slowTestFun(0)
+        () => for (i <- 0 until 10) slowTestFun(0)
       }
       val timeMemoFun = time {
-        for (i <- 0 until 10) slowFunMemoized
+        () => for (i <- 0 until 10) slowFunMemoized
       }
       timeSlowFun should be > timeMemoFun
     }


### PR DESCRIPTION
Fixed many small problems concerning unused variables and imports.
A few deprecation warnings still exists, which will need to be fixed in a second pass. 
@Andreas-Forster there are a few unused test functions in MeshBoundaryTests. If we use them as tests, the tests fail. Maybe you can decide what to do with them. 