### PR TITLE
Added b-spline image interpolator and deprected old interpolation method

### DIFF
--- a/src/main/java/scalismo/common/interpolation/BSplineCoefficients.java
+++ b/src/main/java/scalismo/common/interpolation/BSplineCoefficients.java
@@ -45,9 +45,9 @@
  | based on it.
  \===================================================================*/
 
-package scalismo.image;
+package scalismo.common.interpolation;
 
-class BSplineCoefficients {
+public class BSplineCoefficients {
 
 	
 	private static float getInitialAntiCausalCoefficientMirrorOnBounds(float[] c,
@@ -76,7 +76,7 @@ class BSplineCoefficients {
 	} /* end getInitialCausalCoefficientMirrorOnBounds */
 
 
-	static void getSplineInterpolationCoefficients(int degree, float[] c) throws Exception {
+	public static void getSplineInterpolationCoefficients(int degree, float[] c) throws Exception {
 		
 		float z[] = null;
 		if (degree == 0 || degree == 1) { 

--- a/src/main/scala/scalismo/common/Field.scala
+++ b/src/main/scala/scalismo/common/Field.scala
@@ -82,6 +82,30 @@ trait Field[D, A] extends Function1[Point[D], A] { self =>
 
 }
 
+trait DifferentiableField[D, A, dA] extends Field[D, A] { self =>
+
+  protected[scalismo] val df: Point[D] => dA
+
+  def differentiate: Field[D, dA] = {
+    Field(domain, df)
+  }
+}
+
+object DifferentiableField {
+  def apply[D, A, dA](domain: Domain[D], f: Point[D] => A, df: Point[D] => dA): DifferentiableField[D, A, dA] = {
+
+    val outerdf = df
+    val outerf = f
+    val outerdomain = domain
+
+    new DifferentiableField[D, A, dA] {
+      override protected[scalismo] val df: Point[D] => dA = outerdf
+      override protected[scalismo] val f: Point[D] => A = outerf
+      override def domain: Domain[D] = outerdomain
+    }
+  }
+}
+
 /**
  * A scalar valued field.
  */

--- a/src/main/scala/scalismo/common/interpolation/BSplineImageInterpolator.scala
+++ b/src/main/scala/scalismo/common/interpolation/BSplineImageInterpolator.scala
@@ -1,0 +1,263 @@
+package scalismo.common.interpolation
+
+import breeze.linalg.DenseVector
+import scalismo.common._
+import scalismo.geometry._
+import scalismo.image.DiscreteImageDomain
+import scalismo.numerics.{ BSpline }
+
+trait BSplineImageInterpolator[D, A] extends DifferentiableFieldInterpolator[D, DiscreteImageDomain[D], A, EuclideanVector[D]] {
+  implicit protected val scalar: Scalar[A]
+
+  private[scalismo] def applyMirrorBoundaryCondition(k: Int, numCoefficients: Int) = {
+    if (k < 0) -k
+    else if (k >= numCoefficients) numCoefficients - (k - numCoefficients) - 2
+    else k
+  }
+}
+
+object BSplineImageInterpolator {
+
+  trait Create[D] {
+    def createBSplineInterpolator[A: Scalar](degree: Int): BSplineImageInterpolator[D, A]
+  }
+
+  implicit object create1D extends Create[_1D] {
+    override def createBSplineInterpolator[A: Scalar](degree: Int): BSplineImageInterpolator[_1D, A] = new BSplineImageInterpolator1D[A](degree)
+  }
+
+  implicit object create2D extends Create[_2D] {
+    override def createBSplineInterpolator[A: Scalar](degree: Int): BSplineImageInterpolator[_2D, A] = new BSplineImageInterpolator2D[A](degree)
+  }
+
+  implicit object create3D extends Create[_3D] {
+    override def createBSplineInterpolator[A: Scalar](degree: Int): BSplineImageInterpolator[_3D, A] = new BSplineImageInterpolator3D[A](degree)
+  }
+
+  def apply[D: NDSpace, A: Scalar](degree: Int)(implicit creator: Create[D]): BSplineImageInterpolator[D, A] = {
+    creator.createBSplineInterpolator(degree)
+  }
+
+}
+
+case class BSplineImageInterpolator1D[A: Scalar](degree: Int) extends BSplineImageInterpolator[_1D, A] {
+
+  override protected val scalar: Scalar[A] = Scalar[A]
+
+  override def interpolate(discreteField: DiscreteField[_1D, DiscreteImageDomain[_1D], A]): DifferentiableField[_1D, A, EuclideanVector[_1D]] = {
+
+    val domain = discreteField.domain
+    val ck = determineCoefficients1D(degree, discreteField)
+
+    /*
+     * Computes values at given point with corresponding coefficients and spline basis
+     * */
+    def iterateOnPoints(x: Point[_1D], splineBasis: ((Double) => Double)): Double = {
+      val xUnit = (x(0) - domain.origin(0)) / domain.spacing(0)
+
+      val k1 = scala.math.ceil(xUnit - 0.5f * (degree + 1)).toInt
+      val K = degree + 1
+
+      var result = 0.0
+      var k = k1
+      while (k <= k1 + K - 1) {
+        val kBC = applyMirrorBoundaryCondition(k, domain.size(0))
+        result = result + splineBasis(xUnit.toDouble - k) * ck(kBC)
+        k = k + 1
+      }
+      result
+    }
+
+    // the continuous interpolation function
+    def f(x: Point[_1D]) = {
+      val splineBasis: (Double => Double) = BSpline.nthOrderBSpline(degree)
+      scalar.fromDouble(iterateOnPoints(x, splineBasis))
+    }
+    // the derivative
+    def df(x: Point[_1D]) = {
+      //derivative
+      val splineBasisD1: (Double => Double) = { x => (BSpline.nthOrderBSpline(degree - 1)(x + 0.5f) - BSpline.nthOrderBSpline(degree - 1)(x - 0.5f)) * (1 / domain.spacing(0)) }
+      EuclideanVector(iterateOnPoints(x, splineBasisD1))
+    }
+    DifferentiableField[_1D, A, EuclideanVector[_1D]](domain.boundingBox, f, df)
+  }
+
+  /* determine the b-spline coefficients for a 1D image */
+  private def determineCoefficients1D(degree: Int, img: DiscreteField[_1D, DiscreteImageDomain[_1D], A]): Array[Float] = {
+
+    // floats is an input-output argument here
+    val floats = new Array[Float](img.data.size)
+    img.data.map((v: A) => scalar.toFloat(v)).copyToArray(floats)
+    BSplineCoefficients.getSplineInterpolationCoefficients(degree, floats)
+    floats
+  }
+
+}
+
+case class BSplineImageInterpolator2D[A: Scalar](degree: Int) extends BSplineImageInterpolator[_2D, A] {
+
+  override protected val scalar = Scalar[A]
+
+  override def interpolate(discreteField: DiscreteField[_2D, DiscreteImageDomain[_2D], A]): DifferentiableField[_2D, A, EuclideanVector[_2D]] = {
+    val domain = discreteField.domain
+
+    val ck = determineCoefficients2D(degree, discreteField)
+
+    def iterateOnPoints(x: Point[_2D], splineBasis: ((Double, Double) => Double)): Double = {
+
+      val xUnit = (x(0) - domain.origin(0)) / domain.spacing(0)
+      val yUnit = (x(1) - domain.origin(1)) / domain.spacing(1)
+
+      val k1 = scala.math.ceil(xUnit - 0.5f * (degree + 1)).toInt
+      val l1 = scala.math.ceil(yUnit - 0.5f * (degree + 1)).toInt
+
+      val K = degree + 1
+
+      var result = 0.0
+      var l = l1
+      while (l <= l1 + K - 1) {
+        val lBC = applyMirrorBoundaryCondition(l, domain.size(1))
+        var k = k1
+        while (k <= k1 + K - 1) {
+          val kBC = applyMirrorBoundaryCondition(k, domain.size(0))
+          val pointId = domain.pointId(IntVector(kBC, lBC))
+          result = result + ck(pointId.id) * splineBasis(xUnit - k, yUnit - l)
+          k = k + 1
+        }
+        l = l + 1
+      }
+      result
+    }
+
+    val bSplineNthOrder = BSpline.nthOrderBSpline(degree) _
+    val bSplineNmin1thOrder = BSpline.nthOrderBSpline(degree - 1) _
+
+    def f(x: Point[_2D]) = {
+      val splineBasis = (x: Double, y: Double) => bSplineNthOrder(x) * bSplineNthOrder(y) // apply function
+      scalar.fromDouble(iterateOnPoints(x, splineBasis))
+    }
+    def df(x: Point[_2D]) = {
+      val splineBasisD1 = (x: Double, y: Double) => (bSplineNmin1thOrder(x + 0.5f) - bSplineNmin1thOrder(x - 0.5f)) * bSplineNthOrder(y)
+      val splineBasisD2 = (x: Double, y: Double) => bSplineNthOrder(x) * (bSplineNmin1thOrder(y + 0.5f) - bSplineNmin1thOrder(y - 0.5f))
+      val dfx = (iterateOnPoints(x, splineBasisD1) * (1 / discreteField.domain.spacing(0))).toFloat
+      val dfy = (iterateOnPoints(x, splineBasisD2) * (1 / discreteField.domain.spacing(1))).toFloat
+      EuclideanVector(dfx, dfy)
+    }
+
+    DifferentiableField[_2D, A, EuclideanVector[_2D]](discreteField.domain.boundingBox, f, df)
+  }
+
+  /* determine the b-spline coefficients for a 2D image. The coefficients are returned
+  * as a DenseVector, i.e. the rows are written one after another */
+  private def determineCoefficients2D(degree: Int, img: DiscreteField[_2D, DiscreteImageDomain[_2D], A]): Array[Float] = {
+    val numeric = implicitly[Scalar[A]]
+    val coeffs = DenseVector.zeros[Float](img.values.size)
+    var y = 0
+    while (y < img.domain.size(1)) {
+      val rowValues = (0 until img.domain.size(0)).map(x => img(img.domain.pointId(IntVector(x, y))))
+
+      // the c is an input-output argument here
+      val c = rowValues.map(numeric.toFloat).toArray
+      BSplineCoefficients.getSplineInterpolationCoefficients(degree, c)
+
+      val idxInCoeffs = img.domain.pointId(IntVector(0, y)).id
+      coeffs(idxInCoeffs until idxInCoeffs + img.domain.size(0)) := DenseVector(c)
+      y = y + 1
+    }
+    coeffs.data
+  }
+}
+
+case class BSplineImageInterpolator3D[A: Scalar](degree: Int) extends BSplineImageInterpolator[_3D, A] {
+
+  override protected val scalar = Scalar[A]
+
+  override def interpolate(discreteField: DiscreteField[_3D, DiscreteImageDomain[_3D], A]): DifferentiableField[_3D, A, EuclideanVector[_3D]] = {
+    val domain = discreteField.domain
+
+    val ck = determineCoefficients3D(degree, discreteField)
+    val pointToIdx = domain.indexToPhysicalCoordinateTransform.inverse
+
+    def iterateOnPoints(x: Point[_3D], splineBasis: ((Double, Double, Double) => Double)): Double = {
+
+      val unitCoords = pointToIdx(x)
+      val xUnit = unitCoords(0)
+      val yUnit = unitCoords(1)
+      val zUnit = unitCoords(2)
+
+      val k1 = scala.math.ceil(xUnit - 0.5f * (degree + 1)).toInt
+      val l1 = scala.math.ceil(yUnit - 0.5f * (degree + 1)).toInt
+      val m1 = scala.math.ceil(zUnit - 0.5f * (degree + 1)).toInt
+
+      val K = degree + 1
+
+      var result = 0.0
+      var k = k1
+      var l = l1
+      var m = m1
+
+      while (m <= m1 + K - 1) {
+        val mBC = applyMirrorBoundaryCondition(m, domain.size(2))
+        l = l1
+        while (l <= l1 + K - 1) {
+          val lBC = applyMirrorBoundaryCondition(l, domain.size(1))
+          k = k1
+          while (k <= k1 + K - 1) {
+            val kBC = applyMirrorBoundaryCondition(k, domain.size(0))
+            val pointId = domain.pointId(IntVector(kBC, lBC, mBC))
+            result = result + ck(pointId.id) * splineBasis(xUnit - k, yUnit - l, zUnit - m)
+            k = k + 1
+          }
+          l = l + 1
+        }
+        m = m + 1
+      }
+      result
+    }
+
+    val bSplineNthOrder = BSpline.nthOrderBSpline(degree) _
+    val bSplineNmin1thOrder = BSpline.nthOrderBSpline(degree - 1) _
+
+    def f(x: Point[_3D]): A = {
+      val splineBasis = (x: Double, y: Double, z: Double) => bSplineNthOrder(x) * bSplineNthOrder(y) * bSplineNthOrder(z)
+      scalar.fromDouble(iterateOnPoints(x, splineBasis))
+    }
+
+    def df(x: Point[_3D]) = {
+      val splineBasisD1 = (x: Double, y: Double, z: Double) => (bSplineNmin1thOrder(x + 0.5f) - bSplineNmin1thOrder(x - 0.5f)) * bSplineNthOrder(y) * bSplineNthOrder(z)
+      val splineBasisD2 = (x: Double, y: Double, z: Double) => bSplineNthOrder(x) * (bSplineNmin1thOrder(y + 0.5f) - bSplineNmin1thOrder(y - 0.5f)) * bSplineNthOrder(z)
+      val splineBasisD3 = (x: Double, y: Double, z: Double) => bSplineNthOrder(x) * bSplineNthOrder(y) * (bSplineNmin1thOrder(z + 0.5f) - bSplineNmin1thOrder(z - 0.5f))
+      val dfx = (iterateOnPoints(x, splineBasisD1) * (1 / domain.spacing(0))).toFloat
+      val dfy = (iterateOnPoints(x, splineBasisD2) * (1 / domain.spacing(1))).toFloat
+      val dfz = (iterateOnPoints(x, splineBasisD3) * (1 / domain.spacing(2))).toFloat
+      EuclideanVector(dfx, dfy, dfz)
+    }
+
+    val bbox = domain.boundingBox
+    DifferentiableField(BoxDomain3D(bbox.origin, bbox.oppositeCorner), f, df)
+  }
+
+  private def determineCoefficients3D(degree: Int, discreteField: DiscreteField[_3D, DiscreteImageDomain[_3D], A]): Array[Float] = {
+
+    val coeffs = DenseVector.zeros[Float](discreteField.values.size)
+    var z = 0
+    var y = 0
+    while (z < discreteField.domain.size(2)) {
+      y = 0
+      while (y < discreteField.domain.size(1)) {
+        val rowValues = (0 until discreteField.domain.size(0))
+          .map(x => discreteField.apply(discreteField.domain.pointId(IntVector(x, y, z))))
+
+        // the c is an input-output argument here
+        val c = rowValues.map(scalar.toFloat).toArray
+        BSplineCoefficients.getSplineInterpolationCoefficients(degree, c)
+        val idxInCoeffs = discreteField.domain.pointId(IntVector(0, y, z)).id
+        coeffs(idxInCoeffs until idxInCoeffs + discreteField.domain.size(0)) := DenseVector(c)
+        y = y + 1
+      }
+      z = z + 1
+    }
+    coeffs.data
+  }
+}
+

--- a/src/main/scala/scalismo/common/interpolation/FieldInterpolator.scala
+++ b/src/main/scala/scalismo/common/interpolation/FieldInterpolator.scala
@@ -15,7 +15,7 @@
  */
 package scalismo.common.interpolation
 
-import scalismo.common.{DiscreteDomain, DiscreteField, Field}
+import scalismo.common.{DifferentiableField, DiscreteDomain, DiscreteField, Field}
 
 /**
  * Base trait for all interpolators that can be used to interpolate a [[DiscreteField]]
@@ -31,4 +31,10 @@ trait FieldInterpolator[D, -DDomain <: DiscreteDomain[D], A] {
    * @return A continuous field of the same type.
    */
   def interpolate(df: DiscreteField[D, DDomain, A]): Field[D, A]
+}
+
+trait DifferentiableFieldInterpolator[D, -DDomain <: DiscreteDomain[D], A, dA]
+extends FieldInterpolator [D, DDomain, A] {
+
+  override def interpolate(df: DiscreteField[D, DDomain, A]): DifferentiableField[D, A, dA]
 }

--- a/src/main/scala/scalismo/common/interpolation/LinearInterpolation.scala
+++ b/src/main/scala/scalismo/common/interpolation/LinearInterpolation.scala
@@ -16,7 +16,7 @@
 
 package scalismo.common.interpolation
 
-import scalismo.common.{ BoxDomain, DiscreteField, Field }
+import scalismo.common.{ DiscreteField, Field }
 import scalismo.geometry._
 import scalismo.image.DiscreteImageDomain
 import scalismo.numerics.ValueInterpolator

--- a/src/main/scala/scalismo/common/interpolation/NearestNeighborInterpolation.scala
+++ b/src/main/scala/scalismo/common/interpolation/NearestNeighborInterpolation.scala
@@ -16,7 +16,7 @@
 package scalismo.common
 
 import scalismo.common.interpolation.FieldInterpolator
-import scalismo.geometry.Point
+import scalismo.geometry.{ Point, _1D, _2D, _3D }
 
 /**
  * Nearest neighbor interpolation of a discrete field. This implementation is generic and
@@ -34,4 +34,15 @@ case class NearestNeighborInterpolator[D, A]() extends FieldInterpolator[D, Disc
     Field(RealSpace[D], valueAtClosestPoint)
   }
 
+}
+
+object NearestNeighborInterpolator1D {
+  def apply[A](): NearestNeighborInterpolator[_1D, A] = NearestNeighborInterpolator[_1D, A]()
+}
+
+object NearestNeighborInterpolator2D {
+  def apply[A](): NearestNeighborInterpolator[_2D, A] = NearestNeighborInterpolator[_2D, A]()
+}
+object NearestNeighborInterpolator3D {
+  def apply[A](): NearestNeighborInterpolator[_3D, A] = NearestNeighborInterpolator[_3D, A]()
 }

--- a/src/main/scala/scalismo/image/DiscreteScalarImage.scala
+++ b/src/main/scala/scalismo/image/DiscreteScalarImage.scala
@@ -16,12 +16,9 @@
 
 package scalismo.image
 
-import breeze.linalg.DenseVector
 import scalismo.common._
-import scalismo.common.interpolation.FieldInterpolator
+import scalismo.common.interpolation.{ BSplineImageInterpolator, DifferentiableFieldInterpolator, FieldInterpolator }
 import scalismo.geometry._
-import scalismo.image.DiscreteScalarImage.Create
-import scalismo.numerics.BSpline
 
 import scala.reflect.ClassTag
 
@@ -33,7 +30,7 @@ import scala.reflect.ClassTag
  * @tparam D  The dimensionality of the image
  * @tparam A The type of the pixel (needs to implement Scalar).
  */
-abstract class DiscreteScalarImage[D: NDSpace: Create, A: Scalar: ClassTag] protected (override val domain: DiscreteImageDomain[D], override val data: ScalarArray[A])
+class DiscreteScalarImage[D: NDSpace, A: Scalar: ClassTag](override val domain: DiscreteImageDomain[D], override val data: ScalarArray[A])
     extends DiscreteImage[D, A](domain, data) {
 
   require(domain.numberOfPoints == data.size)
@@ -47,7 +44,6 @@ abstract class DiscreteScalarImage[D: NDSpace: Create, A: Scalar: ClassTag] prot
 
   /**
    * Interpolates the image with the given interpolator.
-   * Note, that in contrast to the method [[DiscreteField.interpolate]] this method returns a scalar image
    *
    * @param interpolator The interpolator used to interpolate the image
    * @param dummy Used to distinguish the method from the generic one inherited from [[DiscreteField]]
@@ -57,289 +53,109 @@ abstract class DiscreteScalarImage[D: NDSpace: Create, A: Scalar: ClassTag] prot
     ScalarImage(f.domain, f.f andThen (Scalar[A].toFloat))
   }
 
-  /** Returns a new ContinuousScalarImage by interpolating the given DiscreteScalarImage using b-spline interpolation of given order */
-  def interpolate(order: Int): DifferentiableScalarImage[D]
+  /**
+   * Interpolates the image with the given interpolator.
+   * Note, that in contrast to the method [[DiscreteField.interpolate]] this method returns a scalar image
+   *
+   * @param interpolator The interpolator used to interpolate the image
+   * @param dummy Used to distinguish the method from the generic one inherited from [[DiscreteField]]
+   */
+  def interpolate(interpolator: DifferentiableFieldInterpolator[D, DiscreteImageDomain[D], A, EuclideanVector[D]])(implicit dummy: DummyImplicit): DifferentiableScalarImage[D] = {
+    val f = interpolator.interpolate(this)
+    DifferentiableScalarImage(f.domain, f.f andThen (Scalar[A].toFloat), f.df)
+  }
 
-  /** Returns a continuous scalar field. If you want a nearest neighbor interpolation that returns a [[ScalarImage]], use [[interpolate(0)]] instead*/
-  @deprecated("please use the [[interpolate]] method with a [[NearestNeighborInterpolator]] instead", "0.16")
-  override def interpolateNearestNeighbor(): ScalarField[D, A] = {
-    val ev = implicitly[Scalar[A]]
-    ScalarField(RealSpace[D], this.interpolate(0) andThen ev.fromFloat _)
+  /** Returns a new ContinuousScalarImage by interpolating the given DiscreteScalarImage using b-spline interpolation of given order */
+  @deprecated("please use interpolate(BSplineImageInterpolatorxD[A](order)) instead", "v0.18")
+  def interpolate(order: Int)(implicit bsplineCreator: BSplineImageInterpolator.Create[D]): DifferentiableScalarImage[D] = {
+    val interpolator = bsplineCreator.createBSplineInterpolator(order)
+    interpolate(interpolator)
   }
 
   /** Returns a new DiscreteScalarImage which is obtained by resampling the given image on the points defined by the new domain */
-  def resample(newDomain: DiscreteImageDomain[D], interpolationDegree: Int, outsideValue: Float): DiscreteScalarImage[D, A] = {
+  def resample(newDomain: DiscreteImageDomain[D], interpolationDegree: Int, outsideValue: Float)(implicit bsplineCreator: BSplineImageInterpolator.Create[D]): DiscreteScalarImage[D, A] = {
 
-    val contImg = interpolate(interpolationDegree)
+    val contImg = interpolate(bsplineCreator.createBSplineInterpolator(interpolationDegree))
     contImg.sample(newDomain, outsideValue)
   }
 
 }
 
-/**
- * Factory methods for creating a new DiscreteScalarImage, as well as method to interpolate and resample images.
- */
 object DiscreteScalarImage {
-
-  trait Create[D] {
-    def create[A: Scalar: ClassTag](domain: DiscreteImageDomain[D], values: ScalarArray[A]): DiscreteScalarImage[D, A]
-  }
-
-  implicit object Create1D extends Create[_1D] {
-    def create[A: Scalar: ClassTag](domain: DiscreteImageDomain[_1D], values: ScalarArray[A]): DiscreteScalarImage[_1D, A] = {
-      new DiscreteScalarImage1D(domain, values)
-    }
-  }
-
-  implicit object Create2D extends Create[_2D] {
-    def create[A: Scalar: ClassTag](domain: DiscreteImageDomain[_2D], values: ScalarArray[A]): DiscreteScalarImage[_2D, A] = {
-      new DiscreteScalarImage2D(domain, values)
-    }
-  }
-
-  implicit object Create3D extends Create[_3D] {
-    def create[A: Scalar: ClassTag](domain: DiscreteImageDomain[_3D], values: ScalarArray[A]): DiscreteScalarImage[_3D, A] = {
-      new DiscreteScalarImage3D(domain, values)
-    }
-  }
-
-  /** create a new DiscreteScalarImage with given domain and values */
-  def apply[D: NDSpace, A: Scalar: ClassTag](domain: DiscreteImageDomain[D], values: ScalarArray[A])(implicit create: Create[D]) = {
-    create.create(domain, values)
-  }
-
-  /** create a new DiscreteScalarImage with given domain and values */
-  def apply[D: NDSpace, A: Scalar: ClassTag](domain: DiscreteImageDomain[D], values: Traversable[A])(implicit create: Create[D]) = {
-    create.create(domain, ScalarArray(values.toArray))
-  }
-
-  /** create a new DiscreteScalarImage with given domain and values which are defined by the given function f */
-  def apply[D: NDSpace, A: Scalar: ClassTag](domain: DiscreteImageDomain[D], f: Point[D] => A)(implicit create: Create[D]) = {
-    create.create(domain, ScalarArray(domain.points.map(f).toArray))
+  def apply[D: NDSpace, A: Scalar: ClassTag](domain: DiscreteImageDomain[D], data: ScalarArray[A]): DiscreteScalarImage[D, A] = {
+    new DiscreteScalarImage(domain, data)
   }
 
   /** create a new DiscreteScalarImage, with all pixel values set to the given value */
-  def apply[D: NDSpace, A: Scalar: ClassTag](domain: DiscreteImageDomain[D])(v: => A)(implicit create: Create[D]) = {
-    create.create(domain, ScalarArray(Array.fill(domain.numberOfPoints)(v)))
+  def apply[D: NDSpace, A: Scalar: ClassTag](domain: DiscreteImageDomain[D], v: => A): DiscreteScalarImage[D, A] = {
+    DiscreteScalarImage(domain, ScalarArray(Array.fill(domain.numberOfPoints)(v)))
   }
 
-  /**
-   * computes the right index for the coefficient,
-   * taking the boundary conditions into account (it mirrors at the border)
-   */
-  private[scalismo] def applyMirrorBoundaryCondition(k: Int, numCoefficients: Int) = {
-    if (k < 0) -k
-    else if (k >= numCoefficients) numCoefficients - (k - numCoefficients) - 2
-    else k
+  /** create a new DiscreteScalarImage, with all pixel values set to the given value */
+  def apply[D: NDSpace, A: Scalar: ClassTag](domain: DiscreteImageDomain[D], f: Point[D] => A): DiscreteScalarImage[D, A] = {
+    val data = domain.points.map(f)
+    DiscreteScalarImage(domain, ScalarArray(data.toArray))
+  }
+
+  /** create a new DiscreteScalarImage with given domain and values */
+  def apply[D: NDSpace, A: Scalar: ClassTag](domain: DiscreteImageDomain[D], values: Traversable[A]): DiscreteScalarImage[D, A] = {
+    DiscreteScalarImage(domain, ScalarArray(values.toArray))
   }
 
 }
 
-private class DiscreteScalarImage1D[A: Scalar: ClassTag](domain: DiscreteImageDomain[_1D], data: ScalarArray[A]) extends DiscreteScalarImage[_1D, A](domain, data) {
-
-  def interpolate(degree: Int): DifferentiableScalarImage[_1D] = {
-
-    val ck = determineCoefficients1D(degree, this)
-
-    /*
-     * Computes values at given point with corresponding coefficients and spline basis
-     * */
-    def iterateOnPoints(x: Point[_1D], splineBasis: ((Double) => Double)): Double = {
-      val xUnit = (x(0) - domain.origin(0)) / domain.spacing(0)
-
-      val k1 = scala.math.ceil(xUnit - 0.5f * (degree + 1)).toInt
-      val K = degree + 1
-
-      var result = 0.0
-      var k = k1
-      while (k <= k1 + K - 1) {
-        val kBC = DiscreteScalarImage.applyMirrorBoundaryCondition(k, domain.size(0))
-        result = result + splineBasis(xUnit.toDouble - k) * ck(kBC)
-        k = k + 1
-      }
-      result
-    }
-
-    // the continuous interpolation function
-    def f(x: Point[_1D]) = {
-      val splineBasis: (Double => Double) = BSpline.nthOrderBSpline(degree)
-      iterateOnPoints(x, splineBasis).toFloat
-    }
-    // the derivative
-    def df(x: Point[_1D]) = {
-      //derivative
-      val splineBasisD1: (Double => Double) = { x => (BSpline.nthOrderBSpline(degree - 1)(x + 0.5f) - BSpline.nthOrderBSpline(degree - 1)(x - 0.5f)) * (1 / domain.spacing(0)) }
-      EuclideanVector(iterateOnPoints(x, splineBasisD1).toFloat)
-    }
-    DifferentiableScalarImage(domain.boundingBox, f, df)
+object DiscreteScalarImage1D {
+  def apply[A: Scalar: ClassTag](domain: DiscreteImageDomain[_1D], data: ScalarArray[A]): DiscreteScalarImage[_1D, A] = {
+    new DiscreteScalarImage[_1D, A](domain, data)
   }
 
-  /* determine the b-spline coefficients for a 1D image */
-  private def determineCoefficients1D[Pixel: Scalar](degree: Int, img: DiscreteScalarImage[_1D, Pixel]): Array[Float] = {
-    val numeric = implicitly[Scalar[Pixel]]
+  def apply[A: Scalar: ClassTag](domain: DiscreteImageDomain[_1D], v: => A): DiscreteScalarImage[_1D, A] = {
+    DiscreteScalarImage(domain, v)
+  }
 
-    // the c is an input-output argument here
-    val c = img.data.map[Float](numeric.toFloat)
-    val floats: Array[Float] = c.asInstanceOf[PrimitiveScalarArray[Float]].rawData
-    BSplineCoefficients.getSplineInterpolationCoefficients(degree, floats)
-    floats
+  def apply[A: Scalar: ClassTag](domain: DiscreteImageDomain[_1D], f: Point[_1D] => A): DiscreteScalarImage[_1D, A] = {
+    DiscreteScalarImage(domain, f)
+  }
+
+  def apply[A: Scalar: ClassTag](domain: DiscreteImageDomain[_1D], values: Traversable[A]): DiscreteScalarImage[_1D, A] = {
+    DiscreteScalarImage(domain, values)
+  }
+
+}
+
+object DiscreteScalarImage2D {
+  def apply[A: Scalar: ClassTag](domain: DiscreteImageDomain[_2D], data: ScalarArray[A]): DiscreteScalarImage[_2D, A] = {
+    new DiscreteScalarImage[_2D, A](domain, data)
+  }
+
+  def apply[A: Scalar: ClassTag](domain: DiscreteImageDomain[_2D], v: => A): DiscreteScalarImage[_2D, A] = {
+    DiscreteScalarImage(domain, v)
+  }
+
+  def apply[A: Scalar: ClassTag](domain: DiscreteImageDomain[_2D], f: Point[_2D] => A): DiscreteScalarImage[_2D, A] = {
+    DiscreteScalarImage(domain, f)
+  }
+
+  def apply[A: Scalar: ClassTag](domain: DiscreteImageDomain[_2D], values: Traversable[A]): DiscreteScalarImage[_2D, A] = {
+    DiscreteScalarImage(domain, values)
   }
 }
 
-private class DiscreteScalarImage2D[A: Scalar: ClassTag](domain: DiscreteImageDomain[_2D], data: ScalarArray[A]) extends DiscreteScalarImage[_2D, A](domain, data) {
-
-  def interpolate(degree: Int): DifferentiableScalarImage[_2D] = {
-    val ck = determineCoefficients2D(degree, this)
-
-    def iterateOnPoints(x: Point[_2D], splineBasis: ((Double, Double) => Double)): Double = {
-      val xUnit = (x(0) - domain.origin(0)) / domain.spacing(0)
-      val yUnit = (x(1) - domain.origin(1)) / domain.spacing(1)
-
-      val k1 = scala.math.ceil(xUnit - 0.5f * (degree + 1)).toInt
-      val l1 = scala.math.ceil(yUnit - 0.5f * (degree + 1)).toInt
-
-      val K = degree + 1
-
-      var result = 0.0
-      var l = l1
-      while (l <= l1 + K - 1) {
-        val lBC = DiscreteScalarImage.applyMirrorBoundaryCondition(l, domain.size(1))
-        var k = k1
-        while (k <= k1 + K - 1) {
-          val kBC = DiscreteScalarImage.applyMirrorBoundaryCondition(k, domain.size(0))
-          val pointId = domain.pointId(IntVector(kBC, lBC))
-          result = result + ck(pointId.id) * splineBasis(xUnit - k, yUnit - l)
-          k = k + 1
-        }
-        l = l + 1
-      }
-      result
-    }
-
-    val bSplineNthOrder = BSpline.nthOrderBSpline(degree) _
-    val bSplineNmin1thOrder = BSpline.nthOrderBSpline(degree - 1) _
-
-    def f(x: Point[_2D]) = {
-      val splineBasis = (x: Double, y: Double) => bSplineNthOrder(x) * bSplineNthOrder(y) // apply function
-      iterateOnPoints(x, splineBasis).toFloat
-    }
-    def df(x: Point[_2D]) = {
-      val splineBasisD1 = (x: Double, y: Double) => (bSplineNmin1thOrder(x + 0.5f) - bSplineNmin1thOrder(x - 0.5f)) * bSplineNthOrder(y)
-      val splineBasisD2 = (x: Double, y: Double) => bSplineNthOrder(x) * (bSplineNmin1thOrder(y + 0.5f) - bSplineNmin1thOrder(y - 0.5f))
-      val dfx = (iterateOnPoints(x, splineBasisD1) * (1 / domain.spacing(0))).toFloat
-      val dfy = (iterateOnPoints(x, splineBasisD2) * (1 / domain.spacing(1))).toFloat
-      EuclideanVector(dfx, dfy)
-    }
-
-    DifferentiableScalarImage(domain.boundingBox, f, df)
-
+object DiscreteScalarImage3D {
+  def apply[A: Scalar: ClassTag](domain: DiscreteImageDomain[_3D], data: ScalarArray[A]): DiscreteScalarImage[_3D, A] = {
+    new DiscreteScalarImage[_3D, A](domain, data)
   }
 
-  /* determine the b-spline coefficients for a 2D image. The coefficients are returned
-  * as a DenseVector, i.e. the rows are written one after another */
-  private def determineCoefficients2D[Pixel: Scalar](degree: Int, img: DiscreteScalarImage[_2D, Pixel]): Array[Float] = {
-    val numeric = implicitly[Scalar[Pixel]]
-    val coeffs = DenseVector.zeros[Float](img.values.size)
-    var y = 0
-    while (y < img.domain.size(1)) {
-      val rowValues = (0 until img.domain.size(0)).map(x => img(img.domain.pointId(IntVector(x, y))))
-
-      // the c is an input-output argument here
-      val c = rowValues.map(numeric.toFloat).toArray
-      BSplineCoefficients.getSplineInterpolationCoefficients(degree, c)
-
-      val idxInCoeffs = img.domain.pointId(IntVector(0, y)).id
-      coeffs(idxInCoeffs until idxInCoeffs + img.domain.size(0)) := DenseVector(c)
-      y = y + 1
-    }
-    coeffs.data
-  }
-}
-
-private class DiscreteScalarImage3D[A: Scalar: ClassTag](domain: DiscreteImageDomain[_3D], data: ScalarArray[A]) extends DiscreteScalarImage[_3D, A](domain, data) {
-  def interpolate(degree: Int): DifferentiableScalarImage[_3D] = {
-    val ck = determineCoefficients3D(degree, this)
-    val pointToIdx = domain.indexToPhysicalCoordinateTransform.inverse
-
-    def iterateOnPoints(x: Point[_3D], splineBasis: ((Double, Double, Double) => Double)): Double = {
-
-      val unitCoords = pointToIdx(x)
-      val xUnit = unitCoords(0)
-      val yUnit = unitCoords(1)
-      val zUnit = unitCoords(2)
-
-      val k1 = scala.math.ceil(xUnit - 0.5f * (degree + 1)).toInt
-      val l1 = scala.math.ceil(yUnit - 0.5f * (degree + 1)).toInt
-      val m1 = scala.math.ceil(zUnit - 0.5f * (degree + 1)).toInt
-
-      val K = degree + 1
-
-      var result = 0.0
-      var k = k1
-      var l = l1
-      var m = m1
-
-      while (m <= m1 + K - 1) {
-        val mBC = DiscreteScalarImage.applyMirrorBoundaryCondition(m, domain.size(2))
-        l = l1
-        while (l <= l1 + K - 1) {
-          val lBC = DiscreteScalarImage.applyMirrorBoundaryCondition(l, domain.size(1))
-          k = k1
-          while (k <= k1 + K - 1) {
-            val kBC = DiscreteScalarImage.applyMirrorBoundaryCondition(k, domain.size(0))
-            val pointId = domain.pointId(IntVector(kBC, lBC, mBC))
-            result = result + ck(pointId.id) * splineBasis(xUnit - k, yUnit - l, zUnit - m)
-            k = k + 1
-          }
-          l = l + 1
-        }
-        m = m + 1
-      }
-      result
-    }
-
-    val bSplineNthOrder = BSpline.nthOrderBSpline(degree) _
-    val bSplineNmin1thOrder = BSpline.nthOrderBSpline(degree - 1) _
-
-    def f(x: Point[_3D]) = {
-      val splineBasis = (x: Double, y: Double, z: Double) => bSplineNthOrder(x) * bSplineNthOrder(y) * bSplineNthOrder(z)
-      iterateOnPoints(x, splineBasis).toFloat
-    }
-    def df(x: Point[_3D]) = {
-      val splineBasisD1 = (x: Double, y: Double, z: Double) => (bSplineNmin1thOrder(x + 0.5f) - bSplineNmin1thOrder(x - 0.5f)) * bSplineNthOrder(y) * bSplineNthOrder(z)
-      val splineBasisD2 = (x: Double, y: Double, z: Double) => bSplineNthOrder(x) * (bSplineNmin1thOrder(y + 0.5f) - bSplineNmin1thOrder(y - 0.5f)) * bSplineNthOrder(z)
-      val splineBasisD3 = (x: Double, y: Double, z: Double) => bSplineNthOrder(x) * bSplineNthOrder(y) * (bSplineNmin1thOrder(z + 0.5f) - bSplineNmin1thOrder(z - 0.5f))
-      val dfx = (iterateOnPoints(x, splineBasisD1) * (1 / domain.spacing(0))).toFloat
-      val dfy = (iterateOnPoints(x, splineBasisD2) * (1 / domain.spacing(1))).toFloat
-      val dfz = (iterateOnPoints(x, splineBasisD3) * (1 / domain.spacing(2))).toFloat
-      EuclideanVector(dfx, dfy, dfz)
-    }
-    val bbox = domain.boundingBox
-    DifferentiableScalarImage(BoxDomain3D(bbox.origin, bbox.oppositeCorner), f, df)
-
+  def apply[A: Scalar: ClassTag](domain: DiscreteImageDomain[_3D], v: => A): DiscreteScalarImage[_3D, A] = {
+    DiscreteScalarImage(domain, v)
   }
 
-  private def determineCoefficients3D[Pixel: Scalar](degree: Int, img: DiscreteScalarImage[_3D, Pixel]): Array[Float] = {
-    val numeric = implicitly[Scalar[Pixel]]
-    val coeffs = DenseVector.zeros[Float](img.values.size)
-    var z = 0
-    var y = 0
-    while (z < img.domain.size(2)) {
-      y = 0
-      while (y < img.domain.size(1)) {
-        val rowValues = (0 until img.domain.size(0)).map(x => img(IntVector(x, y, z)))
-
-        // the c is an input-output argument here
-        val c = rowValues.map(numeric.toFloat).toArray
-        BSplineCoefficients.getSplineInterpolationCoefficients(degree, c)
-        val idxInCoeffs = img.domain.pointId(IntVector(0, y, z)).id
-        coeffs(idxInCoeffs until idxInCoeffs + img.domain.size(0)) := DenseVector(c)
-        y = y + 1
-      }
-      z = z + 1
-    }
-    coeffs.data
+  def apply[A: Scalar: ClassTag](domain: DiscreteImageDomain[_3D], f: Point[_3D] => A): DiscreteScalarImage[_3D, A] = {
+    DiscreteScalarImage(domain, f)
   }
 
+  def apply[A: Scalar: ClassTag](domain: DiscreteImageDomain[_3D], values: Traversable[A]): DiscreteScalarImage[_3D, A] = {
+    DiscreteScalarImage(domain, values)
+  }
 }
 

--- a/src/main/scala/scalismo/image/Image.scala
+++ b/src/main/scala/scalismo/image/Image.scala
@@ -105,7 +105,7 @@ class ScalarImage[D: NDSpace] protected (override val domain: Domain[D], overrid
    * Returns a discrete scalar image with the given domain, whose values are obtained by sampling the scalarImage at the domain points.
    * If the image is not defined at a domain point, the outside value is used.
    */
-  def sample[Pixel: Scalar: ClassTag](domain: DiscreteImageDomain[D], outsideValue: Float)(implicit ev: DiscreteScalarImage.Create[D]): DiscreteScalarImage[D, Pixel] = {
+  def sample[Pixel: Scalar: ClassTag](domain: DiscreteImageDomain[D], outsideValue: Float): DiscreteScalarImage[D, Pixel] = {
     val numeric = implicitly[Scalar[Pixel]]
     val convertedOutsideValue = numeric.fromFloat(outsideValue)
 

--- a/src/main/scala/scalismo/image/filter/DiscreteImageFilter.scala
+++ b/src/main/scala/scalismo/image/filter/DiscreteImageFilter.scala
@@ -15,6 +15,7 @@
  */
 package scalismo.image.filter
 
+import scalismo.common.interpolation.BSplineImageInterpolator
 import scalismo.common.{ Scalar, ScalarArray }
 import scalismo.geometry._
 import scalismo.image.DiscreteScalarImage
@@ -30,7 +31,7 @@ object DiscreteImageFilter {
    * Computes a (signed) distance transform of the image.
    * @note The value that is returned is not the euclidean distance unless the image has unit spacing. Even worse, the distance might depend on the spacing of the image.
    */
-  def distanceTransform[D: NDSpace: CanConvertToVtk: DiscreteScalarImage.Create, A: Scalar: ClassTag: TypeTag](img: DiscreteScalarImage[D, A]): DiscreteScalarImage[D, Float] = {
+  def distanceTransform[D: NDSpace: CanConvertToVtk: BSplineImageInterpolator.Create, A: Scalar: ClassTag: TypeTag](img: DiscreteScalarImage[D, A]): DiscreteScalarImage[D, Float] = {
 
     val scalar = implicitly[Scalar[A]]
 

--- a/src/main/scala/scalismo/io/MeshIO.scala
+++ b/src/main/scala/scalismo/io/MeshIO.scala
@@ -25,7 +25,6 @@ import scalismo.mesh._
 import scalismo.utils.MeshConversion
 import vtk._
 
-import scala.io.Source
 import scala.reflect.ClassTag
 import scala.reflect.runtime.universe.TypeTag
 import scala.util.{ Failure, Success, Try }

--- a/src/main/scala/scalismo/statisticalmodel/asm/ImagePreprocessor.scala
+++ b/src/main/scala/scalismo/statisticalmodel/asm/ImagePreprocessor.scala
@@ -18,6 +18,7 @@ package scalismo.statisticalmodel.asm
 
 import breeze.linalg.DenseVector
 import ncsa.hdf.`object`.Group
+import scalismo.common.interpolation.BSplineImageInterpolator3D
 import scalismo.common.{ Domain, Field, VectorField }
 import scalismo.geometry.{ Point, _3D }
 import scalismo.image.DiscreteScalarImage
@@ -82,7 +83,7 @@ case class IdentityImagePreprocessor(override val ioMetadata: IOMetadata = Ident
   override def apply(inputImage: DiscreteScalarImage[_3D, Float]): PreprocessedImage = new PreprocessedImage {
     override val valueType = PreprocessedImage.Intensity
 
-    val interpolated = inputImage.interpolate(3)
+    val interpolated = inputImage.interpolate(BSplineImageInterpolator3D[Float](3))
 
     override def domain: Domain[_3D] = interpolated.domain
 
@@ -134,7 +135,7 @@ case class GaussianGradientImagePreprocessor(stddev: Float, override val ioMetad
       } else {
         inputImage
       }
-    }.interpolate(1).differentiate
+    }.interpolate(BSplineImageInterpolator3D[Float](1)).differentiate
 
     override def domain: Domain[_3D] = gradientImage.domain
 

--- a/src/test/scala/scalismo/common/LinearInterpolatorTest.scala
+++ b/src/test/scala/scalismo/common/LinearInterpolatorTest.scala
@@ -20,7 +20,6 @@ import scalismo.ScalismoTestSuite
 import scalismo.geometry._
 import scalismo.image.{ DiscreteImageDomain, DiscreteScalarImage }
 import scalismo.common.interpolation.{ LinearImageInterpolator, LinearImageInterpolator3D }
-import scalismo.io.ImageIO
 
 class LinearInterpolatorTest extends ScalismoTestSuite {
 

--- a/src/test/scala/scalismo/image/InterpolationTest.scala
+++ b/src/test/scala/scalismo/image/InterpolationTest.scala
@@ -20,6 +20,7 @@ import java.io.File
 import org.scalatest.PrivateMethodTester
 import scalismo.ScalismoTestSuite
 import scalismo.common.PointId
+import scalismo.common.interpolation.{ BSplineImageInterpolator1D, BSplineImageInterpolator2D, BSplineImageInterpolator3D }
 import scalismo.geometry.IntVector.implicits._
 import scalismo.geometry.Point.implicits._
 import scalismo.geometry.EuclideanVector.implicits._
@@ -37,7 +38,7 @@ class InterpolationTest extends ScalismoTestSuite with PrivateMethodTester {
     it("interpolates the values for origin 2.3 and spacing 1.5") {
       val domain = DiscreteImageDomain[_1D](2.3, 1.5, 7)
       val discreteImage = DiscreteScalarImage(domain, Seq[Float](1.4, 2.1, 7.5, 9.0, 8.0, 0.0, 2.1))
-      val continuousImg = discreteImage.interpolate(0)
+      val continuousImg = discreteImage.interpolate(BSplineImageInterpolator1D[Float](0))
       for ((pt, idx) <- discreteImage.domain.points.zipWithIndex) {
         continuousImg(pt) should be(discreteImage(idx) +- 0.0001f)
       }
@@ -49,7 +50,7 @@ class InterpolationTest extends ScalismoTestSuite with PrivateMethodTester {
     it("interpolates the values for origin 2.3 and spacing 1.5") {
       val domain = DiscreteImageDomain[_1D](2.3, 1.5, 7)
       val discreteImage = DiscreteScalarImage[_1D, Float](domain, Seq[Float](1.4, 2.1, 7.5, 9, 8, 0, 2.1))
-      val continuousImg = discreteImage.interpolate(1)
+      val continuousImg = discreteImage.interpolate(BSplineImageInterpolator1D[Float](1))
       for ((pt, idx) <- discreteImage.domain.points.zipWithIndex) {
         continuousImg(pt) should be(discreteImage(idx) +- 0.0001f)
       }
@@ -58,7 +59,7 @@ class InterpolationTest extends ScalismoTestSuite with PrivateMethodTester {
     it("interpolates the values for origin 0 and spacing 1") {
       val domain = DiscreteImageDomain[_1D](0.0, 1.0, 5)
       val discreteImage = DiscreteScalarImage(domain, Seq(3.0, 2.0, 1.5, 1.0, 0.0))
-      val continuousImg = discreteImage.interpolate(0)
+      val continuousImg = discreteImage.interpolate(BSplineImageInterpolator1D[Double](0))
       for ((pt, idx) <- discreteImage.domain.points.zipWithIndex) {
         assert(continuousImg(pt) === discreteImage(idx))
       }
@@ -70,7 +71,7 @@ class InterpolationTest extends ScalismoTestSuite with PrivateMethodTester {
         val domain = DiscreteImageDomain[_1D](-2.0, 0.01, 400)
 
         val discreteSinImage = DiscreteScalarImage(domain, domain.points.map(x => math.sin(x * math.Pi)).toIndexedSeq)
-        val interpolatedSinImage = discreteSinImage.interpolate(3)
+        val interpolatedSinImage = discreteSinImage.interpolate(BSplineImageInterpolator1D[Double](3))
         val derivativeImage = interpolatedSinImage.differentiate
 
         val discreteCosImage = DiscreteScalarImage(domain, domain.points.map(x => math.Pi * math.cos(x * math.Pi)).toIndexedSeq)
@@ -90,7 +91,7 @@ class InterpolationTest extends ScalismoTestSuite with PrivateMethodTester {
         val domain = DiscreteImageDomain[_2D]((0.0, 0.0), (1.0, 1.0), (2, 3))
         val discreteImage = DiscreteScalarImage(domain, Seq(1f, 2f, 3f, 4f, 5f, 6f))
 
-        val continuousImg = discreteImage.interpolate(0)
+        val continuousImg = discreteImage.interpolate(BSplineImageInterpolator2D[Float](0))
 
         for ((pt, idx) <- discreteImage.domain.points.zipWithIndex) {
           continuousImg(pt) should be(discreteImage(PointId(idx)) +- 0.0001f)
@@ -101,7 +102,7 @@ class InterpolationTest extends ScalismoTestSuite with PrivateMethodTester {
         val domain = DiscreteImageDomain[_2D]((2.0, 3.0), (1.5, 0.1), (2, 3))
         val discreteImage = DiscreteScalarImage(domain, Seq(1.4f, 2.1f, 7.5f, 9f, 8f, 0f))
 
-        val continuousImg = discreteImage.interpolate(0)
+        val continuousImg = discreteImage.interpolate(BSplineImageInterpolator2D[Float](0))
 
         for ((pt, idx) <- discreteImage.domain.points.zipWithIndex) {
           continuousImg(pt) should be(discreteImage(PointId(idx)) +- 0.0001f)
@@ -111,9 +112,9 @@ class InterpolationTest extends ScalismoTestSuite with PrivateMethodTester {
     describe(" of degree 3") {
       it("Interpolates the values for origin (2,3) and spacing (1.5, 2.3)") {
         val domain = DiscreteImageDomain[_2D]((2.0, 3.0), (1.5, 1.3), (10, 10))
-        val discreteImage = DiscreteScalarImage(domain, domain.points.map(x => x(0).toFloat).toArray)
+        val discreteImage = DiscreteScalarImage(domain, domain.points.map(x => x(0).toFloat).toSeq)
 
-        val continuousImg = discreteImage.interpolate(3)
+        val continuousImg = discreteImage.interpolate(BSplineImageInterpolator2D[Float](3))
 
         for ((pt, idx) <- discreteImage.domain.points.zipWithIndex) {
           continuousImg(pt) should be(discreteImage(PointId(idx)) +- 0.0001f)
@@ -123,7 +124,7 @@ class InterpolationTest extends ScalismoTestSuite with PrivateMethodTester {
       it("Interpolates the values correctly for a test dataset") {
         val testImgUrl = getClass.getResource("/lena256.vtk").getPath
         val discreteFixedImage = ImageIO.read2DScalarImage[Short](new File(testImgUrl)).get
-        val interpolatedImage = discreteFixedImage.interpolate(2)
+        val interpolatedImage = discreteFixedImage.interpolate(BSplineImageInterpolator2D[Short](2))
 
         for ((p, i) <- discreteFixedImage.domain.points.zipWithIndex) {
           interpolatedImage(p).toShort should be(discreteFixedImage(PointId(i)) +- 30)
@@ -133,8 +134,8 @@ class InterpolationTest extends ScalismoTestSuite with PrivateMethodTester {
       it("Derivative of interpolated function is correct") {
         val domain = DiscreteImageDomain[_2D]((-2.0, -2.0), (0.01, 0.01), (400, 400))
 
-        val discreteFImage = DiscreteScalarImage(domain, domain.points.map(x => x(0) * x(0) + x(1) * x(1)).toArray)
-        val interpolatedFImage = discreteFImage.interpolate(3)
+        val discreteFImage = DiscreteScalarImage(domain, domain.points.map(x => x(0) * x(0) + x(1) * x(1)).toSeq)
+        val interpolatedFImage = discreteFImage.interpolate(BSplineImageInterpolator2D[Double](3))
         val derivativeImage = interpolatedFImage.differentiate
 
         for ((pt, idx) <- domain.points.zipWithIndex.filter(x => math.abs(x._1(0)) < 1.90 && math.abs(x._1(1)) < 1.90)) {
@@ -151,7 +152,7 @@ class InterpolationTest extends ScalismoTestSuite with PrivateMethodTester {
         val domain = DiscreteImageDomain[_3D]((2.0, 3.0, 0.0), (1.5, 1.3, 2.0), (2, 3, 2))
         val discreteImage = DiscreteScalarImage[_3D, Float](domain, Array(1.4f, 2.1f, 7.5f, 9f, 8f, 0f, 1.4f, 2.1f, 7.5f, 9f, 8f, 0f))
 
-        val continuousImg = discreteImage.interpolate(0)
+        val continuousImg = discreteImage.interpolate(BSplineImageInterpolator3D[Float](0))
 
         for ((pt, idx) <- discreteImage.domain.points.zipWithIndex) {
           continuousImg(pt) should be(discreteImage(PointId(idx)) +- 0.0001f)
@@ -164,7 +165,7 @@ class InterpolationTest extends ScalismoTestSuite with PrivateMethodTester {
         val domain = DiscreteImageDomain[_3D]((2.0, 3.0, 0.0), (1.5, 1.3, 2.0), (2, 3, 2))
         val discreteImage = DiscreteScalarImage[_3D, Float](domain, Array(1.4f, 2.1f, 7.5f, 9f, 8f, 0f, 1.4f, 2.1f, 7.5f, 9f, 8f, 0f))
 
-        val continuousImg = discreteImage.interpolate(1)
+        val continuousImg = discreteImage.interpolate(BSplineImageInterpolator3D[Float](1))
 
         for ((pt, idx) <- discreteImage.domain.points.zipWithIndex) {
           continuousImg(pt) should be(discreteImage(PointId(idx)) +- 0.0001f)
@@ -177,7 +178,7 @@ class InterpolationTest extends ScalismoTestSuite with PrivateMethodTester {
         val domain = DiscreteImageDomain[_3D]((2.0, 3.0, 0.0), (1.5, 1.3, 2.0), (10, 10, 10))
         val discreteImage = DiscreteScalarImage[_3D, Float](domain, domain.points.map(x => x(0).toFloat).toArray)
 
-        val continuousImg = discreteImage.interpolate(3)
+        val continuousImg = discreteImage.interpolate(BSplineImageInterpolator3D[Float](3))
 
         for ((pt, idx) <- discreteImage.domain.points.zipWithIndex) {
           continuousImg(pt) should be(discreteImage(PointId(idx)) +- 0.0001f)
@@ -187,8 +188,8 @@ class InterpolationTest extends ScalismoTestSuite with PrivateMethodTester {
       it("Derivative of interpolated function is correct") {
         val domain = DiscreteImageDomain[_3D]((-2.0, -2.0, -2.0), (0.1, 0.1, 0.1), (40, 40, 40))
 
-        val discreteFImage = DiscreteScalarImage(domain, domain.points.map(x => x(0) * x(0) + x(1) * x(1) + x(2) * x(2)).toArray)
-        val interpolatedFImage = discreteFImage.interpolate(3)
+        val discreteFImage = DiscreteScalarImage(domain, domain.points.map(x => x(0) * x(0) + x(1) * x(1) + x(2) * x(2)).toSeq)
+        val interpolatedFImage = discreteFImage.interpolate(BSplineImageInterpolator3D[Double](3))
         val derivativeImage = interpolatedFImage.differentiate
 
         for ((pt, idx) <- domain.points.zipWithIndex.filter(x => math.abs(x._1(0)) < 1.0 && math.abs(x._1(1)) < 1.0 && math.abs(x._1(2)) < 1.0)) {
@@ -201,7 +202,7 @@ class InterpolationTest extends ScalismoTestSuite with PrivateMethodTester {
       it("Interpolates a real dataset correctly") {
         val path = getClass.getResource("/3dimage.nii").getPath
         val discreteImage = ImageIO.read3DScalarImage[Short](new File(path)).get
-        val continuousImage = discreteImage.interpolate(1)
+        val continuousImage = discreteImage.interpolate(BSplineImageInterpolator3D[Short](1))
 
         for ((p, i) <- discreteImage.domain.points.zipWithIndex.filter(p => p._2 % 100 == 0))
           discreteImage(PointId(i)) should be(continuousImage(p).toShort +- 1.toShort)

--- a/src/test/scala/scalismo/image/ResampleTests.scala
+++ b/src/test/scala/scalismo/image/ResampleTests.scala
@@ -19,6 +19,7 @@ import java.io.File
 
 import scalismo.ScalismoTestSuite
 import scalismo.common.PointId
+import scalismo.common.interpolation.{ BSplineImageInterpolator2D, BSplineImageInterpolator3D }
 import scalismo.io.ImageIO
 
 class ResampleTests extends ScalismoTestSuite {
@@ -30,7 +31,7 @@ class ResampleTests extends ScalismoTestSuite {
 
     // here we do 1st order interpolation. 3rd order would not work, as it does not necessarily preserve the
     // pixel values at the strong edges - and we thus could not formulate a reasonable test
-    val continuousImage = discreteImage.interpolate(1)
+    val continuousImage = discreteImage.interpolate(BSplineImageInterpolator2D[Short](1))
 
     it("yields the original discrete image") {
       val resampledImage = continuousImage.sample[Short](discreteImage.domain, 0)
@@ -44,7 +45,7 @@ class ResampleTests extends ScalismoTestSuite {
   describe("Resampling a 3D image") {
     val path = getClass.getResource("/3dimage.nii").getPath
     val discreteImage = ImageIO.read3DScalarImage[Short](new File(path)).get
-    val continuousImage = discreteImage.interpolate(0)
+    val continuousImage = discreteImage.interpolate(BSplineImageInterpolator3D[Short](0))
 
     it("yields the original discrete image") {
       val resampledImage = continuousImage.sample[Short](discreteImage.domain, 0)

--- a/src/test/scala/scalismo/io/ImageIOTests.scala
+++ b/src/test/scala/scalismo/io/ImageIOTests.scala
@@ -155,7 +155,7 @@ class ImageIOTests extends ScalismoTestSuite {
     it("can be stored to VTK and re-read in right precision") {
       val domain = DiscreteImageDomain[_3D](Point(-72.85742f, -72.85742f, -273.0f), EuclideanVector(0.85546875f, 0.85546875f, 1.5f), IntVector(15, 15, 15))
       val values = DenseVector.zeros[Short](15 * 15 * 15).data
-      val discreteImage = DiscreteScalarImage(domain, values)
+      val discreteImage = DiscreteScalarImage(domain, values.toSeq)
       val f = File.createTempFile("dummy", ".vtk")
       f.deleteOnExit()
       ImageIO.writeVTK(discreteImage, f)

--- a/src/test/scala/scalismo/io/MeshIOTests.scala
+++ b/src/test/scala/scalismo/io/MeshIOTests.scala
@@ -22,7 +22,6 @@ import scalismo.common.{ Scalar, ScalarArray }
 import scalismo.geometry._3D
 import scalismo.mesh.{ ScalarMeshField, TriangleMesh }
 
-import scala.io.Source
 import scala.reflect.ClassTag
 import scala.reflect.runtime.universe.TypeTag
 import scala.util.{ Failure, Success, Try }

--- a/src/test/scala/scalismo/registration/MetricTests.scala
+++ b/src/test/scala/scalismo/registration/MetricTests.scala
@@ -20,11 +20,12 @@ import _root_.java.io.File
 import breeze.linalg.DenseVector
 import scalismo.ScalismoTestSuite
 import scalismo.common.BoxDomain
+import scalismo.common.interpolation.{ BSplineImageInterpolator2D }
 import scalismo.geometry.Point.implicits._
 import scalismo.geometry._
-import scalismo.image.{ DiscreteImageDomain, DifferentiableScalarImage }
+import scalismo.image.{ DifferentiableScalarImage, DiscreteImageDomain }
 import scalismo.io.ImageIO
-import scalismo.numerics.{ LBFGSOptimizer, GridSampler, UniformSampler }
+import scalismo.numerics.{ GridSampler, LBFGSOptimizer, UniformSampler }
 import scalismo.utils.Random
 
 class MetricTests extends ScalismoTestSuite {
@@ -48,7 +49,7 @@ class MetricTests extends ScalismoTestSuite {
     val testImgURL = getClass.getResource("/dm128.vtk").getPath
 
     val fixedImage = ImageIO.read2DScalarImage[Float](new File(testImgURL)).get
-    val fixedImageCont = fixedImage.interpolate(3)
+    val fixedImageCont = fixedImage.interpolate(BSplineImageInterpolator2D[Float](3))
     val translationSpace = TranslationSpace[_2D]
     val sampler = GridSampler(DiscreteImageDomain(fixedImage.domain.boundingBox, size = IntVector(50, 50)))
 
@@ -95,7 +96,7 @@ class MetricTests extends ScalismoTestSuite {
     val testImgURL = getClass.getResource("/dm128.vtk").getPath
 
     val fixedImage = ImageIO.read2DScalarImage[Float](new File(testImgURL)).get
-    val fixedImageCont = fixedImage.interpolate(3)
+    val fixedImageCont = fixedImage.interpolate(BSplineImageInterpolator2D[Float](3))
     val translationSpace = TranslationSpace[_2D]
     val sampler = GridSampler(DiscreteImageDomain(fixedImage.domain.boundingBox, size = IntVector(50, 50)))
 

--- a/src/test/scala/scalismo/registration/RegistrationTests.scala
+++ b/src/test/scala/scalismo/registration/RegistrationTests.scala
@@ -18,6 +18,7 @@ package scalismo.registration
 import java.io.File
 
 import breeze.linalg.DenseVector
+import scalismo.common.interpolation.{ BSplineImageInterpolator2D, BSplineImageInterpolator3D }
 import scalismo.{ ScalismoTestSuite, numerics }
 import scalismo.common.{ Field, NearestNeighborInterpolator, PointId, RealSpace }
 import scalismo.geometry._
@@ -174,7 +175,7 @@ class RegistrationTests extends ScalismoTestSuite {
       val testImgUrl = getClass.getResource("/dm128.vtk").getPath
 
       val discreteFixedImage = ImageIO.read2DScalarImage[Float](new File(testImgUrl)).get
-      val fixedImage = discreteFixedImage.interpolate(3)
+      val fixedImage = discreteFixedImage.interpolate(BSplineImageInterpolator2D[Float](2))
       val transformationSpace = TranslationSpace[_2D]
       val translationParams = DenseVector[Double](-10.0, 5.0)
       val translationTransform = transformationSpace.transformForParameters(translationParams)
@@ -196,7 +197,7 @@ class RegistrationTests extends ScalismoTestSuite {
     it("Recovers the correct parameters for a rotation transform") {
       val testImgUrl = getClass.getResource("/dm128.vtk").getPath
       val discreteFixedImage = ImageIO.read2DScalarImage[Float](new File(testImgUrl)).get
-      val fixedImage = discreteFixedImage.interpolate(3)
+      val fixedImage = discreteFixedImage.interpolate(BSplineImageInterpolator2D[Float](3))
       val domain = discreteFixedImage.domain
       val center = ((domain.boundingBox.oppositeCorner - domain.origin) * 0.5).toPoint
       val transformationSpace = RotationSpace[_2D](center)
@@ -220,7 +221,7 @@ class RegistrationTests extends ScalismoTestSuite {
       val testImgUrl = getClass.getResource("/dm128.vtk").getPath
 
       val discreteFixedImage = ImageIO.read2DScalarImage[Float](new File(testImgUrl)).get
-      val fixedImage = discreteFixedImage.interpolate(3)
+      val fixedImage = discreteFixedImage.interpolate(BSplineImageInterpolator2D[Float](3))
 
       val domain = discreteFixedImage.domain
       val gp = GaussianProcess(Field(RealSpace[_2D], (_: Point[_2D]) => EuclideanVector.zeros[_2D]), DiagonalKernel(GaussianKernel[_2D](50.0) * 50.0, 2))
@@ -253,7 +254,7 @@ class RegistrationTests extends ScalismoTestSuite {
       val testImgUrl = getClass.getResource("/dm128.vtk").getPath
 
       val discreteFixedImage = ImageIO.read2DScalarImage[Float](new File(testImgUrl)).get
-      val fixedImage = discreteFixedImage.interpolate(3)
+      val fixedImage = discreteFixedImage.interpolate(BSplineImageInterpolator2D[Float](3))
 
       val domain = discreteFixedImage.domain
 
@@ -287,7 +288,7 @@ class RegistrationTests extends ScalismoTestSuite {
   describe("A 3D image registration") {
     val testImgUrl = getClass.getResource("/3ddm.nii").getPath
     val discreteFixedImage = ImageIO.read3DScalarImage[Float](new File(testImgUrl)).get
-    val fixedImage = discreteFixedImage.interpolate(3)
+    val fixedImage = discreteFixedImage.interpolate(BSplineImageInterpolator3D[Float](3))
 
     val transformationSpace = TranslationSpace[_3D]
     val domain = discreteFixedImage.domain

--- a/src/test/scala/scalismo/registration/TransformationTests.scala
+++ b/src/test/scala/scalismo/registration/TransformationTests.scala
@@ -20,6 +20,7 @@ import java.io.File
 import breeze.linalg.DenseVector
 import scalismo.ScalismoTestSuite
 import scalismo.common.PointId
+import scalismo.common.interpolation.BSplineImageInterpolator3D
 import scalismo.geometry.IntVector.implicits._
 import scalismo.geometry.Point.implicits._
 import scalismo.geometry.EuclideanVector.implicits._
@@ -142,7 +143,7 @@ class TransformationTests extends ScalismoTestSuite {
 
     val path = getClass.getResource("/3dimage.nii").getPath
     val discreteImage = ImageIO.read3DScalarImage[Short](new File(path)).get
-    val continuousImage = discreteImage.interpolate(0)
+    val continuousImage = discreteImage.interpolate(BSplineImageInterpolator3D[Short](0))
 
     it("translation forth and back of a real dataset yields the same image") {
 


### PR DESCRIPTION
The usual mechanism of interpolating discrete objects in Scalismo is by calling the method ```interpolate``` with a suitable interpolator. The only exception so far was the interpolation in the ```DiscreteScalarImage``` class, where the interpolator was fixed to be a bspline interpolator and only the order of the b-spline was passed as an argument. 

This PR introduces the class ```BSplineImageInterpolator``` and unifies the interpolation mechanism of images with the rest of the library. This does not only make Scalismo more uniform, but also makes explicit which interpolator is used. 
