### PR TITLE
Scala 2.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ jdk:
 #  - rm -f $HOME/.ivy2/.*.lock $HOME/.ivy2/*.lock
 
 scala:
-  - 2.12.1
+  - 2.13.0
 
 script:
   - travis_wait sbt ++$TRAVIS_SCALA_VERSION update

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -5,7 +5,6 @@ import com.typesafe.sbteclipse.plugin.EclipsePlugin._
 import com.typesafe.sbt.SbtSite.site
 import com.typesafe.sbt.SbtGhPages._
 import com.typesafe.sbt.SbtGit.git
-
 import com.banno.license.Plugin.LicenseKeys._
 import com.banno.license.Licenses._
 import sbtbuildinfo.Plugin._
@@ -13,13 +12,13 @@ import com.typesafe.sbt.SbtGit.useJGit
 
 object BuildSettings {
   val buildOrganization = "ch.unibas.cs.gravis"
-  val buildScalaVersion = "2.12.8"
+  val buildScalaVersion = "2.13.0"
 
 
   val buildSettings = Defaults.defaultSettings ++ Seq(
     organization := buildOrganization,
     scalaVersion := buildScalaVersion,
-    crossScalaVersions := Seq("2.11.12", "2.12.18", "2.13.0"),
+    crossScalaVersions := Seq("2.11.12", "2.12.8", "2.13.0"),
     javacOptions ++= (CrossVersion.partialVersion(scalaVersion.value) match {
       case Some((2,  11)) => Seq("-source", "1.6", "-target", "1.6")
       case _ => Seq("-source", "1.8", "-target", "1.8")
@@ -66,7 +65,17 @@ object STKBuild extends Build {
     "scalismo",
     file("."),
     settings = buildSettings ++ Seq(
-      libraryDependencies ++= commonDeps,
+      libraryDependencies ++= {
+        CrossVersion.partialVersion(scalaVersion.value) match {
+          case Some((2, major)) if major >= 13 => {
+            commonDeps ++
+              Seq("org.scala-lang.modules" %% "scala-parallel-collections" % "0.2.0")
+          }
+          case _ => {
+            commonDeps
+          }
+        }
+      },
       resolvers ++= stkResolvers,
       parallelExecution in Test := false,
       EclipseKeys.withSource := true)
@@ -82,7 +91,7 @@ object STKBuild extends Build {
         useJGit
       ) ++
       buildInfoSettings ++
-      Seq(
+      Seq(  
       sourceGenerators in Compile <+= buildInfo,
       buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion),
       buildInfoPackage := "scalismo"
@@ -100,4 +109,5 @@ object STKBuild extends Build {
     sprayJson,
     slf4jNop
   )
+
 }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -44,8 +44,8 @@ object Resolvers {
 object Dependencies {
   import BuildSettings.scalismoPlatform
   val scalatest = "org.scalatest" %% "scalatest" % "3.0.8" % "test"
-  val breezeMath = "org.scalanlp" %% "breeze" % "1.0-RC3"
-  val breezeNative = "org.scalanlp" %% "breeze-natives" % "1.0-RC3"
+  val breezeMath = "org.scalanlp" %% "breeze" % "1.0-RC4"
+  val breezeNative = "org.scalanlp" %% "breeze-natives" % "1.0-RC4"
   val sprayJson = "io.spray" %% "spray-json" % "1.3.5"
   val scalismoNativeStub = "ch.unibas.cs.gravis" % "scalismo-native-stub" % "4.0.0"
   val scalismoNativeImpl = "ch.unibas.cs.gravis" % s"scalismo-native-$scalismoPlatform" % "4.0.0" % "test"

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -45,8 +45,8 @@ object Resolvers {
 object Dependencies {
   import BuildSettings.scalismoPlatform
   val scalatest = "org.scalatest" %% "scalatest" % "3.0.1" % "test"
-  val breezeMath = "org.scalanlp" %% "breeze" % "0.13"
-  val breezeNative = "org.scalanlp" %% "breeze-natives" % "0.13"
+  val breezeMath = "org.scalanlp" %% "breeze" % "1.0-RC3"
+  val breezeNative = "org.scalanlp" %% "breeze-natives" % "1.0-RC3"
   val sprayJson = "io.spray" %% "spray-json" % "1.3.3"
   val scalismoNativeStub = "ch.unibas.cs.gravis" % "scalismo-native-stub" % "4.0.0"
   val scalismoNativeImpl = "ch.unibas.cs.gravis" % s"scalismo-native-$scalismoPlatform" % "4.0.0" % "test"

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -18,7 +18,7 @@ object BuildSettings {
   val buildSettings = Defaults.defaultSettings ++ Seq(
     organization := buildOrganization,
     scalaVersion := buildScalaVersion,
-    crossScalaVersions := Seq("2.11.12", "2.12.8", "2.13.0"),
+    crossScalaVersions := Seq("2.12.8", "2.13.0"),
     javacOptions ++= (CrossVersion.partialVersion(scalaVersion.value) match {
       case Some((2,  11)) => Seq("-source", "1.6", "-target", "1.6")
       case _ => Seq("-source", "1.8", "-target", "1.8")

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -13,13 +13,13 @@ import com.typesafe.sbt.SbtGit.useJGit
 
 object BuildSettings {
   val buildOrganization = "ch.unibas.cs.gravis"
-  val buildScalaVersion = "2.12.6"
+  val buildScalaVersion = "2.12.8"
 
 
   val buildSettings = Defaults.defaultSettings ++ Seq(
     organization := buildOrganization,
     scalaVersion := buildScalaVersion,
-    crossScalaVersions := Seq("2.11.12", "2.12.6"),
+    crossScalaVersions := Seq("2.11.12", "2.12.18", "2.13.0"),
     javacOptions ++= (CrossVersion.partialVersion(scalaVersion.value) match {
       case Some((2,  11)) => Seq("-source", "1.6", "-target", "1.6")
       case _ => Seq("-source", "1.8", "-target", "1.8")
@@ -44,10 +44,10 @@ object Resolvers {
 
 object Dependencies {
   import BuildSettings.scalismoPlatform
-  val scalatest = "org.scalatest" %% "scalatest" % "3.0.1" % "test"
+  val scalatest = "org.scalatest" %% "scalatest" % "3.0.8" % "test"
   val breezeMath = "org.scalanlp" %% "breeze" % "1.0-RC3"
   val breezeNative = "org.scalanlp" %% "breeze-natives" % "1.0-RC3"
-  val sprayJson = "io.spray" %% "spray-json" % "1.3.3"
+  val sprayJson = "io.spray" %% "spray-json" % "1.3.5"
   val scalismoNativeStub = "ch.unibas.cs.gravis" % "scalismo-native-stub" % "4.0.0"
   val scalismoNativeImpl = "ch.unibas.cs.gravis" % s"scalismo-native-$scalismoPlatform" % "4.0.0" % "test"
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.17
+sbt.version=0.13.18

--- a/src/main/scala/scalismo/common/DiscreteField.scala
+++ b/src/main/scala/scalismo/common/DiscreteField.scala
@@ -149,7 +149,7 @@ object DiscreteScalarField {
     new DiscreteScalarField[D, DDomain, A](domain, data)
   }
 
-  def apply[D: NDSpace, DDomain <: DiscreteDomain[D], A: Scalar: ClassTag](domain: DDomain, data: Traversable[A]): DiscreteScalarField[D, DDomain, A] = {
+  def apply[D: NDSpace, DDomain <: DiscreteDomain[D], A: Scalar: ClassTag](domain: DDomain, data: Iterable[A]): DiscreteScalarField[D, DDomain, A] = {
     new DiscreteScalarField[D, DDomain, A](domain, ScalarArray(data.toArray))
   }
 }

--- a/src/main/scala/scalismo/common/Scalar.scala
+++ b/src/main/scala/scalismo/common/Scalar.scala
@@ -189,11 +189,6 @@ sealed trait ScalarArray[S] extends IndexedSeq[S] {
   def length: Int
 
   /**
-   * Returns the length of the data array. This is an alias for [[ScalarArray#length]]
-   */
-  override final lazy val size = length
-
-  /**
    * Determines if <code>index</code> lies within the bounds of the array
    * @param index the index in the array for which to check if it lies within the array bounds
    * @return <code>true</code> if <code>index</code> lies within the array bounds, <code>false</code> otherwise.
@@ -279,13 +274,14 @@ final class PrimitiveScalarArray[S <: AnyVal: ClassTag](rawData: Array[S]) exten
    */
   override def iterator: Iterator[S] = rawData.iterator
 
-  override lazy val hashCode: Int = rawData.deep.hashCode()
+  override lazy val hashCode: Int = rawData.toSeq.hashCode()
 
   override def canEqual(that: Any): Boolean = that.isInstanceOf[PrimitiveScalarArray[_]]
 
   override def equals(that: Any) = {
     that match {
-      case a: PrimitiveScalarArray[_] => (this canEqual that) && this.rawData.deep == a.rawData.deep
+      case a: PrimitiveScalarArray[_] =>
+        (this canEqual that) && this.rawData.sameElements(a.rawData)
       case _ => false
     }
   }
@@ -316,13 +312,13 @@ final class ValueClassScalarArray[S <: AnyVal, U <: AnyVal](rawData: Array[U])(i
    */
   override def iterator: Iterator[S] = rawData.iterator.map(scalar.fromUnderlying)
 
-  override lazy val hashCode: Int = rawData.deep.hashCode()
+  override lazy val hashCode: Int = rawData.toSeq.hashCode()
 
   override def canEqual(that: Any): Boolean = that.isInstanceOf[ValueClassScalarArray[_, _]]
 
   override def equals(that: Any) = {
     that match {
-      case a: ValueClassScalarArray[_, _] => (this canEqual that) && this.rawData.deep == a.rawData.deep
+      case a: ValueClassScalarArray[_, _] => (this canEqual that) && this.rawData.sameElements(a.rawData)
       case _ => false
     }
   }

--- a/src/main/scala/scalismo/common/UnstructuredPointsDomain.scala
+++ b/src/main/scala/scalismo/common/UnstructuredPointsDomain.scala
@@ -21,10 +21,11 @@ import scalismo.geometry._
 import scalismo.mesh.kdtree.{ KDTreeMap, RegionBuilder }
 import scala.collection.parallel.CollectionConverters._
 import scala.language.implicitConversions
+import Ordering.Double.IeeeOrdering
 
 sealed abstract class UnstructuredPointsDomain[D: NDSpace: Create] private[scalismo] (private[scalismo] val pointSequence: IndexedSeq[Point[D]]) extends DiscreteDomain[D] {
 
-  override def points: Iterator[Point[D]] = pointSequence.toIterator
+  override def points: Iterator[Point[D]] = pointSequence.iterator
   override def numberOfPoints = pointSequence.size
 
   override def point(id: PointId) = pointSequence(id.id)

--- a/src/main/scala/scalismo/common/UnstructuredPointsDomain.scala
+++ b/src/main/scala/scalismo/common/UnstructuredPointsDomain.scala
@@ -19,7 +19,7 @@ package scalismo.common
 import scalismo.common.UnstructuredPointsDomain.Create
 import scalismo.geometry._
 import scalismo.mesh.kdtree.{ KDTreeMap, RegionBuilder }
-
+import scala.collection.parallel.CollectionConverters._
 import scala.language.implicitConversions
 
 sealed abstract class UnstructuredPointsDomain[D: NDSpace: Create] private[scalismo] (private[scalismo] val pointSequence: IndexedSeq[Point[D]]) extends DiscreteDomain[D] {
@@ -68,7 +68,9 @@ sealed abstract class UnstructuredPointsDomain[D: NDSpace: Create] private[scali
     pointIDMap.get(pt)
   }
 
-  override def transform(transform: Point[D] => Point[D]): UnstructuredPointsDomain[D] = UnstructuredPointsDomain(pointSequence.par.map(transform).toIndexedSeq)
+  override def transform(transform: Point[D] => Point[D]): UnstructuredPointsDomain[D] = {
+    UnstructuredPointsDomain(pointSequence.par.map(transform).toIndexedSeq)
+  }
 
 }
 

--- a/src/main/scala/scalismo/common/interpolation/LinearInterpolation.scala
+++ b/src/main/scala/scalismo/common/interpolation/LinearInterpolation.scala
@@ -16,7 +16,7 @@
 
 package scalismo.common.interpolation
 
-import scalismo.common.{ BoxDomain, DiscreteField, Field }
+import scalismo.common.{ DiscreteField, Field }
 import scalismo.geometry._
 import scalismo.image.DiscreteImageDomain
 import scalismo.numerics.ValueInterpolator

--- a/src/main/scala/scalismo/geometry/Coordinate.scala
+++ b/src/main/scala/scalismo/geometry/Coordinate.scala
@@ -31,16 +31,17 @@ abstract class Coordinate[D: NDSpace, @specialized(Int, Float, Double) S] {
 
   def toBreezeVector = DenseVector(data)
 
-  override def hashCode = data.deep.hashCode()
+  override def hashCode = data.toSeq.hashCode()
 
   override def equals(other: Any): Boolean = other match {
-    case that: Coordinate[D, S] => that.canEqual(this) && this.data.deep == that.data.deep
+    case that: Coordinate[D, S] => that.canEqual(this) &&
+      this.data.sameElements(that.data)
     case _ => false
   }
 
   protected def canEqual(other: Any): Boolean
 
-  override def toString = data.deep.toString()
+  override def toString = data.toSeq.toString()
 }
 
 /**

--- a/src/main/scala/scalismo/geometry/IntVector.scala
+++ b/src/main/scala/scalismo/geometry/IntVector.scala
@@ -16,7 +16,7 @@
 package scalismo.geometry
 
 import breeze.linalg.DenseVector
-import spire.algebra.Rng
+import spire.algebra.{ CRing, Rng }
 
 import scala.language.implicitConversions
 
@@ -114,12 +114,13 @@ object IntVector {
   }
 
   /** spire Module implementation for Index (no scalar division) */
-  implicit def spireModule[D: NDSpace] = new spire.algebra.Module[IntVector[D], Int] {
-    override implicit def scalar: Rng[Int] = Rng[Int]
+  implicit def spireModule[D: NDSpace] = new spire.algebra.CModule[IntVector[D], Int] {
+    override implicit def scalar: CRing[Int] = CRing[Int]
     override def timesl(r: Int, v: IntVector[D]): IntVector[D] = v.map(i => i * r)
     override def negate(x: IntVector[D]): IntVector[D] = x.map(i => -i)
     override def zero: IntVector[D] = zeros[D]
     override def plus(x: IntVector[D], y: IntVector[D]): IntVector[D] = x.mapWithIndex((v, i) => v + y(i))
+
   }
 
   object implicits {

--- a/src/main/scala/scalismo/geometry/IntVector.scala
+++ b/src/main/scala/scalismo/geometry/IntVector.scala
@@ -16,7 +16,7 @@
 package scalismo.geometry
 
 import breeze.linalg.DenseVector
-import spire.algebra.{ CRing, Rng }
+import spire.algebra.CRing
 
 import scala.language.implicitConversions
 

--- a/src/main/scala/scalismo/geometry/SquareMatrix.scala
+++ b/src/main/scala/scalismo/geometry/SquareMatrix.scala
@@ -120,11 +120,11 @@ class SquareMatrix[D: NDSpace] private (private[scalismo] val data: Array[Double
     SquareMatrix[D](this.toBreezeMatrix.t.toArray)
   }
 
-  override def hashCode = data.deep.hashCode()
+  override def hashCode = data.toSeq.hashCode()
 
   override def equals(other: Any): Boolean = other match {
     case that: SquareMatrix[D] =>
-      that.canEqual(this) && this.data.deep == that.data.deep
+      that.canEqual(this) && this.data.sameElements(that.data)
     case _ => false
   }
 

--- a/src/main/scala/scalismo/image/DiscreteImageDomain.scala
+++ b/src/main/scala/scalismo/image/DiscreteImageDomain.scala
@@ -19,6 +19,7 @@ import breeze.linalg.{ DenseMatrix, DenseVector, diag }
 import scalismo.common._
 import scalismo.geometry._
 import scalismo.registration.{ AnisotropicSimilarityTransformation, AnisotropicSimilarityTransformationSpace, RotationSpace }
+import Ordering.Double.IeeeOrdering
 
 import scala.language.implicitConversions
 

--- a/src/main/scala/scalismo/image/DiscreteScalarImage.scala
+++ b/src/main/scala/scalismo/image/DiscreteScalarImage.scala
@@ -109,7 +109,7 @@ object DiscreteScalarImage {
   }
 
   /** create a new DiscreteScalarImage with given domain and values */
-  def apply[D: NDSpace, A: Scalar: ClassTag](domain: DiscreteImageDomain[D], values: Traversable[A])(implicit create: Create[D]) = {
+  def apply[D: NDSpace, A: Scalar: ClassTag](domain: DiscreteImageDomain[D], values: Iterable[A])(implicit create: Create[D]) = {
     create.create(domain, ScalarArray(values.toArray))
   }
 

--- a/src/main/scala/scalismo/image/Image.scala
+++ b/src/main/scala/scalismo/image/Image.scala
@@ -20,7 +20,7 @@ import scalismo.geometry._
 import scalismo.image.filter.Filter
 import scalismo.numerics.{ GridSampler, Integrator }
 import scalismo.registration.{ CanDifferentiate, Transformation }
-
+import scala.collection.parallel.CollectionConverters._
 import scala.reflect.ClassTag
 
 /**

--- a/src/main/scala/scalismo/io/ActiveShapeModelIO.scala
+++ b/src/main/scala/scalismo/io/ActiveShapeModelIO.scala
@@ -25,7 +25,6 @@ import scalismo.mesh.TriangleMesh
 import scalismo.statisticalmodel.MultivariateNormalDistribution
 import scalismo.statisticalmodel.asm._
 
-import scala.collection.immutable
 import scala.util.{ Failure, Success, Try }
 
 object ActiveShapeModelIO {
@@ -124,7 +123,11 @@ object ActiveShapeModelIO {
       meanArray <- h5file.readNDArray[Float](s"$groupName/${Names.Item.Means}")
       meanVecs = meanArray.data.grouped(n).map(data => DenseVector(data))
     } yield {
-      val dists = meanVecs.zip(covMats).map { case (m, c) => new MultivariateNormalDistribution(m.map(_.toDouble), c.map(_.toDouble)) }.to[immutable.IndexedSeq]
+      val dists = meanVecs.zip(covMats).map {
+        case (m, c) => new MultivariateNormalDistribution(
+          m.map(_.toDouble), c.map(_.toDouble)
+        )
+      }.toIndexedSeq
       val profiles = dists.zip(pointIds).map { case (d, id) => Profile(PointId(id), d) }
       new Profiles(profiles)
     }

--- a/src/main/scala/scalismo/io/ActiveShapeModelIO.scala
+++ b/src/main/scala/scalismo/io/ActiveShapeModelIO.scala
@@ -74,8 +74,8 @@ object ActiveShapeModelIO {
   private def writeProfiles(h5file: HDF5File, group: Group, profiles: Profiles): Try[Unit] = Try {
     val numberOfPoints = profiles.data.length
     val profileLength = if (numberOfPoints > 0) profiles.data.head.distribution.mean.size else 0
-    val means: NDArray[Float] = new NDArray(Array[Long](numberOfPoints, profileLength), profiles.data.flatMap(_.distribution.mean.toArray).toArray.map(_.toFloat))
-    val covariances: NDArray[Float] = new NDArray(Array[Long](numberOfPoints * profileLength, profileLength), profiles.data.flatMap(_.distribution.cov.toArray).toArray.map(_.toFloat))
+    val means: NDArray[Float] = new NDArray(IndexedSeq[Long](numberOfPoints, profileLength), profiles.data.flatMap(_.distribution.mean.toArray).toArray.map(_.toFloat))
+    val covariances: NDArray[Float] = new NDArray(IndexedSeq[Long](numberOfPoints * profileLength, profileLength), profiles.data.flatMap(_.distribution.cov.toArray).toArray.map(_.toFloat))
     val groupName = group.getFullName
 
     val result = for {

--- a/src/main/scala/scalismo/io/HDF5Utils.scala
+++ b/src/main/scala/scalismo/io/HDF5Utils.scala
@@ -29,7 +29,7 @@ case class NDArray[T](dims: IndexedSeq[Long], data: Array[T]) {
 
 class HDF5File(h5file: FileFormat) extends Closeable {
 
-  override def close() { h5file.close() }
+  override def close(): Unit = { h5file.close() }
 
   def exists(path: String): Boolean = h5file.get(path) != null
 

--- a/src/main/scala/scalismo/io/HDF5Utils.scala
+++ b/src/main/scala/scalismo/io/HDF5Utils.scala
@@ -20,7 +20,7 @@ import java.io.{ Closeable, File, IOException }
 import ncsa.hdf.`object`._
 import ncsa.hdf.`object`.h5._
 
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 import scala.util.{ Failure, Success, Try }
 
 case class NDArray[T](dims: IndexedSeq[Long], data: Array[T]) {
@@ -47,7 +47,7 @@ class HDF5File(h5file: FileFormat) extends Closeable {
   def readStringAttribute(path: String, attrName: String): Try[String] = {
     h5file.get(path) match {
       case s @ (_: H5Group | _: H5ScalarDS) => {
-        val metadata = s.getMetadata
+        val metadata = s.getMetadata.asScala
         val maybeAttr = metadata.find(d => d.asInstanceOf[Attribute].getName.equals(attrName))
         maybeAttr match {
           case Some(a) => {
@@ -66,7 +66,7 @@ class HDF5File(h5file: FileFormat) extends Closeable {
   def readIntAttribute(path: String, attrName: String): Try[Int] = {
     h5file.get(path) match {
       case s @ (_: H5Group | _: H5ScalarDS) => {
-        val metadata = s.getMetadata
+        val metadata = s.getMetadata.asScala
         val maybeAttr = metadata.find(d => d.asInstanceOf[Attribute].getName.equals(attrName))
         maybeAttr match {
           case Some(a) => {
@@ -260,7 +260,7 @@ class HDF5File(h5file: FileFormat) extends Closeable {
 
     val groupnames = trimmedPath.split("/", 2)
 
-    def getMember(name: String) = parent.getMemberList.find(_.getName == name.trim())
+    def getMember(name: String) = parent.getMemberList.asScala.find(_.getName == name.trim())
 
     val newgroup = getMember(groupnames(0)) match {
       case Some(g) => g.asInstanceOf[Group]

--- a/src/main/scala/scalismo/io/HDF5Utils.scala
+++ b/src/main/scala/scalismo/io/HDF5Utils.scala
@@ -20,7 +20,7 @@ import java.io.{ Closeable, File, IOException }
 import ncsa.hdf.`object`._
 import ncsa.hdf.`object`.h5._
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.util.{ Failure, Success, Try }
 
 case class NDArray[T](dims: IndexedSeq[Long], data: Array[T]) {

--- a/src/main/scala/scalismo/io/ImageIO.scala
+++ b/src/main/scala/scalismo/io/ImageIO.scala
@@ -30,6 +30,7 @@ import vtk._
 import scala.reflect.ClassTag
 import scala.reflect.runtime.universe.{ TypeTag, typeOf }
 import scala.util.{ Failure, Success, Try }
+import Ordering.Double.IeeeOrdering
 
 /**
  * Implements methods for reading and writing D-dimensional images
@@ -361,7 +362,7 @@ object ImageIO {
       val augmentedMatrix = transformMatrixFromNifti(volume, favourQform).get // get is safe in here
       val linearTransMatrix = augmentedMatrix(0 to 2, 0 to 2)
 
-      val mirrorScale = breeze.linalg.det(linearTransMatrix).signum.toDouble
+      val mirrorScale = breeze.linalg.det(linearTransMatrix).sign.toDouble
 
       val spacing = DenseVector(s(1), s(2), s(3) * mirrorScale)
 

--- a/src/main/scala/scalismo/io/MeshIO.scala
+++ b/src/main/scala/scalismo/io/MeshIO.scala
@@ -25,7 +25,6 @@ import scalismo.mesh._
 import scalismo.utils.MeshConversion
 import vtk._
 
-import scala.io.Source
 import scala.reflect.ClassTag
 import scala.reflect.runtime.universe.TypeTag
 import scala.util.{ Failure, Success, Try }

--- a/src/main/scala/scalismo/io/StatisticalModelIO.scala
+++ b/src/main/scala/scalismo/io/StatisticalModelIO.scala
@@ -83,14 +83,13 @@ object StatismoIO {
    * List all models that are stored in the given hdf5 file.
    */
   def readModelCatalog(file: File): Try[ModelCatalog] = {
-    import scala.collection.JavaConverters._
 
     def flatten[A](xs: Seq[Try[A]]): Try[Seq[A]] = Try(xs.map(_.get))
 
     for {
       h5file <- HDF5Utils.openFileForReading(file)
       catalogGroup <- if (h5file.exists("/catalog")) h5file.getGroup("/catalog") else Failure(NoCatalogPresentException)
-      modelEntries = for (entryGroupObj <- catalogGroup.getMemberList.asScala.toSeq if entryGroupObj.isInstanceOf[Group]) yield {
+      modelEntries = for (entryGroupObj <- catalogGroup.getMemberList.toArray().toSeq if entryGroupObj.isInstanceOf[Group]) yield {
         val entryGroup = entryGroupObj.asInstanceOf[Group]
         readCatalogEntry(h5file, entryGroup)
       }

--- a/src/main/scala/scalismo/io/StatisticalModelIO.scala
+++ b/src/main/scala/scalismo/io/StatisticalModelIO.scala
@@ -27,6 +27,7 @@ import scalismo.mesh.TriangleMesh._
 import scalismo.mesh.{ TriangleCell, TriangleList, TriangleMesh, TriangleMesh3D }
 import scalismo.statisticalmodel.StatisticalMeshModel
 
+import scala.collection.parallel.CollectionConverters._
 import scala.util.{ Failure, Success, Try }
 
 object StatisticalModelIO {

--- a/src/main/scala/scalismo/mesh/LineList.scala
+++ b/src/main/scala/scalismo/mesh/LineList.scala
@@ -53,7 +53,7 @@ case class LineList(lines: IndexedSeq[LineCell]) {
       lineMap(line.ptId1) += lineId
       lineMap(line.ptId2) += lineId
     }
-    val data = lineMap.mapValues(s => s.toSet) // make immutable
+    val data = lineMap.view.mapValues(s => s.toSet) // make immutable
 
     val dataSeq = IndexedSeq.tabulate(pointIds.size) { i => data(pointIds(i)).toIndexedSeq }
     id => dataSeq(id.id)
@@ -77,7 +77,7 @@ case class LineList(lines: IndexedSeq[LineCell]) {
     for (p <- pointIds) {
       pointMap(p) -= p
     }
-    val mapData = pointMap.mapValues(s => s.toSet) // make immutable
+    val mapData = pointMap.view.mapValues(s => s.toSet) // make immutable
     val seqData = IndexedSeq.tabulate(pointIds.size) { i => mapData(pointIds(i)).toIndexedSeq }
     id => seqData(id.id)
   }
@@ -96,7 +96,7 @@ case class LineList(lines: IndexedSeq[LineCell]) {
       lineMap(lineId) ++= lines(lineId.id).pointIds.flatMap(p => adjacentLinesForPoint(p))
       lineMap(lineId) -= lineId
     }
-    val mapData = lineMap.mapValues(s => s.toSet)
+    val mapData = lineMap.view.mapValues(s => s.toSet)
     val seqData = IndexedSeq.tabulate(lineIds.size) { i => mapData(lineIds(i)).toIndexedSeq }
     id => seqData(id.id)
   }

--- a/src/main/scala/scalismo/mesh/Mesh.scala
+++ b/src/main/scala/scalismo/mesh/Mesh.scala
@@ -19,6 +19,7 @@ import scalismo.common.{ PointId, RealSpace }
 import scalismo.geometry._
 import scalismo.image.{ DifferentiableScalarImage, ScalarImage }
 import scalismo.mesh.boundingSpheres.TriangleMesh3DSpatialIndex
+import scala.collection.parallel.CollectionConverters._
 
 /**
  * Defines utility functions on [[TriangleMesh]] instances

--- a/src/main/scala/scalismo/mesh/MeshMetrics.scala
+++ b/src/main/scala/scalismo/mesh/MeshMetrics.scala
@@ -21,6 +21,8 @@ import scalismo.numerics.UniformSampler
 import scalismo.registration.LandmarkRegistration
 import scalismo.utils.Random
 
+import Ordering.Double.IeeeOrdering
+
 /**
  * Implements utility methods for evaluating similarity of [[TriangleMesh]] instances
  *

--- a/src/main/scala/scalismo/mesh/MeshOperations.scala
+++ b/src/main/scala/scalismo/mesh/MeshOperations.scala
@@ -19,6 +19,7 @@ import scalismo.common.{ PointId, RealSpace }
 import scalismo.geometry.{ EuclideanVector, Point, _3D }
 import scalismo.image.{ DifferentiableScalarImage, ScalarImage }
 import scalismo.mesh.boundingSpheres._
+import scala.collection.parallel.CollectionConverters._
 
 object MeshOperations {
   def apply(mesh: TriangleMesh3D) = new TriangleMesh3DOperations(mesh)

--- a/src/main/scala/scalismo/mesh/ScalarMeshField.scala
+++ b/src/main/scala/scalismo/mesh/ScalarMeshField.scala
@@ -43,7 +43,7 @@ case class ScalarMeshField[S: Scalar: ClassTag](mesh: TriangleMesh[_3D], overrid
 }
 
 object ScalarMeshField {
-  def apply[S: Scalar: ClassTag](mesh: TriangleMesh[_3D], data: Traversable[S]): ScalarMeshField[S] = {
+  def apply[S: Scalar: ClassTag](mesh: TriangleMesh[_3D], data: Iterable[S]): ScalarMeshField[S] = {
     ScalarMeshField(mesh, ScalarArray(data.toArray))
   }
 }

--- a/src/main/scala/scalismo/mesh/TriangleList.scala
+++ b/src/main/scala/scalismo/mesh/TriangleList.scala
@@ -37,7 +37,7 @@ case class TriangleList(triangles: IndexedSeq[TriangleCell]) {
       triangleMap(triangle.ptId2) += t
       triangleMap(triangle.ptId3) += t
     }
-    val data = triangleMap.mapValues(s => s.toSet) // make immutable
+    val data = triangleMap.view.mapValues(s => s.toSet) // make immutable
 
     val dataSeq = IndexedSeq.tabulate(pointIds.size) { i => data(pointIds(i)).toIndexedSeq }
     id => dataSeq(id.id)
@@ -58,7 +58,7 @@ case class TriangleList(triangles: IndexedSeq[TriangleCell]) {
     for (p <- pointIds) {
       pointMap(p) -= p
     }
-    val mapData = pointMap.mapValues(s => s.toSet) // make immutable
+    val mapData = pointMap.view.mapValues(s => s.toSet) // make immutable
     val seqData = IndexedSeq.tabulate(pointIds.size) { i => mapData(pointIds(i)).toIndexedSeq }
     id => seqData(id.id)
   }
@@ -73,7 +73,7 @@ case class TriangleList(triangles: IndexedSeq[TriangleCell]) {
       triangleMap(t) ++= triangles(t.id).pointIds.flatMap(p => adjacentTrianglesForPoint(p))
       triangleMap(t) -= t
     }
-    val mapData = triangleMap.mapValues(s => s.toSet)
+    val mapData = triangleMap.view.mapValues(s => s.toSet)
     val seqData = IndexedSeq.tabulate(triangleIds.size) { i => mapData(triangleIds(i)).toIndexedSeq }
     id => seqData(id.id)
   }

--- a/src/main/scala/scalismo/mesh/TriangleMesh.scala
+++ b/src/main/scala/scalismo/mesh/TriangleMesh.scala
@@ -96,7 +96,7 @@ case class TriangleMesh3D(pointSet: UnstructuredPointsDomain[_3D], triangulation
       val cell = triangulation.triangle(tId)
       triangleNormals(tId.id) = computeCellNormal(cell)
     }
-    TriangleProperty(triangulation, triangleNormals)
+    TriangleProperty(triangulation, triangleNormals.toIndexedSeq)
   }
 
   /** Get all vertex normals as a surface property, averages over cell normals */
@@ -117,7 +117,7 @@ case class TriangleMesh3D(pointSet: UnstructuredPointsDomain[_3D], triangulation
       val n = tr.size
       pointNormals(ptId.id) = EuclideanVector3D(x / n, y / n, z / n).normalize
     }
-    SurfacePointProperty(triangulation, pointNormals)
+    SurfacePointProperty(triangulation, pointNormals.toIndexedSeq)
   }
 
   /**

--- a/src/main/scala/scalismo/mesh/boundingSpheres/BSDistance.scala
+++ b/src/main/scala/scalismo/mesh/boundingSpheres/BSDistance.scala
@@ -48,7 +48,7 @@ private case class BC(var a: Double, var b: Double)
 /**
  * Collection of helper classes and functions for bounding spheres.
  */
-private object BSDistance {
+private[mesh] object BSDistance {
 
   /**
    * Calculates the barycentric coordinates of a triangle. Returns also the sum of both.

--- a/src/main/scala/scalismo/mesh/boundingSpheres/BoundingSpheres.scala
+++ b/src/main/scala/scalismo/mesh/boundingSpheres/BoundingSpheres.scala
@@ -21,6 +21,7 @@ import scalismo.geometry.{ EuclideanVector, Point, _3D }
 import scalismo.mesh.TriangleMesh3D
 
 import scala.annotation.tailrec
+import Ordering.Double.IeeeOrdering
 
 /**
  * The idea is that we wrap all elementes in hierarchical spheres as we usually can handle queries to a sphere very easily.
@@ -199,7 +200,7 @@ private[mesh] object BoundingSpheres {
 
         val chosen: Array[Boolean] = choosePointPairsAndUpdateMatchedIndex(closestPointPairs, sortedPoints, matchedPoints)
         val stillActive = chosen.zipWithIndex.filter(s => !s._1).map(t => sortedPoints(t._2))
-        matchPoints(stillActive, matchedPoints)
+        matchPoints(stillActive.toIndexedSeq, matchedPoints)
 
     }
   }

--- a/src/main/scala/scalismo/mesh/boundingSpheres/DiscreteSpatialIndex.scala
+++ b/src/main/scala/scalismo/mesh/boundingSpheres/DiscreteSpatialIndex.scala
@@ -36,7 +36,7 @@ object DiscreteSpatialIndex {
   /**
    * Create PointSetDistance for a list of points.
    */
-  def fromPointList[A <: Traversable[Point[_3D]]](points: A): DiscreteSpatialIndex = {
+  def fromPointList[A <: Iterable[Point[_3D]]](points: A): DiscreteSpatialIndex = {
     val pts = points.toIndexedSeq
     val bs = BoundingSpheres.createForPoints(pts)
     new DiscreteSpatialIndexImplementation(bs, pts)

--- a/src/main/scala/scalismo/mesh/boundingSpheres/SurfaceSpatialIndex.scala
+++ b/src/main/scala/scalismo/mesh/boundingSpheres/SurfaceSpatialIndex.scala
@@ -51,7 +51,7 @@ trait SurfaceSpatialIndex[D] {
 /**
  * Type of the closest point. At the moment the names are only suited for a triangular mesh.
  */
-private object ClosestPointType extends Enumeration {
+object ClosestPointType extends Enumeration {
   type ClosestPointType = Value
   val POINT, ON_LINE, IN_TRIANGLE = Value
 }
@@ -67,7 +67,7 @@ import scalismo.mesh.boundingSpheres.ClosestPointType._
  * @param bc        the barycentric coordinates of the point. The interpretation depends on the ptType.
  * @param idx       the index in the original surface instance of the geometric entity where the closest point lies. The interpretation depends on the ptType.
  */
-private case class ClosestPointMeta(distance2: Double,
+case class ClosestPointMeta(distance2: Double,
   pt: EuclideanVector[_3D],
   ptType: ClosestPointType,
   bc: (Double, Double),

--- a/src/main/scala/scalismo/mesh/kdtree/DimensionalOrdering.scala
+++ b/src/main/scala/scalismo/mesh/kdtree/DimensionalOrdering.scala
@@ -19,6 +19,7 @@ package scalismo.mesh.kdtree
 import scalismo.geometry.{NDSpace, Point}
 
 import scala.annotation.tailrec
+import scala.Ordering.Double.IeeeOrdering
 
 /**
  * DimensionalOrdering is a trait whose instances each represent a strategy for ordering instances

--- a/src/main/scala/scalismo/mesh/kdtree/KDTree.scala
+++ b/src/main/scala/scalismo/mesh/kdtree/KDTree.scala
@@ -17,12 +17,11 @@
 package scalismo.mesh.kdtree
 
 import scala.annotation.tailrec
-import scala.collection.generic.CanBuildFrom
-import scala.collection.mutable.{ ArrayBuffer, Builder }
-import scala.collection.{ IterableLike, MapLike }
+import scala.collection.mutable
+import scala.collection.mutable.{ Builder }
 import scala.math.Ordering.Implicits._
 
-private[scalismo] class KDTree[A] private (root: KDTreeNode[A, Boolean])(implicit ord: DimensionalOrdering[A]) extends IterableLike[A, KDTree[A]] {
+private[scalismo] class KDTree[A] private (root: KDTreeNode[A, Boolean])(implicit ord: DimensionalOrdering[A]) extends Iterable[A] {
   override def seq = this
 
   override def size: Int = root.size
@@ -40,7 +39,7 @@ private[scalismo] class KDTree[A] private (root: KDTreeNode[A, Boolean])(implici
 }
 
 private[scalismo] class KDTreeMap[A, B] private (root: KDTreeNode[A, B])(implicit ord: DimensionalOrdering[A])
-    extends Map[A, B] with MapLike[A, B, KDTreeMap[A, B]] {
+    extends Map[A, B] {
 
   override def empty: KDTreeMap[A, B] = KDTreeMap.empty[A, B](ord)
 
@@ -55,8 +54,15 @@ private[scalismo] class KDTreeMap[A, B] private (root: KDTreeNode[A, B])(implici
 
   def regionQuery(region: Region[A]): Seq[(A, B)] = root.regionQuery(region)
 
-  def +[B1 >: B](kv: (A, B1)): KDTreeMap[A, B1] = KDTreeMap.fromSeq(toSeq ++ Seq(kv))
-  def -(key: A): KDTreeMap[A, B] = KDTreeMap.fromSeq(toSeq.filter(_._1 != key))
+  override def +[B1 >: B](kv: (A, B1)): KDTreeMap[A, B1] = KDTreeMap.fromSeq(toSeq ++ Seq(kv))
+
+  override def removed(key: A): Map[A, B] = {
+    KDTreeMap.fromSeq(toSeq.filter(_._1 != key))
+  }
+
+  override def updated[V1 >: B](key: A, value: V1): Map[A, V1] = {
+    this + ((key, value))
+  }
 }
 
 private[scalismo] sealed trait KDTreeNode[A, B] {
@@ -67,7 +73,7 @@ private[scalismo] sealed trait KDTreeNode[A, B] {
   def findNearest0[R](x: A, n: Int, skipParent: KDTreeNode[A, B], values: Seq[((A, B), R)])(
     implicit metric: Metric[A, R], ord: Ordering[R]): Seq[((A, B), R)]
   def findNearest[R](x: A, n: Int)(implicit metric: Metric[A, R], ord: Ordering[R]): Seq[(A, B)]
-  def toStream: Stream[(A, B)]
+  def toStream: LazyList[(A, B)]
   def toSeq: Seq[(A, B)]
   def regionQuery(region: Region[A])(implicit ord: DimensionalOrdering[A]): Seq[(A, B)]
 
@@ -145,7 +151,7 @@ private[scalismo] case class KDTreeInnerNode[A, B](
         above.regionQuery(region) else Nil)
   }
 
-  def toStream: Stream[(A, B)] = below.toStream ++ Stream((key, value)) ++ above.toStream
+  def toStream: LazyList[(A, B)] = below.toStream ++ LazyList((key, value)) ++ above.toStream
 
   def toSeq: Seq[(A, B)] = below.toSeq ++ Seq((key, value)) ++ above.toSeq
 }
@@ -159,7 +165,7 @@ private[scalismo] case class KDTreeEmpty[A, B]() extends KDTreeNode[A, B] {
   def findNearest0[R](x: A, n: Int, skipParent: KDTreeNode[A, B], values: Seq[((A, B), R)])(
     implicit metric: Metric[A, R], ord: Ordering[R]): Seq[((A, B), R)] = values
   def toSeq: Seq[(A, B)] = Seq.empty
-  def toStream: Stream[(A, B)] = Stream.empty
+  def toStream: LazyList[(A, B)] = LazyList.empty
   def regionQuery(region: Region[A])(implicit ord: DimensionalOrdering[A]): Seq[(A, B)] = Seq.empty
 }
 
@@ -194,18 +200,26 @@ object KDTreeNode {
 private[scalismo] object KDTree {
   def apply[A](points: A*)(implicit ord: DimensionalOrdering[A]) = fromSeq(points)
 
-  def fromSeq[A](points: Seq[A])(implicit ord: DimensionalOrdering[A]) = {
+  def fromSeq[A](points: Seq[A])(implicit ord: DimensionalOrdering[A]): KDTree[A] = {
     assert(ord.dimensions >= 1)
     new KDTree(KDTreeNode.buildTreeNode(0, points map { (_, true) }))
   }
 
-  def newBuilder[A](implicit ord: DimensionalOrdering[A]): Builder[A, KDTree[A]] =
-    new ArrayBuffer[A]() mapResult (x => KDTree.fromSeq(x))
+  def newBuilder[A](implicit ord: DimensionalOrdering[A]): Builder[A, KDTree[A]] = {
 
-  implicit def canBuildFrom[B](implicit ordB: DimensionalOrdering[B]): CanBuildFrom[KDTree[_], B, KDTree[B]] = new CanBuildFrom[KDTree[_], B, KDTree[B]] {
-    def apply: Builder[B, KDTree[B]] = newBuilder(ordB)
-    def apply(from: KDTree[_]): Builder[B, KDTree[B]] = newBuilder(ordB)
+    new Builder[A, KDTree[A]] {
+      val arrayBuilder = mutable.ArrayBuffer[A]()
+      override def clear(): Unit = arrayBuilder.clear()
+
+      override def result(): KDTree[A] = KDTree.fromSeq(arrayBuilder.toSeq)
+
+      override def addOne(elem: A): this.type = {
+        arrayBuilder.addOne(elem)
+        this
+      }
+    }
   }
+
 }
 
 private[scalismo] object KDTreeMap {

--- a/src/main/scala/scalismo/mesh/kdtree/Region.scala
+++ b/src/main/scala/scalismo/mesh/kdtree/Region.scala
@@ -78,7 +78,7 @@ private[scalismo] class RegionBuilder[A] {
   def build: Region[A] = regions.length match {
     case 0 => EntireSpace()
     case 1 => regions.head
-    case _ => RegionIntersection(regions)
+    case _ => RegionIntersection(regions.toSeq)
   }
 }
 

--- a/src/main/scala/scalismo/numerics/Integrator.scala
+++ b/src/main/scala/scalismo/numerics/Integrator.scala
@@ -19,6 +19,7 @@ import breeze.linalg.DenseVector
 import scalismo.common.VectorField
 import scalismo.geometry._
 import scalismo.image.ScalarImage
+import scala.collection.parallel.CollectionConverters._
 
 case class Integrator[D: NDSpace](sampler: Sampler[D]) {
 

--- a/src/main/scala/scalismo/numerics/Optimizer.scala
+++ b/src/main/scala/scalismo/numerics/Optimizer.scala
@@ -20,6 +20,7 @@ import breeze.optimize.{ DiffFunction, LBFGS }
 import scalismo.registration.TransformationSpace.ParameterVector
 
 import scala.collection.Iterator
+import scala.Ordering.Double.IeeeOrdering
 
 trait CostFunction extends (ParameterVector => (Double, DenseVector[Double])) {
   def onlyValue(p: ParameterVector): Double

--- a/src/main/scala/scalismo/numerics/PivotedCholesky.scala
+++ b/src/main/scala/scalismo/numerics/PivotedCholesky.scala
@@ -23,6 +23,7 @@ import scalismo.geometry._
 import scalismo.kernels.{ MatrixValuedPDKernel, PDKernel }
 
 import scala.collection.mutable.ArrayBuffer
+import scala.collection.parallel.CollectionConverters._
 
 /**
  * Result object for the pivoted cholesky of a matrix A
@@ -113,7 +114,9 @@ object PivotedCholesky {
       S(p(k)) = D
 
       val pointIds = ids.splitAt(k + 1)._2
-      val chunks = pointIds.grouped(Math.max(1, n / Runtime.getRuntime().availableProcessors())).toIndexedSeq.par
+      val chunks = pointIds.grouped(Math.max(1, n / Runtime.getRuntime()
+        .availableProcessors()))
+        .toIndexedSeq.par
 
       var c = 0
 
@@ -152,7 +155,7 @@ object PivotedCholesky {
       k += 1
     }
 
-    PivotedCholesky(L.toDenseMatrix, p, tr)
+    PivotedCholesky(L.toDenseMatrix, p.toIndexedSeq, tr)
   }
 
   def computeApproximateCholesky[D: NDSpace, DO: NDSpace](kernel: MatrixValuedPDKernel[D],

--- a/src/main/scala/scalismo/numerics/PivotedCholesky.scala
+++ b/src/main/scala/scalismo/numerics/PivotedCholesky.scala
@@ -24,6 +24,7 @@ import scalismo.kernels.{ MatrixValuedPDKernel, PDKernel }
 
 import scala.collection.mutable.ArrayBuffer
 import scala.collection.parallel.CollectionConverters._
+import scala.Ordering.Double.IeeeOrdering
 
 /**
  * Result object for the pivoted cholesky of a matrix A

--- a/src/main/scala/scalismo/numerics/Sampler.scala
+++ b/src/main/scala/scalismo/numerics/Sampler.scala
@@ -24,6 +24,7 @@ import scalismo.image.DiscreteImageDomain
 import scalismo.mesh.TriangleMesh
 import scalismo.statisticalmodel.GaussianProcess
 import scalismo.utils.Random
+import scala.collection.parallel.CollectionConverters._
 
 /** sample generator typeclass */
 trait Sampler[D] {

--- a/src/main/scala/scalismo/package.scala
+++ b/src/main/scala/scalismo/package.scala
@@ -46,13 +46,13 @@ package object scalismo {
   private def setupVTKGCThread(gcInterval: Long): Unit = {
 
     val runGC = new Runnable() {
-      override def run() {
+      override def run(): Unit = {
         vtkObjectBase.JAVA_OBJECT_MANAGER.gc(false)
       }
     }
 
     val gcThread = new Thread {
-      override def run() {
+      override def run(): Unit = {
         while (true) {
           Thread.sleep(gcInterval)
 

--- a/src/main/scala/scalismo/registration/MeanPointwiseLossMetric.scala
+++ b/src/main/scala/scalismo/registration/MeanPointwiseLossMetric.scala
@@ -22,6 +22,7 @@ import scalismo.geometry.{ NDSpace, Point }
 import scalismo.image.{ DifferentiableScalarImage, ScalarImage }
 import scalismo.numerics._
 import scalismo.registration.RegistrationMetric.ValueAndDerivative
+import scala.collection.parallel.CollectionConverters._
 
 /**
  * Image to image metric which applies a loss function to the pointwise pixel difference.

--- a/src/main/scala/scalismo/registration/MutualInformationMetric.scala
+++ b/src/main/scala/scalismo/registration/MutualInformationMetric.scala
@@ -24,6 +24,8 @@ import scalismo.numerics._
 import scalismo.registration.RegistrationMetric.ValueAndDerivative
 import scalismo.utils.{ Memoize, Random }
 
+import scala.collection.parallel.CollectionConverters._
+
 /**
  * Implementation of the Mutual Information Metric, described in the following paper:
  *

--- a/src/main/scala/scalismo/registration/MutualInformationMetric.scala
+++ b/src/main/scala/scalismo/registration/MutualInformationMetric.scala
@@ -25,6 +25,7 @@ import scalismo.registration.RegistrationMetric.ValueAndDerivative
 import scalismo.utils.{ Memoize, Random }
 
 import scala.collection.parallel.CollectionConverters._
+import scala.Ordering.Float.IeeeOrdering
 
 /**
  * Implementation of the Mutual Information Metric, described in the following paper:

--- a/src/main/scala/scalismo/sampling/proposals/MixtureProposal.scala
+++ b/src/main/scala/scalismo/sampling/proposals/MixtureProposal.scala
@@ -17,6 +17,7 @@ package scalismo.sampling.proposals
 
 import scalismo.sampling._
 import scalismo.utils.Random
+import scala.Ordering.Double.IeeeOrdering
 
 /** mixture of proposals: mixture distribution of multiple proposal distributions */
 class MixtureProposal[A](proposals: IndexedSeq[(Double, ProposalGenerator[A])])(implicit rnd: Random)

--- a/src/main/scala/scalismo/statisticalmodel/DiscreteLowRankGaussianProcess.scala
+++ b/src/main/scala/scalismo/statisticalmodel/DiscreteLowRankGaussianProcess.scala
@@ -27,6 +27,8 @@ import scalismo.statisticalmodel.DiscreteLowRankGaussianProcess.{Eigenpair => Di
 import scalismo.statisticalmodel.LowRankGaussianProcess.Eigenpair
 import scalismo.utils.{Memoize, Random}
 
+import scala.collection.parallel.CollectionConverters._
+
 /**
  * Represents a low-rank gaussian process, that is only defined at a finite, discrete set of points.
  * It supports the same operations as the LowRankGaussianProcess class, but always returns instead a

--- a/src/main/scala/scalismo/statisticalmodel/LowRankGaussianProcess.scala
+++ b/src/main/scala/scalismo/statisticalmodel/LowRankGaussianProcess.scala
@@ -216,14 +216,14 @@ object LowRankGaussianProcess {
    * @
    */
   def approximateGPNystrom[D : NDSpace, Value](gp: GaussianProcess[D, Value],
-    sampler: Sampler[D])(implicit vectorizer: Vectorizer[Value], rand: Random) = {
+    sampler: Sampler[D])(implicit vectorizer: Vectorizer[Value]) = {
     val kltBasis: KLBasis[D, Value] = Kernel.computeNystromApproximation[D, Value](gp.cov, sampler)
     new LowRankGaussianProcess[D, Value](gp.mean, kltBasis)
   }
 
   @deprecated("the method has been renamed to approximateGPNystrom", "0.17")
   def approximateGP[D: NDSpace, Value](gp: GaussianProcess[D, Value],
-    sampler: Sampler[D])(implicit vectorizer: Vectorizer[Value], rand: Random) = {
+    sampler: Sampler[D])(implicit vectorizer: Vectorizer[Value]) = {
     approximateGPNystrom(gp, sampler)
   }
 
@@ -261,7 +261,7 @@ object LowRankGaussianProcess {
    gp: GaussianProcess[D, Value],
    relativeTolerance: Double,
    interpolator: FieldInterpolator[D, DDomain, Value])
-  (implicit vectorizer: Vectorizer[Value], rand: Random): LowRankGaussianProcess[D, Value] = {
+  (implicit vectorizer: Vectorizer[Value]): LowRankGaussianProcess[D, Value] = {
 
     val (basis, scale) = PivotedCholesky.computeApproximateEig(
       kernel = gp.cov,

--- a/src/main/scala/scalismo/statisticalmodel/asm/ActiveShapeModel.scala
+++ b/src/main/scala/scalismo/statisticalmodel/asm/ActiveShapeModel.scala
@@ -28,6 +28,7 @@ import scalismo.utils.Random
 import scala.util.{ Failure, Try }
 
 import scala.collection.parallel.CollectionConverters._
+import scala.Ordering.Double.IeeeOrdering
 
 object ActiveShapeModel {
   type TrainingData = Iterator[(DiscreteScalarImage[_3D, Float], Transformation[_3D])]

--- a/src/main/scala/scalismo/statisticalmodel/asm/ActiveShapeModel.scala
+++ b/src/main/scala/scalismo/statisticalmodel/asm/ActiveShapeModel.scala
@@ -25,8 +25,9 @@ import scalismo.registration.{ LandmarkRegistration, RigidTransformation, RigidT
 import scalismo.statisticalmodel.{ MultivariateNormalDistribution, StatisticalMeshModel }
 import scalismo.utils.Random
 
-import scala.collection.immutable
 import scala.util.{ Failure, Try }
+
+import scala.collection.parallel.CollectionConverters._
 
 object ActiveShapeModel {
   type TrainingData = Iterator[(DiscreteScalarImage[_3D, Float], Transformation[_3D])]
@@ -36,7 +37,7 @@ object ActiveShapeModel {
    */
   def trainModel(statisticalModel: StatisticalMeshModel, trainingData: TrainingData, preprocessor: ImagePreprocessor, featureExtractor: FeatureExtractor, sampler: TriangleMesh[_3D] => Sampler[_3D]): ActiveShapeModel = {
 
-    val sampled = sampler(statisticalModel.referenceMesh).sample.map(_._1).to[immutable.IndexedSeq]
+    val sampled = sampler(statisticalModel.referenceMesh).sample.map(_._1).toIndexedSeq
     val pointIds = sampled.map(statisticalModel.referenceMesh.pointSet.findClosestPoint(_).id)
 
     // preprocessed images can be expensive in terms of memory, so we go through them one at a time.

--- a/src/main/scala/scalismo/statisticalmodel/asm/FeatureExtractor.scala
+++ b/src/main/scala/scalismo/statisticalmodel/asm/FeatureExtractor.scala
@@ -104,7 +104,7 @@ case class NormalDirectionFeatureExtractor(numberOfPoints: Int, spacing: Double,
     val unitNormal = normal * (1.0 / normal.norm)
     require(math.abs(unitNormal.norm - 1.0) < 1e-5)
 
-    val range = ((-1 * numberOfPoints / 2) to (numberOfPoints / 2)).to[immutable.IndexedSeq]
+    val range = ((-1 * numberOfPoints / 2) to (numberOfPoints / 2))
     Some(range map { i => centerPoint + unitNormal * i * spacing })
   }
 

--- a/src/main/scala/scalismo/statisticalmodel/asm/Profiles.scala
+++ b/src/main/scala/scalismo/statisticalmodel/asm/Profiles.scala
@@ -51,7 +51,7 @@ class DiscreteFeatureField[D: NDSpace, DDomain <: DiscreteDomain[D]](domain: DDo
 
   override def isDefinedAt(id: PointId) = id.id < domain.numberOfPoints
 
-  override def values = _values.toIterator
+  override def values = _values.iterator
 
   override def interpolateNearestNeighbor(): Field[D, DenseVector[Double]] = {
     Field(RealSpace[D], (p: Point[D]) => apply(domain.findClosestPoint(p).id))

--- a/src/main/scala/scalismo/statisticalmodel/asm/Profiles.scala
+++ b/src/main/scala/scalismo/statisticalmodel/asm/Profiles.scala
@@ -26,13 +26,15 @@ final case class ProfileId(id: Int) extends AnyVal
 
 case class Profile(pointId: PointId, distribution: MultivariateNormalDistribution)
 
-case class Profiles(private[scalismo] val data: immutable.IndexedSeq[Profile]) extends Traversable[Profile] {
+case class Profiles(private[scalismo] val data: immutable.IndexedSeq[Profile]) extends Iterable[Profile] {
   def apply(profileId: ProfileId): Profile = data(profileId.id)
   def ids: IndexedSeq[ProfileId] = data.indices.map(idx => ProfileId(idx))
 
   override def size = data.size
 
   override def foreach[U](f: (Profile) => U): Unit = data.foreach(f)
+
+  override def iterator: Iterator[Profile] = data.iterator
 }
 
 /**

--- a/src/main/scala/scalismo/statisticalmodel/dataset/DataCollection.scala
+++ b/src/main/scala/scalismo/statisticalmodel/dataset/DataCollection.scala
@@ -24,6 +24,7 @@ import scalismo.registration.{ LandmarkRegistration, Transformation }
 import scalismo.utils.Random
 
 import scala.annotation.tailrec
+import scala.collection.parallel.CollectionConverters._
 
 private[dataset] case class CrossvalidationFold(trainingData: DataCollection, testingData: DataCollection)
 

--- a/src/main/scala/scalismo/statisticalmodel/dataset/DataUtils.scala
+++ b/src/main/scala/scalismo/statisticalmodel/dataset/DataUtils.scala
@@ -21,7 +21,7 @@ import scalismo.registration.Transformation
 
 import scala.util.{ Failure, Success, Try }
 
-private object DataUtils {
+private[scalismo] object DataUtils {
   /**
    * Partitions a list os possible transformation (tries) into those that succeeded and those who failed
    */

--- a/src/main/scala/scalismo/statisticalmodel/dataset/ModelMetrics.scala
+++ b/src/main/scala/scalismo/statisticalmodel/dataset/ModelMetrics.scala
@@ -6,6 +6,7 @@ import scalismo.statisticalmodel.StatisticalMeshModel
 import scalismo.utils.Random
 
 import scala.util.{ Failure, Success, Try }
+import scala.collection.parallel.CollectionConverters._
 
 /**
  * Implements utility functions for evaluating the quality of a [[StatisticalMeshModel]]

--- a/src/main/scala/scalismo/statisticalmodel/dataset/ModelMetrics.scala
+++ b/src/main/scala/scalismo/statisticalmodel/dataset/ModelMetrics.scala
@@ -7,6 +7,7 @@ import scalismo.utils.Random
 
 import scala.util.{ Failure, Success, Try }
 import scala.collection.parallel.CollectionConverters._
+import scala.Ordering.Double.IeeeOrdering
 
 /**
  * Implements utility functions for evaluating the quality of a [[StatisticalMeshModel]]

--- a/src/main/scala/scalismo/utils/Conversions.scala
+++ b/src/main/scala/scalismo/utils/Conversions.scala
@@ -26,6 +26,7 @@ import vtk._
 import scala.reflect.ClassTag
 import scala.reflect.runtime.universe.{TypeTag, typeOf}
 import scala.util.{Failure, Success, Try}
+import scala.Ordering.Double.IeeeOrdering
 
 object VtkHelpers {
 

--- a/src/main/scala/scalismo/utils/VantagePointTree.scala
+++ b/src/main/scala/scalismo/utils/VantagePointTree.scala
@@ -41,7 +41,7 @@ object Metric {
  *
  *  WARNING: the tree only works with a metric (positive, symmetric, triangle inequality)
  */
-sealed trait VantagePointTree[A] extends Traversable[A] {
+sealed trait VantagePointTree[A] extends Iterable[A] {
   /** metric of the space */
   def metric: Metric[A]
 
@@ -67,6 +67,12 @@ sealed trait VantagePointTree[A] extends Traversable[A] {
 
   /** main implementation of neighbour searches */
   protected[utils] def findNN(point: A, candidates: CandidateSet[A]): Unit
+
+  override def iterator: Iterator[A] = {
+    val collectedValues = new mutable.ArrayBuffer[A]()
+    this.foreach(a => collectedValues.addOne(a))
+    collectedValues.iterator
+  }
 }
 
 /** mutable candidate set for neighbour searches (internal use) */
@@ -211,17 +217,18 @@ private case class EmptyVP[A](metric: Metric[A]) extends VantagePointTree[A] {
 }
 
 /** leaf node of VP tree */
-private case class VPLeaf[A](metric: Metric[A], center: A) extends VantagePointTree[A] {
+private case class VPLeaf[A](metric: Metric[A], center: A) extends VantagePointTree[A] { self =>
 
   override def contains(point: A): Boolean = point == center
 
   override def foreach[U](f: (A) => U): Unit = f(center)
 
   override def findNN(point: A, candidates: CandidateSet[A]): Unit = candidates.addCandidate(center, metric(center, point))
+
 }
 
 /** link node: list element, only a single child - should only appear before a leaf */
-private case class VPLink[A](metric: Metric[A], center: A, next: VantagePointTree[A]) extends VantagePointTree[A] {
+private case class VPLink[A](metric: Metric[A], center: A, next: VantagePointTree[A]) extends VantagePointTree[A] { self =>
 
   override def findNN(point: A, candidates: CandidateSet[A]): Unit = {
     candidates.addCandidate(center, metric(center, point))
@@ -234,6 +241,7 @@ private case class VPLink[A](metric: Metric[A], center: A, next: VantagePointTre
     f(center)
     next.foreach(f)
   }
+
 }
 
 /** regular VP tree node with inner and outer children, inner contains all points which are closer to center than radius (inclusive) */
@@ -279,4 +287,5 @@ private case class VPNode[A](metric: Metric[A], center: A, radius: Double, inner
     inner.foreach(f)
     outer.foreach(f)
   }
+
 }

--- a/src/main/scala/scalismo/utils/VantagePointTree.scala
+++ b/src/main/scala/scalismo/utils/VantagePointTree.scala
@@ -16,6 +16,7 @@
 package scalismo.utils
 
 import scala.collection.mutable
+import scala.Ordering.Double.IeeeOrdering
 
 /** represents a metric to be used with the Vantage Point tree */
 trait Metric[A] {

--- a/src/test/scala/scalismo/io/ActiveShapeModelIOTests.scala
+++ b/src/test/scala/scalismo/io/ActiveShapeModelIOTests.scala
@@ -42,7 +42,7 @@ class ActiveShapeModelIOTests extends ScalismoTestSuite {
     val (sprofilePoints, _) = new FixedPointsUniformMeshSampler3D(shapeModel.referenceMesh, 100).sample.unzip
     val pointIds = sprofilePoints.map { point => shapeModel.referenceMesh.pointSet.findClosestPoint(point).id }
     val dists = for (i <- pointIds.indices) yield new MultivariateNormalDistribution(DenseVector.ones[Double](3) * i.toDouble, DenseMatrix.eye[Double](3) * i.toDouble)
-    val profiles = new Profiles(pointIds.to[immutable.IndexedSeq].zip(dists).map { case (i, d) => Profile(i, d) })
+    val profiles = new Profiles(pointIds.zip(dists).map { case (i, d) => Profile(i, d) })
     new ActiveShapeModel(shapeModel, profiles, GaussianGradientImagePreprocessor(1), NormalDirectionFeatureExtractor(1, 1))
   }
 

--- a/src/test/scala/scalismo/io/HDF5UtilsTests.scala
+++ b/src/test/scala/scalismo/io/HDF5UtilsTests.scala
@@ -46,7 +46,7 @@ class HDF5UtilsTests extends ScalismoTestSuite {
       val arr = NDArray(IndexedSeq(2, 3), Array(1, 2, 3, 4, 5, 6))
       h5.writeNDArray("/aGroup/array", arr).get
       val h5new = HDF5Utils.openFileForReading(h5file).get
-      h5new.readNDArray("/aGroup/array").get.data.deep should be(arr.data.deep)
+      h5new.readNDArray("/aGroup/array").get.data.toSeq should be(arr.data.toSeq)
     }
 
     it("can write and read an NDArray[Float]") {
@@ -55,7 +55,7 @@ class HDF5UtilsTests extends ScalismoTestSuite {
       val arr = NDArray(IndexedSeq(2, 3), Array(1f, 2f, 3f, 4f, 5f, 6f))
       h5.writeNDArray("/aGroup/array", arr).get
       val h5new = HDF5Utils.openFileForReading(h5file).get
-      h5new.readNDArray("/aGroup/array").get.data.deep should be(arr.data.deep)
+      h5new.readNDArray("/aGroup/array").get.data.toSeq should be(arr.data.toSeq)
     }
 
     it("fails to write an unknown type") {

--- a/src/test/scala/scalismo/io/ImageIOTests.scala
+++ b/src/test/scala/scalismo/io/ImageIOTests.scala
@@ -201,7 +201,7 @@ class ImageIOTests extends ScalismoTestSuite {
         val oq = o.header.qform_to_mat44()
         val nq = n.header.qform_to_mat44
 
-        oq.deep should equal(nq.deep)
+        oq.toSeq.sameElements(nq.toSeq)
         om.toString() should equal(nm.toString())
 
         val oh = {
@@ -215,7 +215,7 @@ class ImageIOTests extends ScalismoTestSuite {
           val data = for (d <- 0 until dim; k <- 0 until nz; j <- 0 until ny; i <- 0 until nx) yield o.data.get(i, j, k, d)
           data.hashCode()
         }
-        val nh = n.dataAsScalarArray[Short].map[Double](_.toDouble).iterator.toArray.deep.hashCode()
+        val nh = n.dataAsScalarArray[Short].map[Double](_.toDouble).iterator.toArray.toSeq.hashCode()
         nh should equal(oh)
       }
 

--- a/src/test/scala/scalismo/io/MeshIOTests.scala
+++ b/src/test/scala/scalismo/io/MeshIOTests.scala
@@ -22,7 +22,6 @@ import scalismo.common.{ Scalar, ScalarArray }
 import scalismo.geometry._3D
 import scalismo.mesh.{ ScalarMeshField, TriangleMesh }
 
-import scala.io.Source
 import scala.reflect.ClassTag
 import scala.reflect.runtime.universe.TypeTag
 import scala.util.{ Failure, Success, Try }

--- a/src/test/scala/scalismo/kernels/KernelTests.scala
+++ b/src/test/scala/scalismo/kernels/KernelTests.scala
@@ -23,6 +23,7 @@ import scalismo.registration.Transformation
 import scalismo.statisticalmodel.{ GaussianProcess, LowRankGaussianProcess }
 import scalismo.utils.Random
 import scalismo.{ ScalismoTestSuite }
+import scala.collection.parallel.CollectionConverters._
 
 class KernelTests extends ScalismoTestSuite {
 

--- a/src/test/scala/scalismo/mesh/boundingSpheres/MeshSurfaceDistanceTests.scala
+++ b/src/test/scala/scalismo/mesh/boundingSpheres/MeshSurfaceDistanceTests.scala
@@ -411,8 +411,6 @@ class MeshSurfaceDistanceTests extends ScalismoTestSuite {
     }
 
     it("should create correct bounding spheres with values for center and radius which do not contain NaN.") {
-      import scala.language.implicitConversions
-      implicit def toPointId(i: Int): PointId = PointId(i)
 
       def test(
         tri: Triangle) = {

--- a/src/test/scala/scalismo/mesh/boundingSpheres/MeshSurfaceDistanceTests.scala
+++ b/src/test/scala/scalismo/mesh/boundingSpheres/MeshSurfaceDistanceTests.scala
@@ -21,6 +21,7 @@ import scalismo.common.{ PointId, UnstructuredPointsDomain }
 import scalismo.geometry.{ EuclideanVector, Point, _3D }
 import scalismo.mesh.{ TriangleCell, TriangleList, TriangleMesh3D }
 import scalismo.utils.Random
+import scala.collection.parallel.CollectionConverters._
 
 class MeshSurfaceDistanceTests extends ScalismoTestSuite {
 

--- a/src/test/scala/scalismo/numerics/SamplerTests.scala
+++ b/src/test/scala/scalismo/numerics/SamplerTests.scala
@@ -22,6 +22,7 @@ import scalismo.geometry._
 import scalismo.io.MeshIO
 import scalismo.mesh.TriangleMesh
 import scalismo.utils.{ Random, Memoize }
+import scala.collection.parallel.CollectionConverters._
 
 class SamplerTests extends ScalismoTestSuite {
 

--- a/src/test/scala/scalismo/statisticalmodel/GaussianProcessTests.scala
+++ b/src/test/scala/scalismo/statisticalmodel/GaussianProcessTests.scala
@@ -28,6 +28,7 @@ import scalismo.numerics.{ GridSampler, UniformSampler }
 import scalismo.utils.Random
 
 import scala.language.implicitConversions
+import scala.collection.parallel.CollectionConverters._
 
 class GaussianProcessTests extends ScalismoTestSuite {
 

--- a/src/test/scala/scalismo/utils/MemoizationTests.scala
+++ b/src/test/scala/scalismo/utils/MemoizationTests.scala
@@ -27,7 +27,7 @@ class MemoizationTests extends ScalismoTestSuite {
     it("yields the same results after memoizing") {
       val testFunMemoized = Memoize(testFun, 100000)
       for (x <- BigDecimal(-2.0 * Math.PI) until (2.0 * Math.PI) by 0.1)
-        testFun(x.doubleValue()) should be(testFunMemoized(x.doubleValue()))
+        testFun(x.doubleValue) should be(testFunMemoized(x.doubleValue))
     }
 
     it("evaluates faster after memoization") {


### PR DESCRIPTION
Migration to Scala 2.13

Due to the new collection library, it is difficult to maintain code for 2.12 and 2.13 in the same branch. I therefore suggest for the next few releases to maintain separate branches for 2.12 and 2.13. All new features would first be developed for 2.12 and then merged into the ```scala-2.13``` branch. 

At some point in the future, we can then drop support for 2.11 and 2.12. 