### PR TITLE
Corrected domainsize for linearImageInterpolators. Fixes #270

### DIFF
--- a/src/main/scala/scalismo/common/interpolation/LinearInterpolation.scala
+++ b/src/main/scala/scalismo/common/interpolation/LinearInterpolation.scala
@@ -16,7 +16,7 @@
 
 package scalismo.common.interpolation
 
-import scalismo.common.{ DiscreteField, Field }
+import scalismo.common.{ BoxDomain, DiscreteField, Field }
 import scalismo.geometry._
 import scalismo.image.DiscreteImageDomain
 import scalismo.numerics.ValueInterpolator
@@ -79,7 +79,7 @@ case class LinearImageInterpolator1D[A: ValueInterpolator]() extends LinearImage
       )
     }
 
-    Field(domain.boundingBox, interpolatePoint)
+    Field(domain.imageBoundingBox, interpolatePoint)
   }
 }
 
@@ -121,7 +121,7 @@ case class LinearImageInterpolator2D[A: ValueInterpolator]() extends LinearImage
       )
     }
 
-    Field(domain.boundingBox, interpolatePoint)
+    Field(df.domain.imageBoundingBox, interpolatePoint)
   }
 }
 
@@ -174,6 +174,6 @@ case class LinearImageInterpolator3D[A: ValueInterpolator]() extends LinearImage
       c
     }
 
-    Field(domain.boundingBox, interpolatePoint)
+    Field(domain.imageBoundingBox, interpolatePoint)
   }
 }

--- a/src/main/scala/scalismo/image/DiscreteImageDomain.scala
+++ b/src/main/scala/scalismo/image/DiscreteImageDomain.scala
@@ -66,16 +66,29 @@ abstract class DiscreteImageDomain[D: NDSpace] extends DiscreteDomain[D] with Eq
   //def pointToIndex(p: Point[D]): Index[D]
 
   /**
-   * a rectangular region that represents the area over which an image is defined by the points
-   * that represent this image.
+   * a rectangular region that represents the area, which defines the bounding box of the points that make up the
+   * image domain. Warning: This is by one "Voxel" smaller than the region on which the image is defined, as each point
+   * of the domain represents one "voxel".
    *
    * The bounding box origin is always the lower left corner of the image domain, which might be different
    * from the image domain's origin if it is not RAI oriented.
    *
    * An important assumption here is that all images in Scalismo are oriented along the spatial axis (i.e. no oblique images.
    * These are handled at IO by resampling to axis oriented images).
+   *
+   * @see imageBoundingBox
    */
   override def boundingBox: BoxDomain[D]
+
+  /**
+   * a rectangular region over which the image is defined.
+   */
+  def imageBoundingBox: BoxDomain[D] = {
+    // The image bounding box is 1*spacing larger than the bounding box of the point of the domain, as
+    // every point of the domain represents one voxel.
+    val bb = boundingBox
+    BoxDomain(bb.origin, bb.oppositeCorner + spacing)
+  }
 
   /** true if the point is part of the grid points */
   override def isDefinedAt(pt: Point[D]): Boolean = {

--- a/src/test/scala/scalismo/common/LinearInterpolatorTest.scala
+++ b/src/test/scala/scalismo/common/LinearInterpolatorTest.scala
@@ -18,8 +18,9 @@ package scalismo.common
 
 import scalismo.ScalismoTestSuite
 import scalismo.geometry._
-import scalismo.image.{ DiscreteImageDomain, DiscreteScalarImage }
-import scalismo.common.interpolation.LinearImageInterpolator
+import scalismo.image.{DiscreteImageDomain, DiscreteScalarImage}
+import scalismo.common.interpolation.{LinearImageInterpolator, LinearImageInterpolator3D}
+import scalismo.io.ImageIO
 
 class LinearInterpolatorTest extends ScalismoTestSuite {
 
@@ -69,6 +70,24 @@ class LinearInterpolatorTest extends ScalismoTestSuite {
       img_interpolated(point) shouldBe 0.5
 
     }
+
+    it("can be evaluated everywhere where the original image is defined") {
+      val originalDomain = DiscreteImageDomain(Point(0, 0, 0), EuclideanVector(0.1, 0.1, 0.1), IntVector(10, 10, 10))
+      val img = DiscreteScalarImage(originalDomain, (p: Point[_3D]) => p.x)
+      val fineDomain = DiscreteImageDomain(originalDomain.imageBoundingBox, IntVector(100, 100, 100))
+
+      val interpolatedImg = img.interpolate(LinearImageInterpolator3D[Double]())
+      for (pt <- fineDomain.points) {
+        interpolatedImg.isDefinedAt(pt) shouldBe (true)
+      }
+
+      try {
+        interpolatedImg.sample[Double](fineDomain, 0)
+      } catch {
+        case ex: Exception => fail("Should not throw Exception", ex)
+      }
+    }
+
 
   }
 

--- a/src/test/scala/scalismo/common/LinearInterpolatorTest.scala
+++ b/src/test/scala/scalismo/common/LinearInterpolatorTest.scala
@@ -18,8 +18,8 @@ package scalismo.common
 
 import scalismo.ScalismoTestSuite
 import scalismo.geometry._
-import scalismo.image.{DiscreteImageDomain, DiscreteScalarImage}
-import scalismo.common.interpolation.{LinearImageInterpolator, LinearImageInterpolator3D}
+import scalismo.image.{ DiscreteImageDomain, DiscreteScalarImage }
+import scalismo.common.interpolation.{ LinearImageInterpolator, LinearImageInterpolator3D }
 import scalismo.io.ImageIO
 
 class LinearInterpolatorTest extends ScalismoTestSuite {
@@ -87,7 +87,6 @@ class LinearInterpolatorTest extends ScalismoTestSuite {
         case ex: Exception => fail("Should not throw Exception", ex)
       }
     }
-
 
   }
 


### PR DESCRIPTION
This commit fixes the problem that the domain of the interpolated image was defined one voxel too small by the ```LinearImageInterpolator```. The reason was the incorrect use of the bounding box, which is the bounding box around the points that defined the image grid, but not the area where the image is defined. 

To avoid future confusion, a new method ```imageBoundingBox``` was introduced, which makes it easy to obtain the correct region over which the image is defined. 