### PR TITLE
More Efficient PCA computations

### DIFF
--- a/src/main/scala/scalismo/numerics/PivotedCholesky.scala
+++ b/src/main/scala/scalismo/numerics/PivotedCholesky.scala
@@ -113,7 +113,7 @@ object PivotedCholesky {
       S(p(k)) = D
 
       val pointIds = ids.splitAt(k + 1)._2
-      val chunks = pointIds.grouped(n / Runtime.getRuntime().availableProcessors()).toIndexedSeq.par
+      val chunks = pointIds.grouped(Math.max(1, n / Runtime.getRuntime().availableProcessors())).toIndexedSeq.par
 
       var c = 0
 

--- a/src/main/scala/scalismo/statisticalmodel/DiscreteLowRankGaussianProcess.scala
+++ b/src/main/scala/scalismo/statisticalmodel/DiscreteLowRankGaussianProcess.scala
@@ -454,7 +454,6 @@ object DiscreteLowRankGaussianProcess {
     } else {
 
       val (v, d2) = PivotedCholesky.computeApproximateEig(X * X.t * (1.0 / (n - 1)), 1.0, stoppingCriterion)
-      val vt = v.t
 
       val D = d2.map(v => Math.sqrt(v))
       val Dinv = D.map(d => if (d > 1e-6) 1.0 / d else 0.0)
@@ -465,7 +464,7 @@ object DiscreteLowRankGaussianProcess {
       }
 
       // The final basis matrix is commputed based on the data matrix and v
-      val U: DenseMatrix[Double] = X.t * vt.t
+      val U: DenseMatrix[Double] = X.t * v
       (U, d2)
 
     }


### PR DESCRIPTION
The current PCA implementation in Scalismo is not ideal in several respects:
1. It does many unnecessary explicit matrix computation, which lead to a large memory overhead
2. It does not distinguish the cases more variables than datasets and more datasets than variables, thus leading to unnessary computation in the latter case
3. There is no possibility to compute only the leading principle components

This PR fixes all these issues. To avoid computing all principle components, it uses the pivoted cholesky decomposition. 

Note, before this PR is merged, the documentation of the PCA and Pivoted Cholesky should be improved.   