### PR TITLE
Methods for decimating triangle meshes and statistical mesh models

### DIFF
--- a/src/main/scala/scalismo/common/interpolation/TriangleMeshInterpolator.scala
+++ b/src/main/scala/scalismo/common/interpolation/TriangleMeshInterpolator.scala
@@ -1,0 +1,42 @@
+package scalismo.common.interpolation
+
+import scalismo.common.{DiscreteField, Field, RealSpace, UnstructuredPointsDomain}
+import scalismo.geometry.{Point, _3D}
+import scalismo.mesh.{SurfacePointProperty, TriangleMesh}
+import scalismo.mesh.boundingSpheres.{ClosestPointInTriangle, ClosestPointIsVertex, ClosestPointOnLine}
+import scalismo.numerics.ValueInterpolator
+
+/**
+  * Interpolates a given discrete field defined on the vertices
+  * of a triangle mesh (i.e. a MeshField) by means of a surface interpolation
+  * on the surface defined by the mesh.
+  *
+  * @param mesh The mesh on which the interpolation is performed.
+  */
+case class TriangleMeshInterpolator[A : ValueInterpolator](mesh : TriangleMesh[_3D]) extends
+  FieldInterpolator[_3D, UnstructuredPointsDomain[_3D], A] {
+
+  override def interpolate(field: DiscreteField[_3D,
+    UnstructuredPointsDomain[_3D], A]): Field[_3D, A] = {
+
+    // for this method to make sense, the field needs to be defined
+    // on the mesh. There is no good way to check this rigorously.
+    // A simple sanity check is, however, that the number of points
+    // of the domain is the same.
+    require(mesh.pointSet.numberOfPoints == field.values.size)
+
+    val fieldOnSurface =
+      SurfacePointProperty(mesh.triangulation, field.values.toIndexedSeq)
+
+    val f = (pt: Point[_3D]) =>
+      mesh.operations.closestPointOnSurface(pt) match {
+        case ClosestPointIsVertex(pt, _, id) => fieldOnSurface(id)
+        case ClosestPointInTriangle(pt, _, id, bc) =>
+          fieldOnSurface(id, bc)
+        case ClosestPointOnLine(pt, _, (id0, id1), d) =>
+          ValueInterpolator[A].blend(fieldOnSurface(id0), fieldOnSurface(id1), d)
+      }
+    Field(RealSpace[_3D], f)
+  }
+}
+

--- a/src/main/scala/scalismo/common/interpolation/TriangleMeshInterpolator.scala
+++ b/src/main/scala/scalismo/common/interpolation/TriangleMeshInterpolator.scala
@@ -1,23 +1,21 @@
 package scalismo.common.interpolation
 
