### PR TITLE
Parameter D in Eigenbasis Calculation from Pivoted Cholesky Output

### DIFF
--- a/src/main/scala/scalismo/kernels/Kernel.scala
+++ b/src/main/scala/scalismo/kernels/Kernel.scala
@@ -273,7 +273,7 @@ object Kernel {
 
     // we compute the eigenvectors only approximately, to a tolerance of 1e-5. As the nystrom approximation is
     // anyway not exact, this should be sufficient for all practical cases.
-    val (uMat, lambdaMat) = PivotedCholesky.computeApproximateEig(k, ptsForNystrom, 1.0, RelativeTolerance(1e-5))
+    val (uMat, lambdaMat) = PivotedCholesky.computeApproximateEig(k, ptsForNystrom, RelativeTolerance(1e-5))
 
     val lambda = lambdaMat.map(lmbda => (lmbda / effectiveNumberOfPointsSampled.toDouble))
     val numParams = (for (i <- (0 until lambda.size) if lambda(i) >= 1e-8) yield 1).size

--- a/src/main/scala/scalismo/statisticalmodel/DiscreteGaussianProcess.scala
+++ b/src/main/scala/scalismo/statisticalmodel/DiscreteGaussianProcess.scala
@@ -122,7 +122,6 @@ class DiscreteGaussianProcess[D: NDSpace, +DDomain <: DiscreteDomain[D], Value] 
 
     val (basis, scale) = PivotedCholesky.computeApproximateEig(
       cov.asBreezeMatrix,
-      D = 1.0,
       RelativeTolerance(0.0)
     )
 

--- a/src/main/scala/scalismo/statisticalmodel/DiscreteLowRankGaussianProcess.scala
+++ b/src/main/scala/scalismo/statisticalmodel/DiscreteLowRankGaussianProcess.scala
@@ -450,11 +450,11 @@ object DiscreteLowRankGaussianProcess {
     // Whether it is more efficient to compute the PCA using the gram matrix or the covariance matrix, depends on
     // whether we have more examples than variables.
     val (basisMat, varianceVector) = if (X.rows > X.cols) {
-      val (u, d2) = PivotedCholesky.computeApproximateEig(X.t * X * (1.0 / (n - 1)), 1.0, stoppingCriterion)
+      val (u, d2) = PivotedCholesky.computeApproximateEig(X.t * X * (1.0 / (n - 1)), stoppingCriterion)
       (u, d2)
     } else {
 
-      val (v, d2) = PivotedCholesky.computeApproximateEig(X * X.t * (1.0 / (n - 1)), 1.0, stoppingCriterion)
+      val (v, d2) = PivotedCholesky.computeApproximateEig(X * X.t * (1.0 / (n - 1)), stoppingCriterion)
 
       val D = d2.map(v => Math.sqrt(v))
       val Dinv = D.map(d => if (d > 1e-6) 1.0 / d else 0.0)

--- a/src/main/scala/scalismo/statisticalmodel/LowRankGaussianProcess.scala
+++ b/src/main/scala/scalismo/statisticalmodel/LowRankGaussianProcess.scala
@@ -266,7 +266,6 @@ object LowRankGaussianProcess {
     val (basis, scale) = PivotedCholesky.computeApproximateEig(
       kernel = gp.cov,
       xs = domain.points.toIndexedSeq,
-      D = 1.0,
       stoppingCriterion = RelativeTolerance(relativeTolerance)
     )
 

--- a/src/test/scala/scalismo/numerics/PivotedCholeskyTest.scala
+++ b/src/test/scala/scalismo/numerics/PivotedCholeskyTest.scala
@@ -35,7 +35,7 @@ class PivotedCholeskyTest extends ScalismoTestSuite {
       val k = GaussianKernel[_1D](1.0)
       val matrixValuedK = DiagonalKernel[_1D](k, 1)
       val m = Kernel.computeKernelMatrix[_1D](pts, matrixValuedK)
-      val eigCholesky = PivotedCholesky.computeApproximateEig(matrixValuedK, pts, 1.0, PivotedCholesky.RelativeTolerance(1e-15))
+      val eigCholesky = PivotedCholesky.computeApproximateEig(matrixValuedK, pts, PivotedCholesky.RelativeTolerance(1e-15))
       val (u, d) = eigCholesky
       val D = (u * breeze.linalg.diag(d) * u.t) - m
       Math.sqrt(breeze.linalg.trace(D * D.t)) should be <= 1e-5
@@ -49,7 +49,7 @@ class PivotedCholeskyTest extends ScalismoTestSuite {
       val k = GaussianKernel[_3D](1.0)
       val matrixValuedK = DiagonalKernel[_3D](k, 3)
       val m = Kernel.computeKernelMatrix[_3D](pts, matrixValuedK)
-      val eigCholesky = PivotedCholesky.computeApproximateEig(matrixValuedK, pts, 1.0, PivotedCholesky.RelativeTolerance(1e-15))
+      val eigCholesky = PivotedCholesky.computeApproximateEig(matrixValuedK, pts, PivotedCholesky.RelativeTolerance(1e-15))
       val (u, d) = eigCholesky
       val D = (u * breeze.linalg.diag(d) * u.t) - m
       Math.sqrt(breeze.linalg.trace(D * D.t)) should be <= 1e-5


### PR DESCRIPTION
Fixes #164 

The mass matrix parameter D is in our situation a scalar, which is set to 1.0. Since there is no occasion to be found where we would have to change this, I would also propose to remove the exposure of this parameter. 

In a future case, in which the current calculation needs to be adapted with a different D, I would propose to define it as a separate function.