### PR TITLE
use openjdk8 on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ language: scala
 env:
  - SCALISMO_PLATFORM=linux64
 
+jdk:
+  - openjdk8
+
+
 ## Caching seems to cause problems of its own, so we leave it commented for now.
 ## We use travis_wait instead (see below in the script: section) to give the build more time.
 #cache:
@@ -17,7 +21,6 @@ scala:
   - 2.12.1
 
 script:
-  - jdk_switcher use oraclejdk8
   - travis_wait sbt ++$TRAVIS_SCALA_VERSION update
   - travis_wait sbt ++$TRAVIS_SCALA_VERSION -Djava.awt.headless=true compile test
   - sbt scalariformFormat && git diff --exit-code   # fails build if scalariform results in changes to the code


### PR DESCRIPTION
We explicitly set the java environment to java 8 in travis tests. This ensures that annoying compatibility problems, when developing with newer versions, will be detected early.