### PR TITLE
Introduced StatisticalModelIO object

### DIFF
--- a/src/main/scala/scalismo/io/StatisticalModelIO.scala
+++ b/src/main/scala/scalismo/io/StatisticalModelIO.scala
@@ -19,7 +19,6 @@ import java.io.File
 
 import scalismo.common.{ PointId, UnstructuredPointsDomain }
 import scalismo.geometry.{ Point, _3D }
-import scalismo.io.StatismoIO.StatismoModelType.StatismoModelType
 import scalismo.mesh.{ TriangleCell, TriangleList, TriangleMesh, TriangleMesh3D }
 import scalismo.mesh.TriangleMesh._
 import scalismo.statisticalmodel.StatisticalMeshModel
@@ -27,16 +26,51 @@ import scalismo.statisticalmodel.StatisticalMeshModel
 import scala.util.Try
 import breeze.linalg.DenseVector
 import breeze.linalg.DenseMatrix
+
 import scala.util.Failure
 import scala.util.Success
 import java.util.Calendar
+
 import ncsa.hdf.`object`._
 import java.io.DataOutputStream
 import java.io.FileOutputStream
 import java.io.DataInputStream
 import java.io.FileInputStream
 
+import scalismo.io.StatismoIO.StatismoModelType.StatismoModelType
+
+object StatisticalModelIO {
+
+  /**
+   * Reads a statistical mesh model. The file type is determined
+   * based on the extension. Currently on the Scalismo format (.h5)
+   * is supported.
+   *
+   * @param file The statismo file
+   * @return A StatisticalMeshModel or the Failure
+   */
+  def readStatisticalMeshModel(file: File): Try[StatisticalMeshModel] = {
+    // currently, we support only the statismo format
+    StatismoIO.readStatismoMeshModel(file, "/")
+  }
+
+  /**
+   * Writes a statistical mesh model. The file type is determined
+   * based on the extension. Currently on the Scalismo format (.h5)
+   * is supported.
+   *
+   * @param model The statistical model
+   * @param file The file to which the model is written
+   * @return In case of Failure, the Failure is returned.
+   */
+  def writeStatisticalMeshModel(model: StatisticalMeshModel, file: File): Try[Unit] = {
+    // currently, we support only the statismo format
+    StatismoIO.writeStatismoMeshModel(model, file, "/")
+  }
+}
+
 object StatismoIO {
+
   object StatismoModelType extends Enumeration {
     type StatismoModelType = Value
     val Polygon_Mesh, Unknown = Value
@@ -325,9 +359,4 @@ object StatismoIO {
     } map (_ => tmpfile)
   }
 
-  //  def main(args: Array[String]): Unit = {
-  //    org.statismo.stk.core.initialize
-  //    val model = readStatismoMeshModel(new File("/tmp/skull-gaussian-50-0.h5")).get
-  //    println(StatismoIO.writeStatismoMeshModel(model, new File("/tmp/x.h5"), StatismoVersion.v081))
-  //  }
 }

--- a/src/test/scala/scalismo/io/StatisticalModelIOTest.scala
+++ b/src/test/scala/scalismo/io/StatisticalModelIOTest.scala
@@ -18,10 +18,9 @@ package scalismo.io
 import java.io.File
 
 import scalismo.ScalismoTestSuite
-import scalismo.io.StatismoIO.writeStatismoMeshModel
 import scalismo.statisticalmodel.StatisticalMeshModel
 
