### PR TITLE
Changed mesh decimation method from decimatePro to Quadric-edge-collapse

### DIFF
--- a/src/main/scala/scalismo/mesh/MeshOperations.scala
+++ b/src/main/scala/scalismo/mesh/MeshOperations.scala
@@ -189,15 +189,15 @@ class TriangleMesh3DOperations(private val mesh: TriangleMesh3D) {
    */
   def decimate(targetedNumberOfVertices: Int): TriangleMesh[_3D] = {
     val refVtk = MeshConversion.meshToVtkPolyData(mesh)
-    val decimatePro = new vtk.vtkDecimatePro()
+    val decimate = new vtk.vtkQuadricDecimation()
 
     val reductionRate = 1.0 - (targetedNumberOfVertices / mesh.pointSet.numberOfPoints.toDouble)
 
-    decimatePro.SetTargetReduction(reductionRate)
+    decimate.SetTargetReduction(reductionRate)
 
-    decimatePro.SetInputData(refVtk)
-    decimatePro.Update()
-    val decimatedRefVTK = decimatePro.GetOutput()
+    decimate.SetInputData(refVtk)
+    decimate.Update()
+    val decimatedRefVTK = decimate.GetOutput()
     MeshConversion.vtkPolyDataToTriangleMesh(decimatedRefVTK).get
   }
 


### PR DESCRIPTION
Updated mesh decimation method following the discussion in #276. 

Changed mesh decimation method from decimatePro to Quadric-edge-collapse. This decimation technique provides a better triangulation in the decimated meshes and has a smaller avg distance between the original mesh and the decimated mesh.