-import scalismo.common.{DiscreteField, Field, RealSpace, UnstructuredPointsDomain}
-import scalismo.geometry.{Point, _3D}
-import scalismo.mesh.{SurfacePointProperty, TriangleMesh}
-import scalismo.mesh.boundingSpheres.{ClosestPointInTriangle, ClosestPointIsVertex, ClosestPointOnLine}
+import scalismo.common.{ DiscreteField, Field, RealSpace, UnstructuredPointsDomain }
+import scalismo.geometry.{ Point, _3D }
+import scalismo.mesh.{ SurfacePointProperty, TriangleMesh }
+import scalismo.mesh.boundingSpheres.{ ClosestPointInTriangle, ClosestPointIsVertex, ClosestPointOnLine }
 import scalismo.numerics.ValueInterpolator
 
 /**
-  * Interpolates a given discrete field defined on the vertices
-  * of a triangle mesh (i.e. a MeshField) by means of a surface interpolation
-  * on the surface defined by the mesh.
-  *
-  * @param mesh The mesh on which the interpolation is performed.
-  */
-case class TriangleMeshInterpolator[A : ValueInterpolator](mesh : TriangleMesh[_3D]) extends
-  FieldInterpolator[_3D, UnstructuredPointsDomain[_3D], A] {
+ * Interpolates a given discrete field defined on the vertices
+ * of a triangle mesh (i.e. a MeshField) by means of a surface interpolation
+ * on the surface defined by the mesh.
+ *
+ * @param mesh The mesh on which the interpolation is performed.
+ */
+case class TriangleMeshInterpolator[A: ValueInterpolator](mesh: TriangleMesh[_3D]) extends FieldInterpolator[_3D, UnstructuredPointsDomain[_3D], A] {
 
-  override def interpolate(field: DiscreteField[_3D,
-    UnstructuredPointsDomain[_3D], A]): Field[_3D, A] = {
+  override def interpolate(field: DiscreteField[_3D, UnstructuredPointsDomain[_3D], A]): Field[_3D, A] = {
 
     // for this method to make sense, the field needs to be defined
     // on the mesh. There is no good way to check this rigorously.

--- a/src/main/scala/scalismo/mesh/MeshOperations.scala
+++ b/src/main/scala/scalismo/mesh/MeshOperations.scala
@@ -15,10 +15,11 @@
  */
 package scalismo.mesh
 
-import scalismo.common.{ PointId, RealSpace }
-import scalismo.geometry.{ EuclideanVector, Point, _3D }
-import scalismo.image.{ DifferentiableScalarImage, ScalarImage }
+import scalismo.common.{PointId, RealSpace}
+import scalismo.geometry.{EuclideanVector, Point, _3D}
+import scalismo.image.{DifferentiableScalarImage, ScalarImage}
 import scalismo.mesh.boundingSpheres._
+import scalismo.utils.MeshConversion
 
 object MeshOperations {
   def apply(mesh: TriangleMesh3D) = new TriangleMesh3DOperations(mesh)
@@ -178,5 +179,27 @@ class TriangleMesh3DOperations(private val mesh: TriangleMesh3D) {
   def compact: MeshCompactifier = {
     mask(_ => true, _ => true)
   }
+
+  /**
+    * Attempts to reduce the number of vertices of a mesh to the given number of vertices.
+    *
+    * @param targetedNumberOfVertices The targeted number of vertices. Note that it is not guaranteed
+    *                                 that this number is reached exactly
+    * @return The decimated mesh
+    */
+  def decimate(targetedNumberOfVertices : Int) : TriangleMesh[_3D] = {
+      val refVtk = MeshConversion.meshToVtkPolyData(mesh)
+      val decimatePro = new vtk.vtkDecimatePro()
+
+      val reductionRate = 1.0 - (targetedNumberOfVertices / mesh.pointSet.numberOfPoints)
+
+      decimatePro.SetTargetReduction(reductionRate)
+
+      decimatePro.SetInputData(refVtk)
+      decimatePro.Update()
+      val decimatedRefVTK = decimatePro.GetOutput()
+      MeshConversion.vtkPolyDataToTriangleMesh(decimatedRefVTK).get
+  }
+
 }
 

--- a/src/main/scala/scalismo/mesh/MeshOperations.scala
+++ b/src/main/scala/scalismo/mesh/MeshOperations.scala
@@ -15,9 +15,9 @@
  */
 package scalismo.mesh
 
-import scalismo.common.{PointId, RealSpace}
-import scalismo.geometry.{EuclideanVector, Point, _3D}
-import scalismo.image.{DifferentiableScalarImage, ScalarImage}
+import scalismo.common.{ PointId, RealSpace }
+import scalismo.geometry.{ EuclideanVector, Point, _3D }
+import scalismo.image.{ DifferentiableScalarImage, ScalarImage }
 import scalismo.mesh.boundingSpheres._
 import scalismo.utils.MeshConversion
 
@@ -181,24 +181,24 @@ class TriangleMesh3DOperations(private val mesh: TriangleMesh3D) {
   }
 
   /**
-    * Attempts to reduce the number of vertices of a mesh to the given number of vertices.
-    *
-    * @param targetedNumberOfVertices The targeted number of vertices. Note that it is not guaranteed
-    *                                 that this number is reached exactly
-    * @return The decimated mesh
-    */
-  def decimate(targetedNumberOfVertices : Int) : TriangleMesh[_3D] = {
-      val refVtk = MeshConversion.meshToVtkPolyData(mesh)
-      val decimatePro = new vtk.vtkDecimatePro()
+   * Attempts to reduce the number of vertices of a mesh to the given number of vertices.
+   *
+   * @param targetedNumberOfVertices The targeted number of vertices. Note that it is not guaranteed
+   *                                 that this number is reached exactly
+   * @return The decimated mesh
+   */
+  def decimate(targetedNumberOfVertices: Int): TriangleMesh[_3D] = {
+    val refVtk = MeshConversion.meshToVtkPolyData(mesh)
+    val decimatePro = new vtk.vtkDecimatePro()
 
-      val reductionRate = 1.0 - (targetedNumberOfVertices / mesh.pointSet.numberOfPoints)
+    val reductionRate = 1.0 - (targetedNumberOfVertices / mesh.pointSet.numberOfPoints)
 
-      decimatePro.SetTargetReduction(reductionRate)
+    decimatePro.SetTargetReduction(reductionRate)
 
-      decimatePro.SetInputData(refVtk)
-      decimatePro.Update()
-      val decimatedRefVTK = decimatePro.GetOutput()
-      MeshConversion.vtkPolyDataToTriangleMesh(decimatedRefVTK).get
+    decimatePro.SetInputData(refVtk)
+    decimatePro.Update()
+    val decimatedRefVTK = decimatePro.GetOutput()
+    MeshConversion.vtkPolyDataToTriangleMesh(decimatedRefVTK).get
   }
 
 }

--- a/src/main/scala/scalismo/mesh/MeshOperations.scala
+++ b/src/main/scala/scalismo/mesh/MeshOperations.scala
@@ -191,7 +191,7 @@ class TriangleMesh3DOperations(private val mesh: TriangleMesh3D) {
     val refVtk = MeshConversion.meshToVtkPolyData(mesh)
     val decimatePro = new vtk.vtkDecimatePro()
 
-    val reductionRate = 1.0 - (targetedNumberOfVertices / mesh.pointSet.numberOfPoints)
+    val reductionRate = 1.0 - (targetedNumberOfVertices / mesh.pointSet.numberOfPoints.toDouble)
 
     decimatePro.SetTargetReduction(reductionRate)
 

--- a/src/main/scala/scalismo/statisticalmodel/StatisticalMeshModel.scala
+++ b/src/main/scala/scalismo/statisticalmodel/StatisticalMeshModel.scala
@@ -16,20 +16,20 @@
 package scalismo.statisticalmodel
 
 import breeze.linalg.svd.SVD
-import breeze.linalg.{DenseMatrix, DenseVector}
+import breeze.linalg.{ DenseMatrix, DenseVector }
 import breeze.numerics.sqrt
 import scalismo.common._
 import scalismo.common.interpolation.TriangleMeshInterpolator
 import scalismo.geometry.EuclideanVector._
 import scalismo.geometry._
 import scalismo.mesh._
-import scalismo.numerics.{FixedPointsUniformMeshSampler3D, PivotedCholesky}
+import scalismo.numerics.{ FixedPointsUniformMeshSampler3D, PivotedCholesky }
 import scalismo.registration.RigidTransformation
 import scalismo.statisticalmodel.DiscreteLowRankGaussianProcess.Eigenpair
 import scalismo.statisticalmodel.dataset.DataCollection
 import scalismo.utils.Random
 
-import scala.util.{Failure, Success, Try}
+import scala.util.{ Failure, Success, Try }
 
 /**
  * A StatisticalMeshModel is isomorphic to a [[DiscreteLowRankGaussianProcess]]. The difference is that while the DiscreteLowRankGaussianProcess
@@ -192,11 +192,11 @@ case class StatisticalMeshModel private (referenceMesh: TriangleMesh[_3D], gp: D
   }
 
   /**
-    * Changes the number of vertices on which the model is defined
-    * @param targetNumberOfVertices  The desired number of vertices
-    * @return The new model
-    */
-  def decimate(targetNumberOfVertices : Int) : StatisticalMeshModel = {
+   * Changes the number of vertices on which the model is defined
+   * @param targetNumberOfVertices  The desired number of vertices
+   * @return The new model
+   */
+  def decimate(targetNumberOfVertices: Int): StatisticalMeshModel = {
 
     val newReference = referenceMesh.operations.decimate(targetNumberOfVertices)
     val interpolator = TriangleMeshInterpolator[EuclideanVector[_3D]](referenceMesh)

--- a/src/test/scala/scalismo/mesh/MeshDecimationTests.scala
+++ b/src/test/scala/scalismo/mesh/MeshDecimationTests.scala
@@ -12,8 +12,9 @@ class MeshDecimationTests extends ScalismoTestSuite {
     val facemesh = MeshIO.readMesh(new File(path)).get
 
     it("has a reduced number of points") {
-      val reducedMesh = facemesh.operations.decimate(facemesh.pointSet.numberOfPoints / 2)
-      reducedMesh.pointSet.numberOfPoints should be < (facemesh.pointSet.numberOfPoints)
+      val reducedMesh = facemesh.operations.decimate(facemesh.pointSet.numberOfPoints / 3)
+      val reductionRatio = reducedMesh.pointSet.numberOfPoints / facemesh.pointSet.numberOfPoints.toDouble
+      reductionRatio should be(0.3 +- 0.1)
     }
 
     it("has approximately preserves the surface") {

--- a/src/test/scala/scalismo/mesh/MeshDecimationTests.scala
+++ b/src/test/scala/scalismo/mesh/MeshDecimationTests.scala
@@ -1,0 +1,24 @@
+package scalismo.mesh
+
+import java.io.File
+
+import scalismo.ScalismoTestSuite
+import scalismo.io.MeshIO
+
+class MeshDecimationTests extends ScalismoTestSuite {
+  describe("A decimated mesh") {
+
+    val path = getClass.getResource("/facemesh.stl").getPath
+    val facemesh = MeshIO.readMesh(new File(path)).get
+
+    it("has a reduced number of points") {
+      val reducedMesh = facemesh.operations.decimate(facemesh.pointSet.numberOfPoints / 2)
+      reducedMesh.pointSet.numberOfPoints should be < (facemesh.pointSet.numberOfPoints)
+    }
+
+    it("has approximately preserves the surface") {
+      val reducedMesh = facemesh.operations.decimate(facemesh.pointSet.numberOfPoints / 2)
+      MeshMetrics.hausdorffDistance(reducedMesh, facemesh) < 1.0
+    }
+  }
+}

--- a/src/test/scala/scalismo/statisticalmodel/StatisticalModelTests.scala
+++ b/src/test/scala/scalismo/statisticalmodel/StatisticalModelTests.scala
@@ -23,7 +23,7 @@ import scalismo.ScalismoTestSuite
 import scalismo.geometry._
 import scalismo.io.StatismoIO
 import scalismo.mesh.MeshMetrics
-import scalismo.registration.{RigidTransformation, RigidTransformationSpace}
+import scalismo.registration.{ RigidTransformation, RigidTransformationSpace }
 import scalismo.utils.Random
 
 import scala.language.implicitConversions
@@ -100,7 +100,7 @@ class StatisticalModelTests extends ScalismoTestSuite {
       val coeffs = model.coefficients(randomMesh)
 
       val correspondingSampleDecimatedModel = decimatedModel.instance(coeffs)
-      decimatedModel.referenceMesh.pointSet.numberOfPoints should be <(model.referenceMesh.pointSet.numberOfPoints)
+      decimatedModel.referenceMesh.pointSet.numberOfPoints should be < (model.referenceMesh.pointSet.numberOfPoints)
       correspondingSampleDecimatedModel.pointSet.numberOfPoints should equal(decimatedModel.referenceMesh.pointSet.numberOfPoints)
 
       MeshMetrics.hausdorffDistance(randomMesh, correspondingSampleDecimatedModel) < 1

--- a/src/test/scala/scalismo/statisticalmodel/StatisticalModelTests.scala
+++ b/src/test/scala/scalismo/statisticalmodel/StatisticalModelTests.scala
@@ -21,8 +21,9 @@ import breeze.linalg.DenseVector
 import breeze.stats.distributions.Gaussian
 import scalismo.ScalismoTestSuite
 import scalismo.geometry._
-import scalismo.io.{ StatismoIO }
-import scalismo.registration.{ RigidTransformation, RigidTransformationSpace }
+import scalismo.io.StatismoIO
+import scalismo.mesh.MeshMetrics
+import scalismo.registration.{RigidTransformation, RigidTransformationSpace}
 import scalismo.utils.Random
 
 import scala.language.implicitConversions
@@ -87,6 +88,22 @@ class StatisticalModelTests extends ScalismoTestSuite {
       val truncatedModel = model.truncate(newRank)
       truncatedModel.rank should equal(newRank)
 
+    }
+
+    it("yield equivalent samples with reduced number of points when decimated") {
+      val path = getClass.getResource("/facemodel.h5").getPath
+      val model = StatismoIO.readStatismoMeshModel(new File(path)).get
+      val targetNumberOfPoints = model.referenceMesh.pointSet.numberOfPoints / 2
+      val decimatedModel = model.decimate(targetNumberOfPoints)
+
+      val randomMesh = model.sample()
+      val coeffs = model.coefficients(randomMesh)
+
+      val correspondingSampleDecimatedModel = decimatedModel.instance(coeffs)
+      decimatedModel.referenceMesh.pointSet.numberOfPoints should be <(model.referenceMesh.pointSet.numberOfPoints)
+      correspondingSampleDecimatedModel.pointSet.numberOfPoints should equal(decimatedModel.referenceMesh.pointSet.numberOfPoints)
+
+      MeshMetrics.hausdorffDistance(randomMesh, correspondingSampleDecimatedModel) < 1
     }
 
     //    it("can write a changed mean statistical mode, read it and still yield the same space") {


### PR DESCRIPTION
Being able to painlessly reducing the size of meshes and models is of great importance when implementing efficient sampling-based pipelines. This PR proposes to add methods to decimate meshes and statistical mesh models.

As a helper function, a new interpolator, ```TriangleMeshInterpolator```, which interpolates on
the surface defined on a triangle mesh is implemented.