### PR TITLE
Added scalar type to ScalarImage class

### DIFF
--- a/src/main/scala/scalismo/common/Field.scala
+++ b/src/main/scala/scalismo/common/Field.scala
@@ -114,23 +114,37 @@ case class ScalarField[D, A: Scalar: ClassTag](domain: Domain[D], f: Point[D] =>
   val ev = implicitly[Scalar[A]]
   /** adds two images. The domain of the new image is the intersection of both */
   def +(that: ScalarField[D, A]): ScalarField[D, A] = {
-    def f(x: Point[D]): A = ev.fromDouble(ev.toDouble(this.f(x)) + ev.toDouble(that.f(x)))
+    def f(x: Point[D]): A = ev.plus(this.f(x), that.f(x))
     new ScalarField(Domain.intersection[D](domain, that.domain), f)
   }
 
   /** subtract two images. The domain of the new image is the intersection of the domains of the individual images*/
   def -(that: ScalarField[D, A]): ScalarField[D, A] = {
-    def f(x: Point[D]): A = ev.fromDouble(ev.toDouble(this.f(x)) - ev.toDouble(that.f(x)))
+    def f(x: Point[D]): A = ev.minus(this.f(x), that.f(x))
     val newDomain = Domain.intersection[D](domain, that.domain)
     new ScalarField(newDomain, f)
   }
 
   /** scalar multiplication of a vector field */
-  def *(s: Double): ScalarField[D, A] = {
+  def :*(that: ScalarField[D, A]): ScalarField[D, A] = {
+    def f(x: Point[D]): A = ev.times(this.f(x), that.f(x))
+    val newDomain = Domain.intersection[D](domain, that.domain)
+    new ScalarField(newDomain, f)
+  }
 
-    def f(x: Point[D]): A = ev.fromDouble(ev.toDouble(this.f(x)) * s)
+  /** scalar multiplication of a vector field */
+  def *(s: Double): ScalarField[D, Double] = {
+
+    def f(x: Point[D]): Double = ev.timesDouble(this.f(x), s)
     new ScalarField(domain, f)
   }
+
+  def compose(t: Point[D] => Point[D]): ScalarField[D, A] = {
+    val f = this.f.compose(t)
+    val newDomain = Domain.fromPredicate[D]((pt: Point[D]) => isDefinedAt(t(pt)))
+    new ScalarField(newDomain, f)
+  }
+
 }
 
 /**

--- a/src/main/scala/scalismo/common/Scalar.scala
+++ b/src/main/scala/scalismo/common/Scalar.scala
@@ -44,6 +44,13 @@ trait Scalar[@specialized(Byte, Short, Int, Float, Double) S] extends Any {
   def toLong(a: S): Long
   def toFloat(a: S): Float
   def toDouble(a: S): Double
+
+  def plus(s1 : S, s2 : S) : S
+  def minus(s1 : S, s2 : S) : S
+  def times(s1 : S, s2 : S) : S
+  def timesDouble(s1 : S, d : Double) : Double
+  def zero : S
+  def one : S
 }
 
 /**
@@ -103,6 +110,12 @@ object Scalar {
     override def fromFloat(n: Float): A = num.fromFloat(n)
     override def fromDouble(n: Double): A = num.fromDouble(n)
 
+    override def plus(s1: A, s2: A): A = num.plus(s1, s2)
+    override def minus(s1: A, s2: A): A = num.minus(s1, s2)
+    override def times(s1: A, s2: A): A = num.times(s1, s2)
+    override def timesDouble(s1: A, d: Double): Double = num.toDouble(s1) * d
+    override def zero: A = num.zero
+    override def one: A = num.one
   }
 
   class UByteIsScalar extends ValueClassScalar[UByte, Byte] {
@@ -123,27 +136,60 @@ object Scalar {
     override def createArray(data: Array[Byte]): ValueClassScalarArray[UByte, Byte] = ValueClassScalarArray(data)(this)
     override def toUnderlying(u: UByte): Byte = u.toByte
     override def fromUnderlying(p: Byte): UByte = UByte(p)
+
+    override def plus(s1: UByte, s2: UByte): UByte = UByte(s1.toByte + s2.toByte)
+    override def minus(s1: UByte, s2: UByte): UByte = UByte(s1.toByte - s2.toByte)
+    override def times(s1: UByte, s2: UByte): UByte = UByte(s1.toByte * s2.toByte)
+    override def timesDouble(s1: UByte, d: Double): Double = s1.toDouble * d
+
+    override def zero: UByte = UByte(0)
+    override def one: UByte = UByte(1)
   }
 
   class UShortIsScalar extends ValueClassScalar[UShort, Char] {
     override def toByte(a: UShort): Byte = a.toByte
+
     override def toShort(a: UShort): Short = a.toShort
+
     override def toInt(a: UShort): Int = a.toInt
+
     override def toLong(a: UShort): Long = a.toLong
+
     override def toFloat(a: UShort): Float = a.toFloat
+
     override def toDouble(a: UShort): Double = a.toDouble
 
     override def fromByte(n: Byte): UShort = UShort(n.toShort)
+
     override def fromShort(n: Short): UShort = UShort(n)
+
     override def fromInt(n: Int): UShort = UShort(n.toShort)
+
     override def fromLong(n: Long): UShort = UShort(n.toShort)
+
     override def fromFloat(n: Float): UShort = UShort(n.toShort)
+
     override def fromDouble(n: Double): UShort = UShort(n.toShort)
 
     override def createArray(data: Array[Char]): ValueClassScalarArray[UShort, Char] = ValueClassScalarArray(data)(this)
+
     override def toUnderlying(u: UShort): Char = u.toChar
+
     override def fromUnderlying(p: Char): UShort = UShort(p)
+
+    override def plus(s1: UShort, s2: UShort): UShort = UShort(s1.toShort + s2.toShort)
+
+    override def minus(s1: UShort, s2: UShort): UShort = UShort(s1.toShort - s2.toShort)
+
+    override def times(s1: UShort, s2: UShort): UShort = UShort(s1.toShort * s2.toShort)
+
+    override def timesDouble(s1: UShort, d: Double): Double = s1.toDouble * d
+
+    override def zero: UShort = UShort(0)
+
+    override def one: UShort = UShort(1)
   }
+
 
   class UIntIsScalar extends ValueClassScalar[UInt, Int] {
     override def toByte(a: UInt): Byte = a.toByte
@@ -164,6 +210,17 @@ object Scalar {
     override def toUnderlying(u: UInt): Int = u.toInt
     override def fromUnderlying(p: Int): UInt = UInt(p)
 
+    override def plus(s1: UInt, s2: UInt): UInt = UInt(s1.toInt + s2.toInt)
+
+    override def minus(s1: UInt, s2: UInt): UInt = UInt(s1.toInt - s2.toInt)
+
+    override def times(s1: UInt, s2: UInt): UInt = UInt(s1.toInt * s2.toInt)
+
+    override def timesDouble(s1: UInt, d: Double): Double = s1.toDouble * d
+
+    override def zero: UInt = UInt(0)
+
+    override def one: UInt = UInt(1)
   }
 
 }

--- a/src/main/scala/scalismo/image/filter/DiscreteImageFilter.scala
+++ b/src/main/scala/scalismo/image/filter/DiscreteImageFilter.scala
@@ -15,7 +15,7 @@
  */
 package scalismo.image.filter
 
-import scalismo.common.interpolation.BSplineImageInterpolator
+import scalismo.common.interpolation.{ BSplineImageInterpolator, BSplineImageInterpolator2D, BSplineImageInterpolator3D }
 import scalismo.common.{ Scalar, ScalarArray }
 import scalismo.geometry._
 import scalismo.image.DiscreteScalarImage
@@ -65,7 +65,7 @@ object DiscreteImageFilter {
       vtkdistTransform.Delete()
       System.gc() // make sure it deletes the intermediate resuls
 
-      dt.resample(img.domain, 0, 0)
+      dt.resample(img.domain, BSplineImageInterpolator[D, Float](0), 0)
     }
 
     val dt1 = doDistanceTransformVTK(img)

--- a/src/main/scala/scalismo/mesh/Mesh.scala
+++ b/src/main/scala/scalismo/mesh/Mesh.scala
@@ -17,7 +17,7 @@ package scalismo.mesh
 
 import scalismo.common.{ PointId, RealSpace }
 import scalismo.geometry._
-import scalismo.image.{ DifferentiableScalarImage, ScalarImage }
+import scalismo.image.{ DifferentiableScalarImage }
 import scalismo.mesh.boundingSpheres.TriangleMesh3DSpatialIndex
 
 /**
@@ -29,7 +29,7 @@ object Mesh {
    * Returns a new continuous [[DifferentiableScalarImage]] defined on 3-dimensional [[RealSpace]] which is the distance transform of the mesh
    */
   @deprecated("Is moved to TriangleMesh3DMeshOperations.", "0.14")
-  def meshToDistanceImage(mesh: TriangleMesh[_3D]): DifferentiableScalarImage[_3D] = {
+  def meshToDistanceImage(mesh: TriangleMesh[_3D]): DifferentiableScalarImage[_3D, Float] = {
     val spIndex = TriangleMesh3DSpatialIndex.fromTriangleMesh3D(mesh)
 
     def dist(pt: Point[_3D]): Float = Math.sqrt(spIndex.getSquaredShortestDistance(pt)).toFloat
@@ -40,23 +40,6 @@ object Mesh {
       grad * (1.0 / grad.norm)
     }
     DifferentiableScalarImage(RealSpace[_3D], (pt: Point[_3D]) => dist(pt), (pt: Point[_3D]) => grad(pt))
-  }
-
-  /**
-   * Returns a new continuous binary [[ScalarImage]] defined on 3-dimensional [[RealSpace]] , where the mesh surface is used to split the image domain.
-   * Points lying on the space side pointed towards by the surface normals will have value 0. Points lying on the other side have
-   * value 1. Hence if the mesh is a closed surface, points inside the surface have value 1 and points outside 0.
-   *
-   */
-  @deprecated("Is moved to TriangleMesh3DMeshOperations.", "0.14")
-  def meshToBinaryImage(mesh: TriangleMesh[_3D]): ScalarImage[_3D] = {
-    def inside(pt: Point[_3D]): Short = {
-      val closestMeshPt = mesh.pointSet.findClosestPoint(pt)
-      val dotprod = mesh.vertexNormals(closestMeshPt.id) dot (closestMeshPt.point - pt)
-      if (dotprod > 0.0) 1 else 0
-    }
-
-    ScalarImage(RealSpace[_3D], (pt: Point[_3D]) => inside(pt))
   }
 
   /**

--- a/src/main/scala/scalismo/mesh/MeshMetrics.scala
+++ b/src/main/scala/scalismo/mesh/MeshMetrics.scala
@@ -91,7 +91,7 @@ object MeshMetrics {
 
     val numSamplesInA = samplePts.map(imgA).sum
     val numSamplesInB = samplePts.map(imgB).sum
-    val AIntersectB = (imgA + imgB) andThen ((v: Float) => if (v > 1 + 1e-5) 1f else 0f)
+    val AIntersectB = (imgA + imgB) andThen ((v: Short) => if (v > 1) 1f else 0f)
 
     val numSamplesInAIB = samplePts.map(AIntersectB).sum
     2 * numSamplesInAIB / (numSamplesInA + numSamplesInB)

--- a/src/main/scala/scalismo/mesh/MeshOperations.scala
+++ b/src/main/scala/scalismo/mesh/MeshOperations.scala
@@ -81,7 +81,7 @@ class TriangleMesh3DOperations(private val mesh: TriangleMesh3D) {
   /**
    * Returns a new continuous [[DifferentiableScalarImage]] defined on 3-dimensional [[RealSpace]] which is the distance transform of the mesh
    */
-  def toDistanceImage: DifferentiableScalarImage[_3D] = {
+  def toDistanceImage: DifferentiableScalarImage[_3D, Float] = {
     def dist(pt: Point[_3D]): Float = Math.sqrt(shortestDistanceToSurfaceSquared(pt)).toFloat
 
     def grad(pt: Point[_3D]) = {
@@ -99,7 +99,7 @@ class TriangleMesh3DOperations(private val mesh: TriangleMesh3D) {
    * value 1. Hence if the mesh is a closed surface, points inside the surface have value 1 and points outside 0.
    *
    */
-  def toBinaryImage: ScalarImage[_3D] = {
+  def toBinaryImage: ScalarImage[_3D, Short] = {
 
     val meshOps = mesh.operations
 

--- a/src/main/scala/scalismo/registration/MeanHuberLossMetric.scala
+++ b/src/main/scala/scalismo/registration/MeanHuberLossMetric.scala
@@ -16,6 +16,7 @@
 
 package scalismo.registration
 
+import scalismo.common.Scalar
 import scalismo.geometry.NDSpace
 import scalismo.image.{ DifferentiableScalarImage, ScalarImage }
 import scalismo.numerics._
@@ -27,22 +28,26 @@ import scalismo.numerics._
  * @see SumOfPointwiseLossMetric.
  *
  */
-case class MeanHuberLossMetric[D: NDSpace](fixedImage: ScalarImage[D],
-  movingImage: DifferentiableScalarImage[D],
+case class MeanHuberLossMetric[D: NDSpace, A: Scalar](
+  fixedImage: ScalarImage[D, A],
+  movingImage: DifferentiableScalarImage[D, A],
   transformationSpace: TransformationSpace[D],
   sampler: Sampler[D],
   delta: Double = 1.345)
     extends MeanPointwiseLossMetric(fixedImage, movingImage, transformationSpace, sampler) {
 
-  override protected def lossFunction(v: Float): Float = {
-    if (v < delta)
-      (v * v / 2f)
+  val scalar = Scalar[A]
+  override protected def lossFunction(v: A): Double = {
+    val vAsDouble = scalar.toDouble(v)
+    if (vAsDouble < delta)
+      (vAsDouble * vAsDouble / 2f)
     else
-      (delta * (Math.abs(v) - delta / 2)).toFloat
+      (delta * (Math.abs(vAsDouble) - delta / 2)).toFloat
   }
 
-  override protected def lossFunctionDerivative(v: Float): Float = {
-    if (v < delta) v else (delta * Math.signum(v)).toFloat
+  override protected def lossFunctionDerivative(v: A): Double = {
+    val vAsDouble = scalar.toDouble(v)
+    if (vAsDouble < delta) vAsDouble else (delta * Math.signum(vAsDouble)).toFloat
   }
 
 }

--- a/src/main/scala/scalismo/registration/MeanPointwiseLossMetric.scala
+++ b/src/main/scala/scalismo/registration/MeanPointwiseLossMetric.scala
@@ -17,7 +17,7 @@
 package scalismo.registration
 
 import breeze.linalg.DenseVector
-import scalismo.common.Domain
+import scalismo.common.{ Domain, Scalar }
 import scalismo.geometry.{ NDSpace, Point }
 import scalismo.image.{ DifferentiableScalarImage, ScalarImage }
 import scalismo.numerics._
@@ -29,15 +29,16 @@ import scalismo.registration.RegistrationMetric.ValueAndDerivative
  * the sampler.
  */
 
-abstract class MeanPointwiseLossMetric[D: NDSpace](fixedImage: ScalarImage[D],
-    movingImage: DifferentiableScalarImage[D],
+abstract class MeanPointwiseLossMetric[D: NDSpace, A: Scalar](
+    fixedImage: ScalarImage[D, A],
+    movingImage: DifferentiableScalarImage[D, A],
     transformationSpace: TransformationSpace[D],
-    sampler: Sampler[D]) extends ImageMetric[D] {
+    sampler: Sampler[D]) extends ImageMetric[D, A] {
 
   override val ndSpace: NDSpace[D] = implicitly[NDSpace[D]]
 
-  protected def lossFunction(v: Float): Float
-  protected def lossFunctionDerivative(v: Float): Float
+  protected def lossFunction(v: A): Double
+  protected def lossFunctionDerivative(v: A): Double
 
   def value(parameters: DenseVector[Double]): Double = {
     computeValue(parameters, sampler)
@@ -76,7 +77,7 @@ abstract class MeanPointwiseLossMetric[D: NDSpace](fixedImage: ScalarImage[D],
 
     // we compute the mean using a monte carlo integration
     val samples = sampler.sample()
-    samples.par.map { case (pt, _) => metricValue(pt).getOrElse(0f) }.sum / samples.size
+    samples.par.map { case (pt, _) => metricValue(pt).getOrElse(0.0) }.sum / samples.size
   }
 
   private def computeDerivative(parameters: DenseVector[Double],

--- a/src/main/scala/scalismo/registration/MeanSquaresMetric.scala
+++ b/src/main/scala/scalismo/registration/MeanSquaresMetric.scala
@@ -16,6 +16,7 @@
 
 package scalismo.registration
 
+import scalismo.common.Scalar
 import scalismo.geometry.NDSpace
 import scalismo.image.{ DifferentiableScalarImage, ScalarImage }
 import scalismo.numerics.Sampler
@@ -24,20 +25,23 @@ import scalismo.numerics.Sampler
  * The mean squares image to image metric.
  * It is implemented as the squared loss function in terms of the pointwise pixel differences.
  */
-case class MeanSquaresMetric[D: NDSpace](fixedImage: ScalarImage[D],
-  movingImage: DifferentiableScalarImage[D],
+case class MeanSquaresMetric[D: NDSpace, A: Scalar](
+  fixedImage: ScalarImage[D, A],
+  movingImage: DifferentiableScalarImage[D, A],
   transformationSpace: TransformationSpace[D],
   sampler: Sampler[D])
-    extends MeanPointwiseLossMetric[D](fixedImage, movingImage, transformationSpace, sampler) {
+    extends MeanPointwiseLossMetric[D, A](fixedImage, movingImage, transformationSpace, sampler) {
+
+  private val scalar = Scalar[A]
 
   override val ndSpace = implicitly[NDSpace[D]]
 
-  override protected def lossFunction(v: Float): Float = {
-    v * v
+  override protected def lossFunction(v: A): Double = {
+    scalar.toDouble(v) * scalar.toDouble(v)
   }
 
-  override protected def lossFunctionDerivative(v: Float): Float = {
-    2 * v
+  override protected def lossFunctionDerivative(v: A): Double = {
+    2.0 * scalar.toDouble(v)
   }
 
 }

--- a/src/main/scala/scalismo/registration/RegistrationMetric.scala
+++ b/src/main/scala/scalismo/registration/RegistrationMetric.scala
@@ -59,11 +59,11 @@ object RegistrationMetric {
 /**
  * A registration metric for image to image registration.
  */
-trait ImageMetric[D] extends RegistrationMetric[D] {
+trait ImageMetric[D, A] extends RegistrationMetric[D] {
 
-  def fixedImage: ScalarImage[D]
+  def fixedImage: ScalarImage[D, A]
 
-  def movingImage: DifferentiableScalarImage[D]
+  def movingImage: DifferentiableScalarImage[D, A]
 
 }
 

--- a/src/test/scala/scalismo/common/LinearInterpolatorTest.scala
+++ b/src/test/scala/scalismo/common/LinearInterpolatorTest.scala
@@ -81,7 +81,7 @@ class LinearInterpolatorTest extends ScalismoTestSuite {
       }
 
       try {
-        interpolatedImg.sample[Double](fineDomain, 0)
+        interpolatedImg.sample(fineDomain, 0)
       } catch {
         case ex: Exception => fail("Should not throw Exception", ex)
       }

--- a/src/test/scala/scalismo/image/ResampleTests.scala
+++ b/src/test/scala/scalismo/image/ResampleTests.scala
@@ -34,7 +34,7 @@ class ResampleTests extends ScalismoTestSuite {
     val continuousImage = discreteImage.interpolate(BSplineImageInterpolator2D[Short](1))
 
     it("yields the original discrete image") {
-      val resampledImage = continuousImage.sample[Short](discreteImage.domain, 0)
+      val resampledImage = continuousImage.sample(discreteImage.domain, 0)
       discreteImage.values.size should equal(resampledImage.values.size)
       for (i <- 0 until discreteImage.values.size) {
         discreteImage(PointId(i)) should be(resampledImage(PointId(i)))
@@ -48,7 +48,7 @@ class ResampleTests extends ScalismoTestSuite {
     val continuousImage = discreteImage.interpolate(BSplineImageInterpolator3D[Short](0))
 
     it("yields the original discrete image") {
-      val resampledImage = continuousImage.sample[Short](discreteImage.domain, 0)
+      val resampledImage = continuousImage.sample(discreteImage.domain, 0)
       for (i <- 0 until discreteImage.values.size by 100) {
         discreteImage(PointId(i)) should be(resampledImage(PointId(i)))
       }

--- a/src/test/scala/scalismo/numerics/IntegrationTest.scala
+++ b/src/test/scala/scalismo/numerics/IntegrationTest.scala
@@ -40,7 +40,7 @@ class IntegrationTest extends ScalismoTestSuite {
       val integrator = Integrator[_1D](GridSampler(grid))
 
       val res = integrator.integrateScalar(img)
-      res should be((1.0 / 3.0).toFloat +- 0.01)
+      res should be((1.0 / 3.0) +- 0.01)
     }
 
     it("Correctly integrates sin(x) on interval [-Pi, Pi]") {

--- a/src/test/scala/scalismo/registration/KernelTransformationTests.scala
+++ b/src/test/scala/scalismo/registration/KernelTransformationTests.scala
@@ -125,7 +125,7 @@ class KernelTransformationTests extends ScalismoTestSuite {
         val phiImg = DifferentiableScalarImage(domain, (x: Point[_1D]) => phi_i(x)(0) * phi_i(x)(0) * p(x), (pt: Point[_1D]) => EuclideanVector(0.0))
 
         val v = integrator.integrateScalar(phiImg)
-        v should be(1f +- 0.1)
+        v should be(1.0 +- 0.1)
       }
     }
 

--- a/src/test/scala/scalismo/registration/MetricTests.scala
+++ b/src/test/scala/scalismo/registration/MetricTests.scala
@@ -55,7 +55,7 @@ class MetricTests extends ScalismoTestSuite {
 
     it("has the global minimum where the images are similar") {
 
-      val metric = MutualInformationMetric[_2D](fixedImageCont, fixedImage.domain, fixedImageCont, translationSpace, sampler)
+      val metric = MutualInformationMetric(fixedImageCont, fixedImage.domain, fixedImageCont, translationSpace, sampler)
       val zeroVec = DenseVector.zeros[Double](translationSpace.parametersDimensionality)
 
       for (_ <- 0 until 10) {
@@ -66,7 +66,7 @@ class MetricTests extends ScalismoTestSuite {
 
     it("goes to a lower value when following the (negative) gradient") {
 
-      val metric = MutualInformationMetric[_2D](fixedImageCont, fixedImage.domain, fixedImageCont, translationSpace, sampler)
+      val metric = MutualInformationMetric(fixedImageCont, fixedImage.domain, fixedImageCont, translationSpace, sampler)
       for (_ <- 0 until 10) {
         val params = DenseVector.rand(translationSpace.parametersDimensionality, rng.breezeRandBasis.gaussian)
 
@@ -82,7 +82,7 @@ class MetricTests extends ScalismoTestSuite {
       val trueParams = DenseVector.ones[Double](translationSpace.parametersDimensionality)
       val movingImage = fixedImageCont.compose(translationSpace.transformForParameters(-trueParams))
 
-      val metric = MutualInformationMetric[_2D](fixedImageCont, fixedImage.domain, movingImage, translationSpace, sampler)
+      val metric = MutualInformationMetric(fixedImageCont, fixedImage.domain, movingImage, translationSpace, sampler)
 
       val initialParameters = DenseVector.zeros[Double](translationSpace.parametersDimensionality)
       val regIt = Registration(metric, L2Regularizer(translationSpace), 0.0, LBFGSOptimizer(20)).iterator(initialParameters)
@@ -102,7 +102,7 @@ class MetricTests extends ScalismoTestSuite {
 
     it("has the global minimum where the images are similar") {
 
-      val metric = MeanHuberLossMetric[_2D](fixedImageCont, fixedImageCont, translationSpace, sampler)
+      val metric = MeanHuberLossMetric(fixedImageCont, fixedImageCont, translationSpace, sampler)
       val zeroVec = DenseVector.zeros[Double](translationSpace.parametersDimensionality)
 
       for (_ <- 0 until 10) {
@@ -113,7 +113,7 @@ class MetricTests extends ScalismoTestSuite {
 
     it("goes to a lower value when following the (negative) gradient") {
 
-      val metric = MeanHuberLossMetric[_2D](fixedImageCont, fixedImageCont, translationSpace, sampler)
+      val metric = MeanHuberLossMetric(fixedImageCont, fixedImageCont, translationSpace, sampler)
       for (_ <- 0 until 10) {
         val params = DenseVector.rand(translationSpace.parametersDimensionality, rng.breezeRandBasis.gaussian)
 
@@ -129,7 +129,7 @@ class MetricTests extends ScalismoTestSuite {
       val trueParams = DenseVector.ones[Double](translationSpace.parametersDimensionality) * 5.0
       val movingImage = fixedImageCont.compose(translationSpace.transformForParameters(-trueParams))
 
-      val metric = MeanHuberLossMetric[_2D](fixedImageCont, movingImage, translationSpace, sampler)
+      val metric = MeanHuberLossMetric(fixedImageCont, movingImage, translationSpace, sampler)
 
       val initialParameters = DenseVector.zeros[Double](translationSpace.parametersDimensionality)
       val regIt = Registration(metric, L2Regularizer(translationSpace), 0.0, LBFGSOptimizer(20)).iterator(initialParameters)


### PR DESCRIPTION
So far scalar images were fixed to be of value type float. This
restriction complicates the code and is unnecessary. This commit changes
it to be of any arbitrary scalar type.