### PR TITLE
corrected computation of continuous indices in image domains. fixes #272

### DIFF
--- a/src/main/scala/scalismo/image/DiscreteImageDomain.scala
+++ b/src/main/scala/scalismo/image/DiscreteImageDomain.scala
@@ -109,8 +109,7 @@ abstract class DiscreteImageDomain[D: NDSpace] extends DiscreteDomain[D] with Eq
   }
 
   private def pointToContinuousIndex(pt: Point[D]): EuclideanVector[D] = {
-    val data = (0 until dimensionality).map(i => (pt(i) - origin(i)) / spacing(i))
-    EuclideanVector[D](data.toArray)
+    physicalCoordinateToContinuousIndex(pt).toVector
   }
 
   def indexToPoint(i: IntVector[D]) = indexToPhysicalCoordinateTransform(Point[D](i.toArray.map(_.toDouble)))
@@ -119,6 +118,7 @@ abstract class DiscreteImageDomain[D: NDSpace] extends DiscreteDomain[D] with Eq
 
   /** the anisotropic similarity transform that maps between the index and physical coordinates*/
   private[scalismo] def indexToPhysicalCoordinateTransform: AnisotropicSimilarityTransformation[D]
+  private[scalismo] def physicalCoordinateToContinuousIndex: AnisotropicSimilarityTransformation[D]
 
   /**
    * *
@@ -215,6 +215,8 @@ object DiscreteImageDomain {
 //
 case class DiscreteImageDomain1D(size: IntVector[_1D], indexToPhysicalCoordinateTransform: AnisotropicSimilarityTransformation[_1D]) extends DiscreteImageDomain[_1D] {
 
+  override private[scalismo] val physicalCoordinateToContinuousIndex = indexToPhysicalCoordinateTransform.inverse
+
   override val origin = Point1D(indexToPhysicalCoordinateTransform(Point(0))(0))
   private val iVecImage: EuclideanVector1D = indexToPhysicalCoordinateTransform(Point(1)) - indexToPhysicalCoordinateTransform(Point(0))
   override val spacing = EuclideanVector1D(iVecImage.norm.toFloat)
@@ -255,6 +257,8 @@ case class DiscreteImageDomain2D(size: IntVector[_2D], indexToPhysicalCoordinate
     val p = indexToPhysicalCoordinateTransform(Point(0, 0))
     Point2D(p(0), p(1))
   }
+
+  override private[scalismo] val physicalCoordinateToContinuousIndex = indexToPhysicalCoordinateTransform.inverse
 
   private val iVecImage: EuclideanVector2D = indexToPhysicalCoordinateTransform(Point(1, 0)) - indexToPhysicalCoordinateTransform(Point(0, 0))
   private val jVecImage: EuclideanVector2D = indexToPhysicalCoordinateTransform(Point(0, 1)) - indexToPhysicalCoordinateTransform(Point(0, 0))
@@ -303,6 +307,8 @@ case class DiscreteImageDomain3D(size: IntVector[_3D], indexToPhysicalCoordinate
     val p = indexToPhysicalCoordinateTransform(Point(0, 0, 0))
     Point3D(p(0), p(1), p(2))
   }
+
+  override private[scalismo] val physicalCoordinateToContinuousIndex = indexToPhysicalCoordinateTransform.inverse
 
   private val positiveScalingParameters = indexToPhysicalCoordinateTransform.parameters(6 to 8).map(math.abs)
   override val spacing = EuclideanVector3D(positiveScalingParameters(0), positiveScalingParameters(1), positiveScalingParameters(2))

--- a/src/main/scala/scalismo/registration/TransformationSpace.scala
+++ b/src/main/scala/scalismo/registration/TransformationSpace.scala
@@ -796,18 +796,20 @@ case class AnisotropicScalingSpace[D: NDSpace]() extends TransformationSpace[D] 
  * The order of the rigid transform in this case is also fixed : first rotate then translate.
  *
  */
