### PR TITLE
fixes #291 - introduced URLDecoder to decode codes for blank spaces in file paths

### DIFF
--- a/src/test/scala/scalismo/image/DiscreteImageDomainTests.scala
+++ b/src/test/scala/scalismo/image/DiscreteImageDomainTests.scala
@@ -17,6 +17,7 @@
 package scalismo.image
 
 import java.io.File
+import java.net.URLDecoder
 
 import scalismo.ScalismoTestSuite
 import scalismo.common.BoxDomain
@@ -118,7 +119,7 @@ class DiscreteImageDomainTests extends ScalismoTestSuite {
 
     object Fixture {
       val pathH5 = getClass.getResource("/3dimage.nii").getPath
-      val img = ImageIO.read3DScalarImage[Short](new File(pathH5)).get
+      val img = ImageIO.read3DScalarImage[Short](new File(URLDecoder.decode(pathH5, "UTF-8"))).get
     }
     it("correctly maps a coordinate index to a linearIndex") {
       val domain = DiscreteImageDomain[_3D]((0.0, 0.0, 0.0), (1.0, 2.0, 3.0), (42, 49, 65))

--- a/src/test/scala/scalismo/image/InterpolationTest.scala
+++ b/src/test/scala/scalismo/image/InterpolationTest.scala
@@ -16,6 +16,7 @@
 package scalismo.image
 
 import java.io.File
+import java.net.URLDecoder
 
 import org.scalatest.PrivateMethodTester
 import scalismo.ScalismoTestSuite
@@ -123,7 +124,7 @@ class InterpolationTest extends ScalismoTestSuite with PrivateMethodTester {
 
       it("Interpolates the values correctly for a test dataset") {
         val testImgUrl = getClass.getResource("/lena256.vtk").getPath
-        val discreteFixedImage = ImageIO.read2DScalarImage[Short](new File(testImgUrl)).get
+        val discreteFixedImage = ImageIO.read2DScalarImage[Short](new File(URLDecoder.decode(testImgUrl, "UTF-8"))).get
         val interpolatedImage = discreteFixedImage.interpolate(BSplineImageInterpolator2D[Short](2))
 
         for ((p, i) <- discreteFixedImage.domain.points.zipWithIndex) {
@@ -201,7 +202,7 @@ class InterpolationTest extends ScalismoTestSuite with PrivateMethodTester {
 
       it("Interpolates a real dataset correctly") {
         val path = getClass.getResource("/3dimage.nii").getPath
-        val discreteImage = ImageIO.read3DScalarImage[Short](new File(path)).get
+        val discreteImage = ImageIO.read3DScalarImage[Short](new File(URLDecoder.decode(path, "UTF-8"))).get
         val continuousImage = discreteImage.interpolate(BSplineImageInterpolator3D[Short](1))
 
         for ((p, i) <- discreteImage.domain.points.zipWithIndex.filter(p => p._2 % 100 == 0))

--- a/src/test/scala/scalismo/image/ResampleTests.scala
+++ b/src/test/scala/scalismo/image/ResampleTests.scala
@@ -16,6 +16,7 @@
 package scalismo.image
 
 import java.io.File
+import java.net.URLDecoder
 
 import scalismo.ScalismoTestSuite
 import scalismo.common.PointId
@@ -27,7 +28,7 @@ class ResampleTests extends ScalismoTestSuite {
   describe("Resampling a 2D image") {
 
     val testImgUrl = getClass.getResource("/lena.vtk").getPath
-    val discreteImage = ImageIO.read2DScalarImage[Short](new File(testImgUrl)).get
+    val discreteImage = ImageIO.read2DScalarImage[Short](new File(URLDecoder.decode(testImgUrl, "UTF-8"))).get
 
     // here we do 1st order interpolation. 3rd order would not work, as it does not necessarily preserve the
     // pixel values at the strong edges - and we thus could not formulate a reasonable test
@@ -44,7 +45,7 @@ class ResampleTests extends ScalismoTestSuite {
 
   describe("Resampling a 3D image") {
     val path = getClass.getResource("/3dimage.nii").getPath
-    val discreteImage = ImageIO.read3DScalarImage[Short](new File(path)).get
+    val discreteImage = ImageIO.read3DScalarImage[Short](new File(URLDecoder.decode(path, "UTF-8"))).get
     val continuousImage = discreteImage.interpolate(BSplineImageInterpolator3D[Short](0))
 
     it("yields the original discrete image") {

--- a/src/test/scala/scalismo/io/ActiveShapeModelIOTests.scala
+++ b/src/test/scala/scalismo/io/ActiveShapeModelIOTests.scala
@@ -16,6 +16,7 @@
 package scalismo.io
 
 import java.io.File
+import java.net.URLDecoder
 
 import breeze.linalg.{ DenseMatrix, DenseVector }
 import scalismo.ScalismoTestSuite
@@ -36,7 +37,7 @@ class ActiveShapeModelIOTests extends ScalismoTestSuite {
   }
 
   private def createAsm(): ActiveShapeModel = {
-    val statismoFile = new File(getClass.getResource("/facemodel.h5").getPath)
+    val statismoFile = new File(URLDecoder.decode(getClass.getResource("/facemodel.h5").getPath, "UTF-8"))
     val shapeModel = StatismoIO.readStatismoMeshModel(statismoFile).get
 
     val (sprofilePoints, _) = new FixedPointsUniformMeshSampler3D(shapeModel.referenceMesh, 100).sample.unzip

--- a/src/test/scala/scalismo/io/ImageIOTests.scala
+++ b/src/test/scala/scalismo/io/ImageIOTests.scala
@@ -16,6 +16,7 @@
 package scalismo.io
 
 import java.io.File
+import java.net.URLDecoder
 
 import breeze.linalg.{ DenseMatrix, DenseVector }
 import niftijio.NiftiVolume
@@ -67,7 +68,7 @@ class ImageIOTests extends ScalismoTestSuite {
 
     def testReadWrite[T: Scalar: TypeTag: ClassTag]() = {
       val path = getClass.getResource("/images/vtk").getPath
-      val source = new File(s"$path/${dim}d_${typeAsString[T]()}.vtk")
+      val source = new File(s"${URLDecoder.decode(path, "UTF-8")}/${dim}d_${typeAsString[T]()}.vtk")
 
       // read
       val read = readImage[T](source)
@@ -133,7 +134,7 @@ class ImageIOTests extends ScalismoTestSuite {
 
     it("can be converted to vtk and back and yields the same image") {
       val path = getClass.getResource("/lena.vtk").getPath
-      val lena = ImageIO.read2DScalarImage[Short](new File(path)).get
+      val lena = ImageIO.read2DScalarImage[Short](new File(URLDecoder.decode(path, "UTF-8"))).get
       val tmpImgFile = File.createTempFile("image2D", ".vtk")
       tmpImgFile.deleteOnExit()
       ImageIO.writeVTK(lena, tmpImgFile) match {
@@ -169,7 +170,7 @@ class ImageIOTests extends ScalismoTestSuite {
 
     it("can be converted to vtk and back and yields the same image") {
       val path = getClass.getResource("/3dimage.nii").getPath
-      val discreteImage = ImageIO.read3DScalarImage[Short](new File(path)).get
+      val discreteImage = ImageIO.read3DScalarImage[Short](new File(URLDecoder.decode(path, "UTF-8"))).get
       val f = File.createTempFile("dummy", ".vtk")
       f.deleteOnExit()
       ImageIO.writeVTK(discreteImage, f)
@@ -182,8 +183,8 @@ class ImageIOTests extends ScalismoTestSuite {
 
       it("returns the same data as the niftijio reader when using FastReadOnlyNiftiVolume") {
         val filename = getClass.getResource("/3dimage.nii").getPath
-        val o = NiftiVolume.read(filename)
-        val n = FastReadOnlyNiftiVolume.read(filename).get
+        val o = NiftiVolume.read(URLDecoder.decode(filename, "UTF-8"))
+        val n = FastReadOnlyNiftiVolume.read(URLDecoder.decode(filename, "UTF-8")).get
 
         for (i <- 0 until 8) {
           n.header.dim(i) should equal(o.header.dim(i))
@@ -221,7 +222,7 @@ class ImageIOTests extends ScalismoTestSuite {
 
       it("can be written and read again") {
         val pathH5 = getClass.getResource("/3dimage.nii").getPath
-        val origImg = ImageIO.read3DScalarImage[Short](new File(pathH5)).get
+        val origImg = ImageIO.read3DScalarImage[Short](new File(URLDecoder.decode(pathH5, "UTF-8"))).get
         val tmpfile = File.createTempFile("dummy", ".nii")
         tmpfile.deleteOnExit()
 

--- a/src/test/scala/scalismo/io/LandmarkIOTests.scala
+++ b/src/test/scala/scalismo/io/LandmarkIOTests.scala
@@ -16,6 +16,7 @@
 package scalismo.io
 
 import java.io.{ ByteArrayOutputStream, File, InputStream }
+import java.net.URLDecoder
 
 import breeze.linalg.DenseVector
 import scalismo.ScalismoTestSuite
@@ -35,7 +36,6 @@ class LandmarkIOTests extends ScalismoTestSuite {
   describe("Spray LandmarkIO") {
 
     val csvName = "/landmarks.csv"
-    val csvUrl = getClass.getResource(csvName)
     def csvStream() = getClass.getResourceAsStream(csvName)
 
     val jsonName = "/landmarks.json"
@@ -46,7 +46,8 @@ class LandmarkIOTests extends ScalismoTestSuite {
      */
 
     it("can read 3D landmarks in CSV format from a file") {
-      val landmarksTry = LandmarkIO.readLandmarksCsv[_3D](new File(csvUrl.getPath))
+      val csvPath = getClass.getResource(csvName).getPath
+      val landmarksTry = LandmarkIO.readLandmarksCsv[_3D](new File(URLDecoder.decode(csvPath, "UTF-8")))
       landmarksTry should be a 'Success
 
       val landmarks = landmarksTry.get
@@ -64,7 +65,8 @@ class LandmarkIOTests extends ScalismoTestSuite {
     }
 
     it("can read 2D landmarks in CSV format from a file") {
-      val landmarksTry = LandmarkIO.readLandmarksCsv[_2D](new File(csvUrl.getPath))
+      val csvPath = getClass.getResource(csvName).getPath
+      val landmarksTry = LandmarkIO.readLandmarksCsv[_2D](new File(URLDecoder.decode(csvPath, "UTF-8")))
       landmarksTry should be a 'Success
 
       val landmarks = landmarksTry.get

--- a/src/test/scala/scalismo/io/MeshIOTests.scala
+++ b/src/test/scala/scalismo/io/MeshIOTests.scala
@@ -16,6 +16,7 @@
 package scalismo.io
 
 import java.io.File
+import java.net.URLDecoder
 
 import scalismo.ScalismoTestSuite
 import scalismo.common.{ Scalar, ScalarArray }
@@ -32,7 +33,7 @@ class MeshIOTests extends ScalismoTestSuite {
 
     it("yields the original mesh when reading  and writing") {
       val path = getClass.getResource("/facemesh.stl").getPath
-      val origMesh = MeshIO.readMesh(new File(path)).get
+      val origMesh = MeshIO.readMesh(new File(URLDecoder.decode(path, "UTF-8"))).get
 
       def testWriteRead(extension: String): Unit = {
         val tmpFile = File.createTempFile("mesh", ".vtk")
@@ -58,7 +59,7 @@ class MeshIOTests extends ScalismoTestSuite {
 
     it("yields the original polyline when reading  and writing a polyLine in 2D") {
       val path = getClass.getResource("/linemesh.vtk").getPath
-      val origMesh = MeshIO.readLineMesh2D(new File(path)).get
+      val origMesh = MeshIO.readLineMesh2D(new File(URLDecoder.decode(path, "UTF-8"))).get
 
       val tmpFile = File.createTempFile("mesh", ".vtk")
       val writeStatus = MeshIO.writeLineMesh(origMesh, tmpFile)
@@ -74,7 +75,7 @@ class MeshIOTests extends ScalismoTestSuite {
 
     it("yields the original mesh when reading and writing a shape only ply") {
       val path = getClass.getResource("/mean_shapeOnly.ply").getPath
-      val shape = MeshIO.readMesh(new File(path)).get
+      val shape = MeshIO.readMesh(new File(URLDecoder.decode(path, "UTF-8"))).get
       val tmpFile = File.createTempFile("mesh", ".ply")
       MeshIO.writeMesh(shape, tmpFile)
       val reRead = MeshIO.readMesh(tmpFile).get
@@ -85,7 +86,7 @@ class MeshIOTests extends ScalismoTestSuite {
 
     it("yields the original mesh when reading and writing a vertex color ply") {
       val path = getClass.getResource("/mean_vertexColor.ply").getPath
-      val shape = MeshIO.readVertexColorMesh3D(new File(path)).get
+      val shape = MeshIO.readVertexColorMesh3D(new File(URLDecoder.decode(path, "UTF-8"))).get
       val tmpFile = File.createTempFile("mesh", ".ply")
       MeshIO.writeVertexColorMesh3D(shape, tmpFile)
       val reRead = MeshIO.readVertexColorMesh3D(tmpFile).get
@@ -96,7 +97,7 @@ class MeshIOTests extends ScalismoTestSuite {
 
     it("correctly fails when reading a textured ascii ply") {
       val path = getClass.getResource("/mean_textured.ply").getPath
-      val shape = MeshIO.readMesh(new File(path))
+      val shape = MeshIO.readMesh(new File(URLDecoder.decode(path, "UTF-8")))
       assert(shape.isFailure)
     }
 
@@ -106,7 +107,7 @@ class MeshIOTests extends ScalismoTestSuite {
 
     object Fixture {
       val path: String = getClass.getResource("/facemesh.stl").getPath
-      val mesh: TriangleMesh[_3D] = MeshIO.readMesh(new File(path)).get
+      val mesh: TriangleMesh[_3D] = MeshIO.readMesh(new File(URLDecoder.decode(path, "UTF-8"))).get
       val meshData: ScalarMeshField[Int] = ScalarMeshField(mesh, ScalarArray(mesh.pointSet.pointIds.map(_.id).toArray))
     }
 

--- a/src/test/scala/scalismo/io/StatisticalModelIOTest.scala
+++ b/src/test/scala/scalismo/io/StatisticalModelIOTest.scala
@@ -16,6 +16,7 @@
 package scalismo.io
 
 import java.io.File
+import java.net.URLDecoder
 
 import scalismo.ScalismoTestSuite
 import scalismo.common.NearestNeighborInterpolator
@@ -37,7 +38,7 @@ class StatisticalModelIOTest extends ScalismoTestSuite {
     }
 
     it("can be written and read again") {
-      val statismoFile = new File(getClass.getResource("/facemodel.h5").getPath)
+      val statismoFile = new File(URLDecoder.decode(getClass.getResource("/facemodel.h5").getPath, "UTF-8"))
       val dummyFile = File.createTempFile("dummy", "h5")
       dummyFile.deleteOnExit()
 
@@ -53,7 +54,7 @@ class StatisticalModelIOTest extends ScalismoTestSuite {
     }
 
     it("can be written and read again in non-standard location") {
-      val statismoFile = new File(getClass.getResource("/facemodel.h5").getPath)
+      val statismoFile = new File(URLDecoder.decode(getClass.getResource("/facemodel.h5").getPath, "UTF-8"))
       val dummyFile = File.createTempFile("dummy", "h5")
       dummyFile.deleteOnExit()
 
@@ -71,7 +72,7 @@ class StatisticalModelIOTest extends ScalismoTestSuite {
     it("can be written in version 0.81 and read again") {
       import StatismoIO.StatismoVersion.v081
 
-      val statismoFile = new File(getClass.getResource("/facemodel.h5").getPath)
+      val statismoFile = new File(URLDecoder.decode(getClass.getResource("/facemodel.h5").getPath, "UTF-8"))
       val dummyFile = File.createTempFile("dummy", "h5")
       dummyFile.deleteOnExit()
 
@@ -88,7 +89,7 @@ class StatisticalModelIOTest extends ScalismoTestSuite {
   }
 
   it("can read a catalog") {
-    val statismoFile = new File(getClass.getResource("/facemodel.h5").getPath)
+    val statismoFile = new File(URLDecoder.decode(getClass.getResource("/facemodel.h5").getPath, "UTF-8"))
     val catalog = StatismoIO.readModelCatalog(statismoFile).get
     catalog.size should equal(1)
     val firstEntry = catalog.head

--- a/src/test/scala/scalismo/mesh/MeshBoundaryTests.scala
+++ b/src/test/scala/scalismo/mesh/MeshBoundaryTests.scala
@@ -249,8 +249,6 @@ class MeshBoundaryTests extends ScalismoTestSuite {
         val p1 = t4.ptId2
         val p2 = t4.ptId3
 
-        println(p0.id + " " + p1.id + " " + p2.id)
-
         b.pointIsOnBoundary(p0) shouldBe false
         b.pointIsOnBoundary(p1) shouldBe false
         b.pointIsOnBoundary(p2) shouldBe true

--- a/src/test/scala/scalismo/mesh/MeshDecimationTests.scala
+++ b/src/test/scala/scalismo/mesh/MeshDecimationTests.scala
@@ -1,6 +1,7 @@
 package scalismo.mesh
 
 import java.io.File
+import java.net.URLDecoder
 
 import scalismo.ScalismoTestSuite
 import scalismo.io.MeshIO
@@ -9,7 +10,7 @@ class MeshDecimationTests extends ScalismoTestSuite {
   describe("A decimated mesh") {
 
     val path = getClass.getResource("/facemesh.stl").getPath
-    val facemesh = MeshIO.readMesh(new File(path)).get
+    val facemesh = MeshIO.readMesh(new File(URLDecoder.decode(path, "UTF-8"))).get
 
     it("has a reduced number of points") {
       val reducedMesh = facemesh.operations.decimate(facemesh.pointSet.numberOfPoints / 3)

--- a/src/test/scala/scalismo/mesh/MeshMetricsTests.scala
+++ b/src/test/scala/scalismo/mesh/MeshMetricsTests.scala
@@ -16,10 +16,11 @@
 package scalismo.mesh
 
 import java.io.File
+import java.net.URLDecoder
 
 import scalismo.ScalismoTestSuite
 import scalismo.common.PointId
-import scalismo.geometry.{ Point, EuclideanVector, _3D }
+import scalismo.geometry.{ EuclideanVector, Point, _3D }
 import scalismo.io.MeshIO
 import scalismo.utils.Random
 
@@ -28,7 +29,7 @@ class MeshMetricsTests extends ScalismoTestSuite {
   implicit val rng = Random(42L)
 
   val path = getClass.getResource("/facemesh.stl").getPath
-  val mesh = MeshIO.readMesh(new File(path)).get
+  val mesh = MeshIO.readMesh(new File(URLDecoder.decode(path, "UTF-8"))).get
   val translationLength = 1.0
   val translatedMesh = mesh.transform((pt: Point[_3D]) => pt + EuclideanVector(translationLength, 0.0, 0.0))
 
@@ -73,7 +74,7 @@ class MeshMetricsTests extends ScalismoTestSuite {
 
   describe("the dice coefficient") {
     val path = getClass.getResource("/unit-sphere.stl").getPath
-    val spheremesh = MeshIO.readMesh(new File(path)).get
+    val spheremesh = MeshIO.readMesh(new File(URLDecoder.decode(path, "UTF-8"))).get
 
     it("computes the right value for a unit sphere that completely overlaps itself") {
       MeshMetrics.diceCoefficient(spheremesh, spheremesh) should be(1)

--- a/src/test/scala/scalismo/mesh/MeshTests.scala
+++ b/src/test/scala/scalismo/mesh/MeshTests.scala
@@ -16,6 +16,7 @@
 package scalismo.mesh
 
 import java.io.File
+import java.net.URLDecoder
 
 import breeze.linalg.DenseVector
 import scalismo.ScalismoTestSuite
@@ -34,7 +35,7 @@ class MeshTests extends ScalismoTestSuite {
 
   describe("a mesh") {
     val path = getClass.getResource("/facemesh.stl").getPath
-    val facemesh = MeshIO.readMesh(new File(path)).get
+    val facemesh = MeshIO.readMesh(new File(URLDecoder.decode(path, "UTF-8"))).get
 
     it("finds the right closest points for all the points that define the mesh") {
 
@@ -72,7 +73,7 @@ class MeshTests extends ScalismoTestSuite {
 
     it("computes the right binary image for the unit sphere") {
       val path = getClass.getResource("/unit-sphere.stl").getPath
-      val spheremesh = MeshIO.readMesh(new File(path)).get
+      val spheremesh = MeshIO.readMesh(new File(URLDecoder.decode(path, "UTF-8"))).get
       val binaryImg = spheremesh.operations.toBinaryImage
       binaryImg(Point(0, 0, 0)) should be(1)
       binaryImg(Point(2, 0, 0)) should be(0)

--- a/src/test/scala/scalismo/mesh/RegionQueryTest.scala
+++ b/src/test/scala/scalismo/mesh/RegionQueryTest.scala
@@ -16,17 +16,18 @@
 
 package scalismo.mesh
 import java.io.File
+import java.net.URLDecoder
 
 import scalismo.ScalismoTestSuite
 import scalismo.common.{ BoxDomain, UnstructuredPointsDomain }
 import scalismo.geometry._
-import scalismo.image.{ DiscreteImageDomain }
+import scalismo.image.DiscreteImageDomain
 import scalismo.io.MeshIO
 
 class RegionQueryTest extends ScalismoTestSuite {
 
   val path = getClass.getResource("/facemesh.stl").getPath
-  val mesh = MeshIO.readMesh(new File(path)).get
+  val mesh = MeshIO.readMesh(new File(URLDecoder.decode(path, "UTF-8"))).get
   val translationLength = 1.0
   val translatedMesh = mesh.transform((pt: Point[_3D]) => pt + EuclideanVector(translationLength, 0.0, 0.0))
 

--- a/src/test/scala/scalismo/numerics/SamplerTests.scala
+++ b/src/test/scala/scalismo/numerics/SamplerTests.scala
@@ -16,19 +16,20 @@
 package scalismo.numerics
 
 import java.io.File
+import java.net.URLDecoder
 
 import scalismo.ScalismoTestSuite
 import scalismo.geometry._
 import scalismo.io.MeshIO
 import scalismo.mesh.TriangleMesh
-import scalismo.utils.{ Random, Memoize }
+import scalismo.utils.{ Memoize, Random }
 
 class SamplerTests extends ScalismoTestSuite {
 
   implicit val random: Random = Random(42)
 
   val facepath = getClass.getResource("/facemesh.stl").getPath
-  val facemesh = MeshIO.readMesh(new File(facepath)).get
+  val facemesh = MeshIO.readMesh(new File(URLDecoder.decode(facepath, "UTF-8"))).get
 
   describe("A uniform sampler") {
     it("yields approximately uniformly spaced points") {

--- a/src/test/scala/scalismo/registration/MetricTests.scala
+++ b/src/test/scala/scalismo/registration/MetricTests.scala
@@ -16,11 +16,12 @@
 package scalismo.registration
 
 import _root_.java.io.File
+import java.net.URLDecoder
 
 import breeze.linalg.DenseVector
 import scalismo.ScalismoTestSuite
 import scalismo.common.BoxDomain
-import scalismo.common.interpolation.{ BSplineImageInterpolator2D }
+import scalismo.common.interpolation.BSplineImageInterpolator2D
 import scalismo.geometry.Point.implicits._
 import scalismo.geometry._
 import scalismo.image.{ DifferentiableScalarImage, DiscreteImageDomain }
@@ -48,7 +49,7 @@ class MetricTests extends ScalismoTestSuite {
   describe("The mutual information metric") {
     val testImgURL = getClass.getResource("/dm128.vtk").getPath
 
-    val fixedImage = ImageIO.read2DScalarImage[Float](new File(testImgURL)).get
+    val fixedImage = ImageIO.read2DScalarImage[Float](new File(URLDecoder.decode(testImgURL, "UTF-8"))).get
     val fixedImageCont = fixedImage.interpolate(BSplineImageInterpolator2D[Float](3))
     val translationSpace = TranslationSpace[_2D]
     val sampler = GridSampler(DiscreteImageDomain(fixedImage.domain.boundingBox, size = IntVector(50, 50)))
@@ -95,7 +96,7 @@ class MetricTests extends ScalismoTestSuite {
   describe("The huber loss metric") {
     val testImgURL = getClass.getResource("/dm128.vtk").getPath
 
-    val fixedImage = ImageIO.read2DScalarImage[Float](new File(testImgURL)).get
+    val fixedImage = ImageIO.read2DScalarImage[Float](new File(URLDecoder.decode(testImgURL, "UTF-8"))).get
     val fixedImageCont = fixedImage.interpolate(BSplineImageInterpolator2D[Float](3))
     val translationSpace = TranslationSpace[_2D]
     val sampler = GridSampler(DiscreteImageDomain(fixedImage.domain.boundingBox, size = IntVector(50, 50)))

--- a/src/test/scala/scalismo/registration/RegistrationTests.scala
+++ b/src/test/scala/scalismo/registration/RegistrationTests.scala
@@ -16,6 +16,7 @@
 package scalismo.registration
 
 import java.io.File
+import java.net.URLDecoder
 
 import breeze.linalg.DenseVector
 import scalismo.common.interpolation.{ BSplineImageInterpolator2D, BSplineImageInterpolator3D }
@@ -68,7 +69,7 @@ class RegistrationTests extends ScalismoTestSuite {
   describe("A 3D rigid landmark based registration") {
 
     val path = getClass.getResource("/facemesh.stl").getPath
-    val mesh = MeshIO.readMesh(new File(path)).get
+    val mesh = MeshIO.readMesh(new File(URLDecoder.decode(path, "UTF-8"))).get
 
     val parameterVector = DenseVector[Double](1.5, 1.0, 3.5, Math.PI, -Math.PI / 2.0, -Math.PI)
     val trans = RigidTransformationSpace[_3D]().transformForParameters(parameterVector)
@@ -150,7 +151,7 @@ class RegistrationTests extends ScalismoTestSuite {
     it("can transform the mesh appropriately") {
 
       val path = getClass.getResource("/facemesh.stl").getPath
-      val mesh = MeshIO.readMesh(new File(path)).get
+      val mesh = MeshIO.readMesh(new File(URLDecoder.decode(path, "UTF-8"))).get
 
       val parameterVector = DenseVector[Double](1.5, 1.0, 3.5, Math.PI, -Math.PI / 2.0, -Math.PI, 2.0)
       val trans = RigidTransformationSpace[_3D]().product(ScalingSpace[_3D]).transformForParameters(parameterVector)
@@ -175,7 +176,7 @@ class RegistrationTests extends ScalismoTestSuite {
     it("Recovers the correct parameters for a translation transform") {
       val testImgUrl = getClass.getResource("/dm128.vtk").getPath
 
-      val discreteFixedImage = ImageIO.read2DScalarImage[Float](new File(testImgUrl)).get
+      val discreteFixedImage = ImageIO.read2DScalarImage[Float](new File(URLDecoder.decode(testImgUrl, "UTF-8"))).get
       val fixedImage = discreteFixedImage.interpolate(BSplineImageInterpolator2D[Float](2))
       val transformationSpace = TranslationSpace[_2D]
       val translationParams = DenseVector[Double](-10.0, 5.0)
@@ -198,7 +199,7 @@ class RegistrationTests extends ScalismoTestSuite {
 
     it("Recovers the correct parameters for a rotation transform") {
       val testImgUrl = getClass.getResource("/dm128.vtk").getPath
-      val discreteFixedImage = ImageIO.read2DScalarImage[Float](new File(testImgUrl)).get
+      val discreteFixedImage = ImageIO.read2DScalarImage[Float](new File(URLDecoder.decode(testImgUrl, "UTF-8"))).get
       val fixedImage = discreteFixedImage.interpolate(BSplineImageInterpolator2D[Float](3))
       val domain = discreteFixedImage.domain
       val center = ((domain.boundingBox.oppositeCorner - domain.origin) * 0.5).toPoint
@@ -223,7 +224,7 @@ class RegistrationTests extends ScalismoTestSuite {
     it("Recovers the correct parameters for a gp transform") {
       val testImgUrl = getClass.getResource("/dm128.vtk").getPath
 
-      val discreteFixedImage = ImageIO.read2DScalarImage[Float](new File(testImgUrl)).get
+      val discreteFixedImage = ImageIO.read2DScalarImage[Float](new File(URLDecoder.decode(testImgUrl, "UTF-8"))).get
       val fixedImage = discreteFixedImage.interpolate(BSplineImageInterpolator2D[Float](3))
 
       val domain = discreteFixedImage.domain
@@ -257,7 +258,7 @@ class RegistrationTests extends ScalismoTestSuite {
     it("Recovers the correct parameters for a gp transform with a nn interpolated gp") {
       val testImgUrl = getClass.getResource("/dm128.vtk").getPath
 
-      val discreteFixedImage = ImageIO.read2DScalarImage[Float](new File(testImgUrl)).get
+      val discreteFixedImage = ImageIO.read2DScalarImage[Float](new File(URLDecoder.decode(testImgUrl, "UTF-8"))).get
       val fixedImage = discreteFixedImage.interpolate(BSplineImageInterpolator2D[Float](3))
 
       val domain = discreteFixedImage.domain
@@ -291,7 +292,7 @@ class RegistrationTests extends ScalismoTestSuite {
     it("Recovers the correct parameters for a composed rigid and gp transform") {
       val testImgUrl = getClass.getResource("/dm128.vtk").getPath
 
-      val discreteFixedImage = ImageIO.read2DScalarImage[Float](new File(testImgUrl)).get
+      val discreteFixedImage = ImageIO.read2DScalarImage[Float](new File(URLDecoder.decode(testImgUrl, "UTF-8"))).get
       val fixedImage = discreteFixedImage.interpolate(3)
 
       val domain = discreteFixedImage.domain
@@ -332,7 +333,7 @@ class RegistrationTests extends ScalismoTestSuite {
 
   describe("A 3D image registration") {
     val testImgUrl = getClass.getResource("/3ddm.nii").getPath
-    val discreteFixedImage = ImageIO.read3DScalarImage[Float](new File(testImgUrl)).get
+    val discreteFixedImage = ImageIO.read3DScalarImage[Float](new File(URLDecoder.decode(testImgUrl, "UTF-8"))).get
     val fixedImage = discreteFixedImage.interpolate(BSplineImageInterpolator3D[Float](3))
 
     val transformationSpace = TranslationSpace[_3D]

--- a/src/test/scala/scalismo/registration/TransformationTests.scala
+++ b/src/test/scala/scalismo/registration/TransformationTests.scala
@@ -16,6 +16,7 @@
 package scalismo.registration
 
 import java.io.File
+import java.net.URLDecoder
 
 import breeze.linalg.DenseVector
 import scalismo.ScalismoTestSuite
@@ -142,7 +143,7 @@ class TransformationTests extends ScalismoTestSuite {
   describe("In 3D") {
 
     val path = getClass.getResource("/3dimage.nii").getPath
-    val discreteImage = ImageIO.read3DScalarImage[Short](new File(path)).get
+    val discreteImage = ImageIO.read3DScalarImage[Short](new File(URLDecoder.decode(path, "UTF-8"))).get
     val continuousImage = discreteImage.interpolate(BSplineImageInterpolator3D[Short](0))
 
     it("translation forth and back of a real dataset yields the same image") {
@@ -169,7 +170,8 @@ class TransformationTests extends ScalismoTestSuite {
       for (p <- discreteImage.domain.points.filter(rotatedImage.isDefinedAt)) rotatedImage(p) should equal(continuousImage(p))
     }
 
-    val mesh = MeshIO.readMesh(new File(getClass.getResource("/facemesh.stl").getPath)).get
+    val meshPath = URLDecoder.decode(getClass.getResource("/facemesh.stl").getPath, "UTF-8")
+    val mesh = MeshIO.readMesh(new File(meshPath)).get
 
     it("rotation is invertible on meshes") {
 

--- a/src/test/scala/scalismo/statisticalmodel/ActiveShapeModelTests.scala
+++ b/src/test/scala/scalismo/statisticalmodel/ActiveShapeModelTests.scala
@@ -1,6 +1,7 @@
 package scalismo.statisticalmodel
 
 import java.io.File
+import java.net.URLDecoder
 
 import breeze.linalg.DenseVector
 import scalismo.ScalismoTestSuite
@@ -8,7 +9,7 @@ import scalismo.geometry.{ Point, _3D }
 import scalismo.io.{ ImageIO, MeshIO, StatismoIO }
 import scalismo.mesh.{ MeshMetrics, TriangleMesh }
 import scalismo.numerics.{ Sampler, UniformMeshSampler3D }
-import scalismo.registration.{ LandmarkRegistration }
+import scalismo.registration.LandmarkRegistration
 import scalismo.statisticalmodel.asm._
 import scalismo.statisticalmodel.dataset.DataCollection
 import scalismo.utils.Random
@@ -27,11 +28,18 @@ class ActiveShapeModelTests extends ScalismoTestSuite {
       val searchMethod = NormalDirectionSearchPointSampler(numberOfPoints = 31, searchDistance = 6)
       val fittingConfig = FittingConfiguration(featureDistanceThreshold = 2.0, pointDistanceThreshold = 3.0, modelCoefficientBounds = 3.0)
 
-      val shapeModel = StatismoIO.readStatismoMeshModel(new File(getClass.getResource(s"/asmData/model.h5").getPath)).get
+      val path: String = URLDecoder.decode(getClass.getResource(s"/asmData/model.h5").getPath, "UTF-8")
+      val shapeModel = StatismoIO.readStatismoMeshModel(new File(path)).get
       val nbFiles = 7
       // use iterators so files are only loaded when required (and memory can be reclaimed after use)
-      val meshes = (0 until nbFiles).toIterator map (i => MeshIO.readMesh(new File(getClass.getResource(s"/asmData/$i.stl").getPath)).get)
-      val images = (0 until nbFiles).toIterator map (i => ImageIO.read3DScalarImage[Float](new File(getClass.getResource(s"/asmData/$i.vtk").getPath)).get)
+      val meshes = (0 until nbFiles).toIterator map { i =>
+        val meshPath: String = getClass.getResource(s"/asmData/$i.stl").getPath
+        MeshIO.readMesh(new File(URLDecoder.decode(meshPath, "UTF-8"))).get
+      }
+      val images = (0 until nbFiles).toIterator map { i =>
+        val imgPath: String = getClass.getResource(s"/asmData/$i.vtk").getPath
+        ImageIO.read3DScalarImage[Float](new File(URLDecoder.decode(imgPath, "UTF-8"))).get
+      }
 
       val targetImage = images.next()
       val targetMesh = meshes.next()

--- a/src/test/scala/scalismo/statisticalmodel/GaussianProcessTests.scala
+++ b/src/test/scala/scalismo/statisticalmodel/GaussianProcessTests.scala
@@ -15,6 +15,8 @@
  */
 package scalismo.statisticalmodel
 
+import java.net.URLDecoder
+
 import breeze.linalg.{ DenseMatrix, DenseVector }
 import breeze.stats.distributions.Gaussian
 import scalismo.ScalismoTestSuite
@@ -347,7 +349,7 @@ class GaussianProcessTests extends ScalismoTestSuite {
 
     it("approximate the right amount of variance based on the relative error") {
       val ssmPath = getClass.getResource("/facemodel.h5").getPath
-      val ssm = StatismoIO.readStatismoMeshModel(new java.io.File(ssmPath)).get
+      val ssm = StatismoIO.readStatismoMeshModel(new java.io.File(URLDecoder.decode(ssmPath, "UTF-8"))).get
       val nnInterpolator = NearestNeighborInterpolator[_3D, EuclideanVector[_3D]]()
       val gpToApproximate = ssm.gp.interpolate(nnInterpolator)
 
@@ -364,7 +366,7 @@ class GaussianProcessTests extends ScalismoTestSuite {
 
     it("keeps the probability of samples unchanged") {
       val ssmPath = getClass.getResource("/facemodel.h5").getPath
-      val fullSsm = StatismoIO.readStatismoMeshModel(new java.io.File(ssmPath)).get
+      val fullSsm = StatismoIO.readStatismoMeshModel(new java.io.File(URLDecoder.decode(ssmPath, "UTF-8"))).get
 
       // we truncate the ssm to avoid numerical error
       val ssm = fullSsm.truncate(fullSsm.rank / 2)

--- a/src/test/scala/scalismo/statisticalmodel/StatisticalModelTests.scala
+++ b/src/test/scala/scalismo/statisticalmodel/StatisticalModelTests.scala
@@ -16,6 +16,7 @@
 package scalismo.statisticalmodel
 
 import java.io.File
+import java.net.URLDecoder
 
 import breeze.linalg.DenseVector
 import breeze.stats.distributions.Gaussian
@@ -56,7 +57,7 @@ class StatisticalModelTests extends ScalismoTestSuite {
     it("can be calculated with a small amount of samples using PCA") {
 
       val path = getClass.getResource("/facemodel.h5").getPath
-      val model = StatismoIO.readStatismoMeshModel(new File(path)).get
+      val model = StatismoIO.readStatismoMeshModel(new File(URLDecoder.decode(path, "UTF-8"))).get
 
       val ref = model.referenceMesh
 
@@ -74,7 +75,7 @@ class StatisticalModelTests extends ScalismoTestSuite {
 
     it("can be transformed forth and back and yield the same deformations") {
       val path = getClass.getResource("/facemodel.h5").getPath
-      val model = StatismoIO.readStatismoMeshModel(new File(path)).get
+      val model = StatismoIO.readStatismoMeshModel(new File(URLDecoder.decode(path, "UTF-8"))).get
 
       val parameterVector = DenseVector[Double](1.5, 1.0, 3.5, Math.PI, -Math.PI / 2.0, -Math.PI)
       val rigidTransform = RigidTransformationSpace[_3D]().transformForParameters(parameterVector)
@@ -87,7 +88,7 @@ class StatisticalModelTests extends ScalismoTestSuite {
     it("can change the mean shape and still yield the same shape space") {
 
       val path = getClass.getResource("/facemodel.h5").getPath
-      val model = StatismoIO.readStatismoMeshModel(new File(path)).get
+      val model = StatismoIO.readStatismoMeshModel(new File(URLDecoder.decode(path, "UTF-8"))).get
 
       val newMesh = model.sample
 
@@ -103,7 +104,7 @@ class StatisticalModelTests extends ScalismoTestSuite {
 
     it("has the right rank when reduced") {
       val path = getClass.getResource("/facemodel.h5").getPath
-      val model = StatismoIO.readStatismoMeshModel(new File(path)).get
+      val model = StatismoIO.readStatismoMeshModel(new File(URLDecoder.decode(path, "UTF-8"))).get
 
       val newRank = model.rank / 2
       val truncatedModel = model.truncate(newRank)
@@ -113,7 +114,7 @@ class StatisticalModelTests extends ScalismoTestSuite {
 
     it("yield equivalent samples with reduced number of points when decimated") {
       val path = getClass.getResource("/facemodel.h5").getPath
-      val model = StatismoIO.readStatismoMeshModel(new File(path)).get
+      val model = StatismoIO.readStatismoMeshModel(new File(URLDecoder.decode(path, "UTF-8"))).get
       val targetNumberOfPoints = model.referenceMesh.pointSet.numberOfPoints / 2
       val decimatedModel = model.decimate(targetNumberOfPoints)
 

--- a/src/test/scala/scalismo/statisticalmodel/dataset/DataCollectionTests.scala
+++ b/src/test/scala/scalismo/statisticalmodel/dataset/DataCollectionTests.scala
@@ -16,17 +16,18 @@
 package scalismo.statisticalmodel.dataset
 
 import java.io.File
+import java.net.URLDecoder
 
 import scalismo.ScalismoTestSuite
-import scalismo.common.{ Field }
+import scalismo.common.Field
 import scalismo.geometry._
 import scalismo.io.MeshIO
 import scalismo.kernels.{ DiagonalKernel, GaussianKernel }
-import scalismo.mesh.{ TriangleMesh, MeshMetrics }
+import scalismo.mesh.{ MeshMetrics, TriangleMesh }
 import scalismo.numerics.UniformMeshSampler3D
 import scalismo.registration.{ LandmarkRegistration, TranslationTransform }
-import scalismo.statisticalmodel.{ LowRankGaussianProcess, GaussianProcess, StatisticalMeshModel }
-import scalismo.utils.{ Random }
+import scalismo.statisticalmodel.{ GaussianProcess, LowRankGaussianProcess, StatisticalMeshModel }
+import scalismo.utils.Random
 
 class DataCollectionTests extends ScalismoTestSuite {
 
@@ -36,8 +37,8 @@ class DataCollectionTests extends ScalismoTestSuite {
 
     val transformations = for (i <- 0 until 10) yield TranslationTransform(EuclideanVector(i.toDouble, 0.0, 0.0))
     val dataItems = for ((t, i) <- transformations.zipWithIndex) yield DataItem(s"transformation-$i", t)
-    val meshpath = getClass.getResource("/facemesh.stl").getPath
-    val referenceMesh = MeshIO.readMesh(new File(meshpath)).get
+    val meshPath = getClass.getResource("/facemesh.stl").getPath
+    val referenceMesh = MeshIO.readMesh(new File(URLDecoder.decode(meshPath, "UTF-8"))).get
 
     val dataCollection = DataCollection(referenceMesh, dataItems)
 
@@ -114,7 +115,8 @@ class DataCollectionTests extends ScalismoTestSuite {
 
   object Fixture {
 
-    val nonAlignedFaces = new File(getClass.getResource("/nonAlignedFaces").getPath).listFiles.sortBy(_.getName).map { f => MeshIO.readMesh(f).get }.toIndexedSeq
+    val path: String = getClass.getResource("/nonAlignedFaces").getPath
+    val nonAlignedFaces = new File(URLDecoder.decode(path, "UTF-8")).listFiles.sortBy(_.getName).map { f => MeshIO.readMesh(f).get }.toIndexedSeq
     val ref = nonAlignedFaces.head
     val dataset = nonAlignedFaces.tail
 

--- a/src/test/scala/scalismo/utils/ConversionTests.scala
+++ b/src/test/scala/scalismo/utils/ConversionTests.scala
@@ -16,6 +16,8 @@
 
 package scalismo.utils
 
+import java.net.URLDecoder
+
 import scalismo.ScalismoTestSuite
 import scalismo.geometry._2D
 import scalismo.io.{ ImageIO, MeshIO }
@@ -26,7 +28,7 @@ class ConversionTests extends ScalismoTestSuite {
 
     it("can be converted to and from vtk") {
       val path = getClass.getResource("/facemesh.stl").getPath
-      val origmesh = MeshIO.readMesh(new java.io.File(path)).get
+      val origmesh = MeshIO.readMesh(new java.io.File(URLDecoder.decode(path, "UTF-8"))).get
       val vtkpd = MeshConversion.meshToVtkPolyData(origmesh)
       val restoredMesh = MeshConversion.vtkPolyDataToTriangleMesh(vtkpd).get
       origmesh should equal(restoredMesh)
@@ -41,7 +43,7 @@ class ConversionTests extends ScalismoTestSuite {
   describe("an 2D image") {
     it("can be converted to and from vtk") {
       val path = getClass.getResource("/lena.vtk").getPath
-      val origimg = ImageIO.read2DScalarImage[Short](new java.io.File(path)).get
+      val origimg = ImageIO.read2DScalarImage[Short](new java.io.File(URLDecoder.decode(path, "UTF-8"))).get
       val vtksp = ImageConversion.imageToVtkStructuredPoints(origimg)
       val restoredImg = ImageConversion.vtkStructuredPointsToScalarImage[_2D, Short](vtksp).get
 


### PR DESCRIPTION
This fixes #291 by using URLDecoder where it is appropriate. It is not needed if the file to the test resource is created with getResourceAsStream.

A simple test would be to move all test resources to a folder "resources/with space/" and change the location of the files in all tests accordingly. This would make the test fail if the URLDecoder is not used at appropriate locations.

In addition, this PR removes one line printed to the console during one of the tests.