### PR TITLE
added explicit jvm-target directive for Scala 2.12 and higher

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -22,7 +22,7 @@ object BuildSettings {
     crossScalaVersions := Seq("2.11.12", "2.12.6"),
     javacOptions ++= (CrossVersion.partialVersion(scalaVersion.value) match {
       case Some((2,  11)) => Seq("-source", "1.6", "-target", "1.6")
-      case _ => Seq()
+      case _ => Seq("-source", "1.8", "-target", "1.8")
     }),
     scalacOptions ++= (CrossVersion.partialVersion(scalaVersion.value) match {
       case Some((2,  11)) =>  Seq("-encoding", "UTF-8", "-Xlint", "-deprecation", "-unchecked", "-feature", "-target:jvm-1.6")


### PR DESCRIPTION
The target jvm was not set explicitly set for Scala 2.12 or higher. This results in runtime errors for users of Java 8, when a new java version is used to compile and publish Scalismo. 

This PR explicitly sets the target and thus avoids such errors. 

As the currently published version 0.17.1 was published using Java 8, no action is required on the publishing side.