-class StatismoIOTest extends ScalismoTestSuite {
+class StatisticalModelIOTest extends ScalismoTestSuite {
 
   describe("a Statismo Mesh Model") {
 
@@ -38,7 +37,7 @@ class StatismoIOTest extends ScalismoTestSuite {
 
       val t = for {
         model <- StatismoIO.readStatismoMeshModel(statismoFile)
-        _ <- writeStatismoMeshModel(model, dummyFile)
+        _ <- StatismoIO.writeStatismoMeshModel(model, dummyFile)
         readModel <- StatismoIO.readStatismoMeshModel(dummyFile)
       } yield {
         assertModelAlmostEqual(model, readModel)
@@ -54,7 +53,7 @@ class StatismoIOTest extends ScalismoTestSuite {
 
       val t = for {
         model <- StatismoIO.readStatismoMeshModel(statismoFile)
-        _ <- writeStatismoMeshModel(model, dummyFile, "/someLocation")
+        _ <- StatismoIO.writeStatismoMeshModel(model, dummyFile, "/someLocation")
         readModel <- StatismoIO.readStatismoMeshModel(dummyFile, "/someLocation")
       } yield {
         assertModelAlmostEqual(model, readModel)
@@ -72,7 +71,7 @@ class StatismoIOTest extends ScalismoTestSuite {
 
       val t = for {
         model <- StatismoIO.readStatismoMeshModel(statismoFile)
-        _ <- writeStatismoMeshModel(model, dummyFile, statismoVersion = v081)
+        _ <- StatismoIO.writeStatismoMeshModel(model, dummyFile, statismoVersion = v081)
         readModel <- StatismoIO.readStatismoMeshModel(dummyFile)
       } yield {
         assertModelAlmostEqual(model, readModel)

--- a/src/test/scala/scalismo/statisticalmodel/ActiveShapeModelTests.scala
+++ b/src/test/scala/scalismo/statisticalmodel/ActiveShapeModelTests.scala
@@ -5,7 +5,7 @@ import java.io.File
 import breeze.linalg.DenseVector
 import scalismo.ScalismoTestSuite
 import scalismo.geometry.{ Point, _3D }
-import scalismo.io.{ ImageIO, MeshIO, StatismoIO }
+import scalismo.io.{ ImageIO, MeshIO, StatismoIO, StatisticalModelIO }
 import scalismo.mesh.{ MeshMetrics, TriangleMesh }
 import scalismo.numerics.{ Sampler, UniformMeshSampler3D }
 import scalismo.registration.{ LandmarkRegistration, RigidTransformationSpace }

--- a/src/test/scala/scalismo/statisticalmodel/GaussianProcessTests.scala
+++ b/src/test/scala/scalismo/statisticalmodel/GaussianProcessTests.scala
@@ -24,7 +24,7 @@ import scalismo.common._
 import scalismo.geometry.Point.implicits._
 import scalismo.geometry._
 import scalismo.image.DiscreteImageDomain
-import scalismo.io.StatismoIO
+import scalismo.io.StatisticalModelIO
 import scalismo.kernels.{ DiagonalKernel, GaussianKernel, MatrixValuedPDKernel }
 import scalismo.numerics.{ GridSampler, UniformSampler }
 import scalismo.utils.Random

--- a/src/test/scala/scalismo/statisticalmodel/StatisticalModelTests.scala
+++ b/src/test/scala/scalismo/statisticalmodel/StatisticalModelTests.scala
@@ -21,7 +21,7 @@ import breeze.linalg.DenseVector
 import breeze.stats.distributions.Gaussian
 import scalismo.ScalismoTestSuite
 import scalismo.geometry._
-import scalismo.io.StatismoIO
+import scalismo.io.{ StatismoIO, StatisticalModelIO }
 import scalismo.registration.{ RigidTransformation, RigidTransformationSpace }
 import scalismo.utils.Random
 


### PR DESCRIPTION
This PR introduced a new object ```StatisticalModelIO```. This object complements the ```StatismoIO``` class, which provides the concrete implementation of the Statismo file format. The problem with using `StatismoIO``` directly is, that it refers to a concrete implementation of a file format (the statismo file format) rather than the more abstract concept of reading/writing a StatisticalModel. Furthermore, for users who do not know that statismo is a software and fileformat for statistical modelling, the name is unintuitive. 

The ```StatismoIO``` object remains public and is not deprecated, as sometimes we would like to be able to use specific features of the ```StatismoIO``` format, such as the ability to store several models into the same file or read a model catalog. 

This PR addresses issue #249 