### PR TITLE
DataCollection Mesh Loading Memory Fix

### DIFF
--- a/src/main/scala/scalismo/statisticalmodel/dataset/DataCollection.scala
+++ b/src/main/scala/scalismo/statisticalmodel/dataset/DataCollection.scala
@@ -128,7 +128,10 @@ object DataCollection {
    */
   def fromMeshDirectory(referenceMesh: TriangleMesh[_3D], meshDirectory: File)(implicit rng: Random): (Option[DataCollection], Seq[Throwable]) = {
     val meshFileNames = meshDirectory.listFiles().toSeq.filter(fn => fn.getAbsolutePath.endsWith(".vtk") || fn.getAbsolutePath.endsWith(".stl"))
-    val (meshes, ioErrors) = DataUtils.partitionSuccAndFailedTries(for (meshFn <- meshFileNames) yield { MeshIO.readMesh(meshFn) })
+    val (meshes, ioErrors) = DataUtils.partitionSuccAndFailedTries(for (meshFn <- meshFileNames) yield {
+      val fullMesh = MeshIO.readMesh(meshFn)
+      fullMesh.map(m => TriangleMesh3D(m.pointSet,referenceMesh.triangulation))
+    })
     val (dc, meshErrors) = fromMeshSequence(referenceMesh, meshes)
     (dc, ioErrors ++ meshErrors)
   }

--- a/src/main/scala/scalismo/statisticalmodel/dataset/DataCollection.scala
+++ b/src/main/scala/scalismo/statisticalmodel/dataset/DataCollection.scala
@@ -129,8 +129,7 @@ object DataCollection {
   def fromMeshDirectory(referenceMesh: TriangleMesh[_3D], meshDirectory: File)(implicit rng: Random): (Option[DataCollection], Seq[Throwable]) = {
     val meshFileNames = meshDirectory.listFiles().toSeq.filter(fn => fn.getAbsolutePath.endsWith(".vtk") || fn.getAbsolutePath.endsWith(".stl"))
     val (meshes, ioErrors) = DataUtils.partitionSuccAndFailedTries(for (meshFn <- meshFileNames) yield {
-      val fullMesh = MeshIO.readMesh(meshFn)
-      fullMesh.map(m => TriangleMesh3D(m.pointSet,referenceMesh.triangulation))
+      MeshIO.readMesh(meshFn).map(m => TriangleMesh3D(m.pointSet, referenceMesh.triangulation))
     })
     val (dc, meshErrors) = fromMeshSequence(referenceMesh, meshes)
     (dc, ioErrors ++ meshErrors)


### PR DESCRIPTION
This pull request reduces the memory footprint of the function that loads meshes from directory for the data collection. 

This fix relates to the discussion in the Scalismo google group: https://groups.google.com/forum/#!topic/scalismo/MddIEgAnWBg

This should be included as a hotfix.