### PR TITLE
relaxed precision requirement to see if something is 0

### DIFF
--- a/src/main/scala/scalismo/mesh/TetrahedralMesh.scala
+++ b/src/main/scala/scalismo/mesh/TetrahedralMesh.scala
@@ -154,7 +154,7 @@ case class TetrahedralMesh3D(pointSet: UnstructuredPointsDomain[_3D], tetrahedra
     val barycentricCoordinates = new Array[Double](4)
     new vtkTetra().BarycentricCoords(point.toArray, a.toArray, b.toArray, c.toArray, d.toArray, barycentricCoordinates)
 
-    val normalized = barycentricCoordinates.map { e => if ((e >= -1E-50) && (e <= 1E-50)) 0.0 else e }
+    val normalized = barycentricCoordinates.map { e => if (Math.abs(e) <= 1E-10) 0.0 else e }
     val numberOfZeroEntries = countZeroEntries(normalized)
     hasOnlyStrictPositiveElements(normalized) || (numberOfZeroEntries == 2) || (numberOfZeroEntries == 3)
   }

--- a/src/main/scala/scalismo/mesh/TetrahedralMesh.scala
+++ b/src/main/scala/scalismo/mesh/TetrahedralMesh.scala
@@ -154,7 +154,7 @@ case class TetrahedralMesh3D(pointSet: UnstructuredPointsDomain[_3D], tetrahedra
     val barycentricCoordinates = new Array[Double](4)
     new vtkTetra().BarycentricCoords(point.toArray, a.toArray, b.toArray, c.toArray, d.toArray, barycentricCoordinates)
 
-    val normalized = barycentricCoordinates.map { e => if (Math.abs(e) <= 1E-10) 0.0 else e }
+    val normalized = barycentricCoordinates.map { e => if (Math.abs(e) <= 1E-8) 0.0 else e }
     val numberOfZeroEntries = countZeroEntries(normalized)
     hasOnlyStrictPositiveElements(normalized) || (numberOfZeroEntries == 2) || (numberOfZeroEntries == 3)
   }


### PR DESCRIPTION
The precision requirement which is used to decide whether a vertex is close to zero was too strict. In an example, where the points of a mesh themselves were looked up of being inside, it happened that one of the points was deemed outside, as its value was in the range of 1e-17  but the cutoff was 1e-50. It seems that the numerical precision of the operations used to compute whether a point is inside is not good enough to request such a high precision. I would also argue that this precision is not required in practical applications. 