### PR TITLE
Pivoted Cholesky Fix for Issue #284

### DIFF
--- a/src/main/scala/scalismo/numerics/PivotedCholesky.scala
+++ b/src/main/scala/scalismo/numerics/PivotedCholesky.scala
@@ -125,7 +125,6 @@ object PivotedCholesky {
         c += 1
       }
 
-      tr = d(p(k))
 
       def sumChunk(ids: IndexedSeq[Int]): Double = {
 
@@ -146,7 +145,9 @@ object PivotedCholesky {
         sumChunk(pointChunk)
       }
 
-      tr = tr + chunksum.sum
+      d(p(k)) = d(p(k)) - (S(p(k)) * S(p(k)))
+
+      tr = d(p(k)) + chunksum.sum
 
       L.addCol(DenseVector(S.toArray))
       k += 1

--- a/src/main/scala/scalismo/numerics/PivotedCholesky.scala
+++ b/src/main/scala/scalismo/numerics/PivotedCholesky.scala
@@ -125,7 +125,6 @@ object PivotedCholesky {
         c += 1
       }
 
-
       def sumChunk(ids: IndexedSeq[Int]): Double = {
 
         var s = 0.0

--- a/src/test/scala/scalismo/statisticalmodel/StatisticalModelTests.scala
+++ b/src/test/scala/scalismo/statisticalmodel/StatisticalModelTests.scala
@@ -24,7 +24,7 @@ import scalismo.geometry._
 import scalismo.io.StatismoIO
 import scalismo.mesh.MeshMetrics
 import scalismo.numerics.PivotedCholesky.NumberOfEigenfunctions
-import scalismo.registration.{RigidTransformation, RigidTransformationSpace}
+import scalismo.registration.{ RigidTransformation, RigidTransformationSpace }
 import scalismo.statisticalmodel.dataset.DataCollection
 import scalismo.utils.Random
 

--- a/src/test/scala/scalismo/statisticalmodel/StatisticalModelTests.scala
+++ b/src/test/scala/scalismo/statisticalmodel/StatisticalModelTests.scala
@@ -23,7 +23,9 @@ import scalismo.ScalismoTestSuite
 import scalismo.geometry._
 import scalismo.io.StatismoIO
 import scalismo.mesh.MeshMetrics
-import scalismo.registration.{ RigidTransformation, RigidTransformationSpace }
+import scalismo.numerics.PivotedCholesky.NumberOfEigenfunctions
+import scalismo.registration.{RigidTransformation, RigidTransformationSpace}
+import scalismo.statisticalmodel.dataset.DataCollection
 import scalismo.utils.Random
 
 import scala.language.implicitConversions
@@ -49,6 +51,25 @@ class StatisticalModelTests extends ScalismoTestSuite {
               (pt1.toVector - pt2.toVector).norm should be(0.0 +- (0.1))
           }
       }
+    }
+
+    it("can be calculated with a small amount of samples using PCA") {
+
+      val path = getClass.getResource("/facemodel.h5").getPath
+      val model = StatismoIO.readStatismoMeshModel(new File(path)).get
+
+      val ref = model.referenceMesh
+
+      val data = (1 to 3).map(f => model.sample())
+
+      val dc = DataCollection.fromMeshSequence(referenceMesh = ref, registeredMeshes = data)._1.get
+      val dcGpa = DataCollection.gpa(dc)
+
+      val pca1 = StatisticalMeshModel.createUsingPCA(dcGpa, NumberOfEigenfunctions.apply(data.length - 1))
+
+      val pca2 = StatisticalMeshModel.createUsingPCA(dcGpa) // NotConvergedException
+
+      assert(pca1.isSuccess && pca2.isSuccess)
     }
 
     it("can be transformed forth and back and yield the same deformations") {


### PR DESCRIPTION
Fixes #284 

This pull request adds a fix for the computation of the trace and a consistency test that computes a PCA from a small dataset.