-trait AnisotropicSimilarityTransformation[D] extends CompositeTransformation[D] with CanInvert[D]
+trait AnisotropicSimilarityTransformation[D] extends CompositeTransformation[D] with CanInvert[D] {
+  override def inverse : AnisotropicSimilarityTransformation[D]
+}
 
 private class RigidTransformationThenAnisotropicScaling[D: NDSpace](anisotropicScaling: AnisotropicScalingTransformation[D], rigidTransform: RigidTransformation[D])
     extends CompositeTransformation[D](anisotropicScaling, rigidTransform) with AnisotropicSimilarityTransformation[D] {
 
-  def inverse: AnisotropicScalingThenRigidTransformation[D] = new AnisotropicScalingThenRigidTransformation[D](rigidTransform.inverse, anisotropicScaling.inverse)
+  override def inverse: AnisotropicScalingThenRigidTransformation[D] = new AnisotropicScalingThenRigidTransformation[D](rigidTransform.inverse, anisotropicScaling.inverse)
 }
 
 private class AnisotropicScalingThenRigidTransformation[D: NDSpace](rigidTransform: RigidTransformation[D], anisotropicScaling: AnisotropicScalingTransformation[D])
     extends CompositeTransformation[D](rigidTransform, anisotropicScaling) with AnisotropicSimilarityTransformation[D] {
 
-  def inverse: RigidTransformationThenAnisotropicScaling[D] = new RigidTransformationThenAnisotropicScaling[D](anisotropicScaling.inverse, rigidTransform.inverse)
+  override def inverse: RigidTransformationThenAnisotropicScaling[D] = new RigidTransformationThenAnisotropicScaling[D](anisotropicScaling.inverse, rigidTransform.inverse)
 }
 
 /**

--- a/src/test/scala/scalismo/image/DiscreteImageDomainTests.scala
+++ b/src/test/scala/scalismo/image/DiscreteImageDomainTests.scala
@@ -25,8 +25,11 @@ import scalismo.geometry.Point.implicits._
 import scalismo.geometry.EuclideanVector.implicits._
 import scalismo.geometry._
 import scalismo.io.ImageIO
+import scalismo.utils.Random
 
 class DiscreteImageDomainTests extends ScalismoTestSuite {
+
+  implicit val rng = Random(42)
 
   describe("a discreteImageDomain domain") {
     it("correctly reports the number of points") {
@@ -128,6 +131,22 @@ class DiscreteImageDomainTests extends ScalismoTestSuite {
       val idx = IntVector(5, 3, 7)
       val recIdx = domain.index(domain.pointId(idx))
       assert(recIdx === idx)
+    }
+
+    it("correctly computes closest points") {
+
+      // this test implicitly tests also the method pointToContinuousIndex
+
+      val domain = DiscreteImageDomain[_3D]((1.0, 2.0, 3.0), (2.0, 1.0, 0.0), (42, 49, 74))
+
+      val distx = rng.breezeRandBasis.uniform.map(u => domain.spacing(0) * 0.4)
+      val disty = rng.breezeRandBasis.uniform.map(u => domain.spacing(1) * 0.4)
+      val distz = rng.breezeRandBasis.uniform.map(u => domain.spacing(2) * 0.4)
+
+      for (pt <- domain.points) {
+        val perturbedPoint = Point(pt.x + distx.draw(), pt.y + disty.draw(), pt.z + distz.draw())
+        domain.findClosestPoint(perturbedPoint).point should equal(pt)
+      }
     }
 
     it("domains with same parameters yield the same anisotropic similarity transform ") {


### PR DESCRIPTION
Due to a bug in the internal method ```pointToContinuousIndex```, finding closest points for images with a negative direction matrix did not work. The reason is that this method did not properly take the anisotropic transformation into account, which scalismo uses for computing the place and orientation of the domain. 

In the context of this bugfix, I also fixed an issue with the signature of the inverse of the ```AnisotropicSimilarityTransformation```, which returned the generic type ```Transformation``` rather than the specific type ```AnisotropicSimilarityTransformation```. 