### PR TITLE
Fixes #262 closestPointOnDistance

### DIFF
--- a/src/main/scala/scalismo/mesh/boundingSpheres/BSDistance.scala
+++ b/src/main/scala/scalismo/mesh/boundingSpheres/BSDistance.scala
@@ -28,14 +28,14 @@ private[mesh] case class Triangle(a: EuclideanVector[_3D], b: EuclideanVector[_3
   val bc = c - b
   val n = ab.crossproduct(ac)
 
-  val degenerated = if ( n.norm == 0.0 ) { if (a==b&&b==c) 2 else 1 } else 0
+  val degenerated = if (n.norm == 0.0) { if (a == b && b == c) 2 else 1 } else 0
   // 0: ab, 1: ac, 2: bc
   val longestSide = {
     val bc = c - b
-    if ( ab.norm2 > ac.norm2 ) {
-      if ( ab.norm2 > bc.norm2 ) 0 else 2
+    if (ab.norm2 > ac.norm2) {
+      if (ab.norm2 > bc.norm2) 0 else 2
     } else {
-      if ( ac.norm2 > bc.norm2 ) 1 else 2
+      if (ac.norm2 > bc.norm2) 1 else 2
     }
   }
 }
@@ -55,22 +55,22 @@ private object BSDistance {
    */
   @inline
   def calculateBarycentricCoordinates(triangle: Triangle, p: EuclideanVector[_3D]): (Double, Double, Double) = {
-    if ( triangle.degenerated == 2 ) {
-      (1.0,0,0)
-    } else if ( triangle.degenerated == 1) {
+    if (triangle.degenerated == 2) {
+      (1.0, 0, 0)
+    } else if (triangle.degenerated == 1) {
       triangle.longestSide match {
         case 0 =>
           val s = triangle.ab.normalize.dot(p - triangle.a)
           val coordinate = s / triangle.ab.norm
-          (1-coordinate, coordinate, 0)
+          (1 - coordinate, coordinate, 0)
         case 1 =>
           val s = triangle.ac.normalize.dot(p - triangle.a)
           val cooridnate = s / triangle.ac.norm
-          (1-cooridnate,0,cooridnate)
+          (1 - cooridnate, 0, cooridnate)
         case 2 =>
           val s = triangle.bc.normalize.dot(p - triangle.b)
           val cooridnate = s / triangle.bc.norm
-          (0.0,1-cooridnate,cooridnate)
+          (0.0, 1 - cooridnate, cooridnate)
       }
     } else {
       val positionRelativeToA = triangle.a - p

--- a/src/main/scala/scalismo/mesh/boundingSpheres/BoundingSpheres.scala
+++ b/src/main/scala/scalismo/mesh/boundingSpheres/BoundingSpheres.scala
@@ -67,13 +67,9 @@ private[mesh] object BoundingSpheres {
       val a = mesh.pointSet.point(t.ptId1).toVector
       val b = mesh.pointSet.point(t.ptId2).toVector
       val c = mesh.pointSet.point(t.ptId3).toVector
-      val ab = b - a
-      val ac = c - a
 
       new Triangle(
-        a, b, c,
-        ab, ac,
-        ab.crossproduct(ac)
+        a, b, c
       )
 
     }
@@ -154,7 +150,7 @@ private[mesh] object BoundingSpheres {
     val ab = b.center - a.center
     val dist2 = ab.norm2
 
-    val (newCenter, newRadius) = if (dist2 < Double.MinPositiveValue) {
+    val (nc, nr) = if (dist2 < Double.MinPositiveValue) {
       // both have same center
       (a.center, max(a.r2, b.r2) + Double.MinPositiveValue)
     } else {
@@ -170,7 +166,7 @@ private[mesh] object BoundingSpheres {
       ), 2)
       (newCenter, newRadius)
     }
-    new BoundingSphereSplit(newCenter, newRadius, -1, a, b)
+    new BoundingSphereSplit(nc, nr, -1, a, b)
   }
 
   /**
@@ -366,10 +362,24 @@ private object Sphere {
     // handle degenerated cases
     if (ab.norm2 < Double.MinPositiveValue) {
       center = aMc
-      radius2 = max((aMc - a).norm2, (aMc - c).norm2)
+      radius2 = max((center - a).norm2, (center - c).norm2)
     } else if (ac.norm2 < Double.MinPositiveValue || bc.norm2 < Double.MinPositiveValue) {
       center = aMb
-      radius2 = max((aMb - a).norm2, (aMb - b).norm2)
+      radius2 = max((center - a).norm2, (center - b).norm2)
+    } else if (abs(ab.normalize.dot(ac.normalize)) == 1.0) {
+      // all points on same line
+      val lengths = Seq(("ab",ab.norm),("ac",ac.norm),("bc",bc.norm))
+      lengths.maxBy(_._2)._1 match {
+        case "ab" =>
+          center = aMb
+          radius2 = max((center - a).norm2, (center - b).norm2)
+        case "ac" =>
+          center = aMc
+          radius2 = max((center - a).norm2, (center - c).norm2)
+        case "bc" =>
+          center = (b + c) * 0.5
+          radius2 = max((center - b).norm2, (center - c).norm2)
+      }
     } else {
       // non degenerated case
 

--- a/src/main/scala/scalismo/mesh/boundingSpheres/BoundingSpheres.scala
+++ b/src/main/scala/scalismo/mesh/boundingSpheres/BoundingSpheres.scala
@@ -368,7 +368,7 @@ private object Sphere {
       radius2 = max((center - a).norm2, (center - b).norm2)
     } else if (abs(ab.normalize.dot(ac.normalize)) == 1.0) {
       // all points on same line
-      val lengths = Seq(("ab",ab.norm),("ac",ac.norm),("bc",bc.norm))
+      val lengths = Seq(("ab", ab.norm), ("ac", ac.norm), ("bc", bc.norm))
       lengths.maxBy(_._2)._1 match {
         case "ab" =>
           center = aMb

--- a/src/main/scala/scalismo/mesh/boundingSpheres/SurfaceIntersectionIndex.scala
+++ b/src/main/scala/scalismo/mesh/boundingSpheres/SurfaceIntersectionIndex.scala
@@ -57,7 +57,7 @@ object LineTriangleMesh3DIntersectionIndex {
       val a = mesh.pointSet.point(t.ptId1).toVector
       val b = mesh.pointSet.point(t.ptId2).toVector
       val c = mesh.pointSet.point(t.ptId3).toVector
-      new Triangle( a, b, c )
+      new Triangle(a, b, c)
     }
 
     // build up search structure

--- a/src/main/scala/scalismo/mesh/boundingSpheres/SurfaceIntersectionIndex.scala
+++ b/src/main/scala/scalismo/mesh/boundingSpheres/SurfaceIntersectionIndex.scala
@@ -54,19 +54,10 @@ object LineTriangleMesh3DIntersectionIndex {
 
     // build triangle list (use only Vector[_3D], no Points)
     val triangles = mesh.triangulation.triangles.map { t =>
-
       val a = mesh.pointSet.point(t.ptId1).toVector
       val b = mesh.pointSet.point(t.ptId2).toVector
       val c = mesh.pointSet.point(t.ptId3).toVector
-      val ab = b - a
-      val ac = c - a
-
-      new Triangle(
-        a, b, c,
-        ab, ac,
-        ab.crossproduct(ac)
-      )
-
+      new Triangle( a, b, c )
     }
 
     // build up search structure

--- a/src/main/scala/scalismo/mesh/boundingSpheres/SurfaceSpatialIndex.scala
+++ b/src/main/scala/scalismo/mesh/boundingSpheres/SurfaceSpatialIndex.scala
@@ -88,7 +88,7 @@ object TriangleMesh3DSpatialIndex {
       val a = mesh.pointSet.point(t.ptId1).toVector
       val b = mesh.pointSet.point(t.ptId2).toVector
       val c = mesh.pointSet.point(t.ptId3).toVector
-      new Triangle( a, b, c )
+      new Triangle(a, b, c)
     }
 
     // build up search structure

--- a/src/main/scala/scalismo/mesh/boundingSpheres/SurfaceSpatialIndex.scala
+++ b/src/main/scala/scalismo/mesh/boundingSpheres/SurfaceSpatialIndex.scala
@@ -85,19 +85,10 @@ object TriangleMesh3DSpatialIndex {
 
     // build triangle list (use only Vector[_3D], no Points)
     val triangles = mesh.triangulation.triangles.map { t =>
-
       val a = mesh.pointSet.point(t.ptId1).toVector
       val b = mesh.pointSet.point(t.ptId2).toVector
       val c = mesh.pointSet.point(t.ptId3).toVector
-      val ab = b - a
-      val ac = c - a
-
-      new Triangle(
-        a, b, c,
-        ab, ac,
-        ab.crossproduct(ac)
-      )
-
+      new Triangle( a, b, c )
     }
 
     // build up search structure

--- a/src/test/scala/scalismo/mesh/boundingSpheres/MeshSurfaceDistanceTests.scala
+++ b/src/test/scala/scalismo/mesh/boundingSpheres/MeshSurfaceDistanceTests.scala
@@ -15,32 +15,32 @@
  */
 package scalismo.mesh.boundingSpheres
 
-import breeze.linalg.{ max, min }
+import breeze.linalg.{max, min}
 import scalismo.ScalismoTestSuite
-import scalismo.common.{ PointId, UnstructuredPointsDomain }
-import scalismo.geometry.{ Point, EuclideanVector, _3D }
-import scalismo.mesh.{ TriangleCell, TriangleList, TriangleMesh3D }
+import scalismo.common.{PointId, UnstructuredPointsDomain}
+import scalismo.geometry.{EuclideanVector, Point, _3D}
+import scalismo.mesh.{TriangleCell, TriangleList, TriangleMesh3D}
 import scalismo.utils.Random
 
 class MeshSurfaceDistanceTests extends ScalismoTestSuite {
 
-  implicit val rnd = Random(42)
+  implicit val rnd: Random = Random(42)
 
-  def rgen(offset: Double = 0.0, scale: Double = 1.0) = rnd.scalaRandom.nextDouble() * scale + offset
+  def gen(offset: Double = 0.0, scale: Double = 1.0): Double = rnd.scalaRandom.nextDouble() * scale + offset
 
   def randomPoint(offset: Double = 0.0, scale: Double = 1.0): Point[_3D] = {
-    Point(rgen(offset, scale), rgen(offset, scale), rgen(offset, scale))
+    Point(gen(offset, scale), gen(offset, scale), gen(offset, scale))
   }
 
   def randomVector(offset: Double = 0.0, scale: Double = 1.0): EuclideanVector[_3D] = {
-    EuclideanVector(rgen(offset, scale), rgen(offset, scale), rgen(offset, scale))
+    EuclideanVector(gen(offset, scale), gen(offset, scale), gen(offset, scale))
   }
 
   private def randomTriangle(offset: Double, scale: Double): Triangle = {
     val a = randomVector(offset, scale)
     val b = randomVector(offset, scale)
     val c = randomVector(offset, scale)
-    Triangle(a, b, c, b - a, c - a, (b - a).crossproduct(c - a))
+    Triangle(a, b, c)
   }
 
   def aeqV[D](a: EuclideanVector[D], b: EuclideanVector[D], theta: Double = 1.0e-8): Boolean = {
@@ -55,17 +55,20 @@ class MeshSurfaceDistanceTests extends ScalismoTestSuite {
     a - b < theta
   }
 
+
+
+
   describe("The SurfaceDistance") {
 
     it("should use correct barycentric coordinate for points on a line") {
-      (0 until 100) foreach { j =>
+      (0 until 100) foreach { _ =>
         val pairs = IndexedSeq((0.0, 1.0), (10.0, 10.0), (100.0, 100.0), (-10.0, 10.0))
         pairs.foreach { pair =>
           val a = randomVector(pair._1, pair._2)
           val b = randomVector(pair._1, pair._2)
 
-          (0 until 100) foreach { i =>
-            val s = rgen()
+          (0 until 100) foreach { _ =>
+            val s = gen()
 
             val p = a + (b - a) * s
             val res = BSDistance.toLineSegment(p, a, b)
@@ -95,19 +98,19 @@ class MeshSurfaceDistanceTests extends ScalismoTestSuite {
     }
 
     it("should use correct barycentric coordinate for points away from the line") {
-      (0 until 100) foreach { j =>
+      (0 until 100) foreach { _ =>
         val pairs = IndexedSeq((0.0, 1.0), (10.0, 10.0), (100.0, 100.0), (-10.0, 10.0))
         pairs.foreach { pair =>
           val a = randomVector(pair._1, pair._2)
           val b = randomVector(pair._1, pair._2)
 
-          (0 until 100) foreach { i =>
-            val s = rgen()
+          (0 until 100) foreach { _ =>
+            val s = gen()
             val ab = b - a
             val k = ab + randomVector()
             val n = ab.crossproduct(k)
             val p1 = a + ab * s
-            val p = p1 + n * rgen(pair._1, pair._2)
+            val p = p1 + n * gen(pair._1, pair._2)
             val res = BSDistance.toLineSegment(p, a, b)
             if ((b - a).norm2 < Double.MinPositiveValue) {
               res.bc._1 shouldBe 0.5 +- 1.0e-8
@@ -135,16 +138,16 @@ class MeshSurfaceDistanceTests extends ScalismoTestSuite {
     }
 
     it("should return the correct barycentric coordinates in a triangle") {
-      (0 until 100) foreach { j =>
+      (0 until 100) foreach { _ =>
         val pairs = IndexedSeq((0, 1), (10, 10), (100, 100), (-10, 10))
         pairs.foreach { pair =>
           val tri = randomTriangle(pair._1, pair._2)
-          (0 until 100) foreach { i =>
-            val s = rgen()
-            val t = (1.0 - s) * rgen()
+          (0 until 100) foreach { _ =>
+            val s = gen()
+            val t = (1.0 - s) * gen()
 
             val pt = tri.a + tri.ab * s + tri.ac * t
-            val p = pt + tri.n * rgen(pair._1, pair._2)
+            val p = pt + tri.n * gen(pair._1, pair._2)
 
             val ct = BSDistance.toTriangle(p, tri)
             val resT = ct.bc
@@ -160,13 +163,13 @@ class MeshSurfaceDistanceTests extends ScalismoTestSuite {
     }
 
     it("should use correct barycentric coordinates for points in triangle plane ") {
-      (0 until 100) foreach { j =>
+      (0 until 100) foreach { _ =>
         val pairs = IndexedSeq((0.0, 1.0), (10.0, 10.0), (100.0, 100.0), (-10.0, 10.0))
         pairs.foreach { pair =>
           val tri = randomTriangle(pair._1, pair._2)
-          (0 until 100) foreach { i =>
-            val s = rgen()
-            val t = rgen()
+          (0 until 100) foreach { _ =>
+            val s = gen()
+            val t = gen()
 
             val p = tri.a + tri.ab * s + tri.ac * t
 
@@ -179,15 +182,15 @@ class MeshSurfaceDistanceTests extends ScalismoTestSuite {
     }
 
     it("should use correct barycentric coordinates for points outside the triangle plane") {
-      (0 until 100) foreach { j =>
+      (0 until 100) foreach { _ =>
         val pairs = IndexedSeq((0, 1), (10, 10), (100, 100), (-10, 10))
         pairs.foreach { pair =>
           val tri = randomTriangle(pair._1, pair._2)
-          (0 until 100) foreach { i =>
-            val s = rgen()
-            val t = rgen()
+          (0 until 100) foreach { _ =>
+            val s = gen()
+            val t = gen()
 
-            val p = tri.a + tri.ab * s + tri.ac * t + tri.n * rgen(pair._1, pair._2)
+            val p = tri.a + tri.ab * s + tri.ac * t + tri.n * gen(pair._1, pair._2)
 
             val res = BSDistance.calculateBarycentricCoordinates(tri, p)
             s shouldBe res._1 +- 1.0e-8
@@ -198,22 +201,104 @@ class MeshSurfaceDistanceTests extends ScalismoTestSuite {
       }
     }
 
+    it("should use reasonable barycentric coordinates for triangles with three times the same point") {
+
+      def test(tri: Triangle): Unit = {
+        for (x <- BigDecimal(0) to BigDecimal(2) by BigDecimal(0.1)) {
+          val p = EuclideanVector(x.toDouble, 0, 1)
+          val bc = BSDistance.calculateBarycentricCoordinates(tri, p)
+          (bc._1 + bc._2 + bc._3) shouldBe 1.0 +- 1.0e-8
+          val epsilon = 1.0e-12
+          bc._1 should be(1.0 +- epsilon)
+          bc._2 should be(0.0 +- epsilon)
+          bc._3 should be(0.0 +- epsilon)
+        }
+      }
+
+      for (_ <- 0 until 20) {
+        val ev = EuclideanVector(gen(1.0, 3.0), gen(1.0, 3.0), gen(1.0, 3.0))
+        test(Triangle(ev, ev, ev))
+      }
+    }
+
+    it("should use reasonable barycentric coordinates for triangles with only co-linear points") {
+
+      def test(
+        tri: Triangle,
+        pt: EuclideanVector[_3D]
+      ) = {
+        val bc = BSDistance.calculateBarycentricCoordinates(tri, pt)
+        (bc._1 + bc._2 + bc._3) shouldBe 1.0 +- 1.0e-8
+        val epsilon = 1.0e-12
+        bc._1 should be >= 0.0 - epsilon
+        bc._1 should be <= 1.0 + epsilon
+        bc._2 should be >= 0.0 - epsilon
+        bc._2 should be <= 1.0 + epsilon
+        bc._3 should be >= 0.0 - epsilon
+        bc._3 should be <= 1.0 + epsilon
+      }
+
+      {
+        val tri = Triangle(EuclideanVector(0.0, 0.0, 1.0), EuclideanVector(1.0, 0.0, 1.0), EuclideanVector(2.0, 0.0, 1.0))
+        test(tri, tri.a)
+        test(tri, tri.b)
+        test(tri, tri.c)
+      }
+
+      {
+
+        val tri = Triangle(EuclideanVector(0.0, 0.0, 1.0), EuclideanVector(2.0, 0.0, 1.0), EuclideanVector(1.0, 0.0, 1.0))
+        test(tri, tri.a)
+        test(tri, tri.b)
+        test(tri, tri.c)
+      }
+      {
+
+        val tri = Triangle(EuclideanVector(1.0, 0.0, 1.0), EuclideanVector(0.0, 0.0, 1.0), EuclideanVector(2.0, 0.0, 1.0))
+        test(tri, tri.a)
+        test(tri, tri.b)
+        test(tri, tri.c)
+      }
+      {
+
+        val tri = Triangle(EuclideanVector(1.0, 0.0, 1.0), EuclideanVector(2.0, 0.0, 1.0), EuclideanVector(0.0, 0.0, 1.0))
+        test(tri, tri.a)
+        test(tri, tri.b)
+        test(tri, tri.c)
+      }
+      {
+
+        val tri = Triangle(EuclideanVector(2.0, 0.0, 1.0), EuclideanVector(0.0, 0.0, 1.0), EuclideanVector(1.0, 0.0, 1.0))
+        test(tri, tri.a)
+        test(tri, tri.b)
+        test(tri, tri.c)
+      }
+      {
+
+        val tri = Triangle(EuclideanVector(2.0, 0.0, 1.0), EuclideanVector(1.0, 0.0, 1.0), EuclideanVector(0.0, 0.0, 1.0))
+        test(tri, tri.a)
+        test(tri, tri.b)
+        test(tri, tri.c)
+      }
+    }
+
+
     it("should return the same when used for points as the findClosestPoint from UnstructuredPointsDomain") {
 
-      val points = for (i <- 0 until 10000) yield randomPoint()
+      val points = for (_ <- 0 until 10000) yield randomPoint()
       val pd = UnstructuredPointsDomain(points)
 
       val md = DiscreteSpatialIndex.fromPointList(points)
 
-      (0 until 100) foreach { i =>
+      (0 until 100) foreach { _ =>
         val p = randomPoint()
 
         val vpt = pd.findClosestPoint(p)
-        val vdist = (vpt.point - p).norm2
+        val vd = (vpt.point - p).norm2
 
         val cp = md.closestPoint(p)
 
-        vdist shouldBe cp.distanceSquared
+        vd shouldBe cp.distanceSquared
         vpt.point shouldBe cp.point
       }
 
@@ -221,12 +306,12 @@ class MeshSurfaceDistanceTests extends ScalismoTestSuite {
 
     it("should return an equal or smaller distance when used for points than the findClosestPoint from UnstructuredPointsDomain for triangles") {
 
-      val triangles = (0 until 100) map { j =>
+      val triangles = (0 until 100) map { _ =>
         // test if two function lead to same cp
         val a = randomVector()
         val b = randomVector()
         val c = randomVector()
-        Triangle(a, b, c, b - a, c - a, (b - a).crossproduct(c - a))
+        Triangle(a, b, c)
       }
 
       val points = triangles.flatMap(t => Array(t.a.toPoint, t.b.toPoint, t.c.toPoint))
@@ -238,7 +323,7 @@ class MeshSurfaceDistanceTests extends ScalismoTestSuite {
         TriangleList((0 until 3 * triangles.length).grouped(3).map(g => TriangleCell(PointId(g(0)), PointId(g(1)), PointId(g(2)))).toIndexedSeq)
       ))
 
-      (0 until 1000) foreach { i =>
+      (0 until 1000) foreach { _ =>
         val p = randomVector()
 
         // findClosestPoint from UnstructuredPointsDomain
@@ -253,12 +338,12 @@ class MeshSurfaceDistanceTests extends ScalismoTestSuite {
 
     it("should return the same closest point on surface result when processing points in parallel") {
 
-      val triangles = (0 until 100) map { j =>
+      val triangles = (0 until 100) map { _ =>
         // test if two function lead to same cp
         val a = randomVector()
         val b = randomVector()
         val c = randomVector()
-        Triangle(a, b, c, b - a, c - a, (b - a).crossproduct(c - a))
+        Triangle(a, b, c)
       }
 
       val sd = TriangleMesh3DSpatialIndex.fromTriangleMesh3D(TriangleMesh3D(
@@ -266,7 +351,7 @@ class MeshSurfaceDistanceTests extends ScalismoTestSuite {
         TriangleList((0 until 3 * triangles.length).grouped(3).map(g => TriangleCell(PointId(g(0)), PointId(g(1)), PointId(g(2)))).toIndexedSeq)
       ))
 
-      val queries = (0 until 100000) map { i =>
+      val queries = (0 until 100000) map { _ =>
         randomVector()
       }
 
@@ -284,12 +369,12 @@ class MeshSurfaceDistanceTests extends ScalismoTestSuite {
 
     it("should return the same closest point result when processing points in parallel") {
 
-      val triangles = (0 until 100) map { j =>
+      val triangles = (0 until 100) map { _ =>
         // test if two function lead to same cp
         val a = randomVector()
         val b = randomVector()
         val c = randomVector()
-        Triangle(a, b, c, b - a, c - a, (b - a).crossproduct(c - a))
+        Triangle(a, b, c)
       }
 
       val sd = DiscreteSpatialIndex.fromMesh(TriangleMesh3D(
@@ -297,7 +382,7 @@ class MeshSurfaceDistanceTests extends ScalismoTestSuite {
         TriangleList((0 until 3 * triangles.length).grouped(3).map(g => TriangleCell(PointId(g(0)), PointId(g(1)), PointId(g(2)))).toIndexedSeq)
       ))
 
-      val queries = (0 until 100000) map { i =>
+      val queries = (0 until 100000) map { _ =>
         randomVector()
       }
 
@@ -313,6 +398,23 @@ class MeshSurfaceDistanceTests extends ScalismoTestSuite {
       }
     }
 
+
+    it("should work for degenerated triangles correctly.") {
+      import scala.language.implicitConversions
+      implicit def toPointId(i: Int): PointId = PointId(i)
+
+      TriangleMesh3D(
+        IndexedSeq(
+          Point(0, 1, 2),
+          Point(1, 1, 2),
+          Point(2, 1, 2),
+          Point(0, 2, 2),
+          Point(2, 1, 1),
+          Point(2, 2, 3)
+        ),
+        TriangleList(IndexedSeq(TriangleCell(0, 1, 2), TriangleCell(3, 4, 5)))
+      )
+    }
   }
 
   describe("The BoundingSphere") {
@@ -337,7 +439,7 @@ class MeshSurfaceDistanceTests extends ScalismoTestSuite {
         }
       }
 
-      val centers = (0 until 10000) map { i =>
+      val centers = (0 until 10000) map { _ =>
         randomVector()
       }
       val list = centers.sortBy(a => a(1)).zipWithIndex
@@ -355,5 +457,4 @@ class MeshSurfaceDistanceTests extends ScalismoTestSuite {
     }
 
   }
-
 }


### PR DESCRIPTION
This PR fixes #262 by testing for the different cases a triangle can be degenerated (co-linear points or single point only). The cases are then handled in the methods involved in the closest point on surface calculations.

The three main changes are:

- The `scalismo.mesh.boundingSpheres.Triangle` checks for the two degeneration cases of co-linear points, and one single location for all three corners (see [here](https://github.com/unibas-gravis/scalismo/compare/develop...Andreas-Forster:fixClosestPointOnDistance?expand=1#diff-ddf9b36802a00ec944b5eb97399f0fbdR31)).

- The calculation of barycentric coordinates handles the different degenration cases (see [here](https://github.com/unibas-gravis/scalismo/compare/develop...Andreas-Forster:fixClosestPointOnDistance?expand=1#diff-ddf9b36802a00ec944b5eb97399f0fbdR58)).

- When generating the bounding sphere `Sphere` the different degenerated cases do not lead to `NaN`'s any more (see [here](https://github.com/unibas-gravis/scalismo/compare/develop...Andreas-Forster:fixClosestPointOnDistance?expand=1#diff-0866c75747cdecadefbdca9ad6ebb86eR369)).

Furthet changes are:

- The `Triangle` class now calculates internally the values based on the corners, so the constructor takes the minimal set of values needed.

- Tests were added (starting from [here](https://github.com/unibas-gravis/scalismo/compare/develop...Andreas-Forster:fixClosestPointOnDistance?expand=1#diff-ff3c5f5658f2e7d661ffd9bce4e1d414R218)) to check that barycnetric coordinates and the bounding sphere are calculated correctly from also degenerated triangles. In addition the test class is moved to the appropriate folder according to the specified package.