### PR TITLE
Barycentric interpolator

### DIFF
--- a/src/main/scala/scalismo/common/interpolation/BarycentricInterpolator.scala
+++ b/src/main/scala/scalismo/common/interpolation/BarycentricInterpolator.scala
@@ -1,0 +1,50 @@
+package scalismo.common.interpolation
+
+import scalismo.common._
+import scalismo.geometry.{NDSpace, Point, _3D}
+import scalismo.mesh.{TetrahedralCell, TetrahedralMesh}
+import scalismo.numerics.ValueInterpolator
+
+trait BarycentricInterpolator[D, A] extends FieldInterpolator[D, UnstructuredPointsDomain[D], A] {
+  implicit protected val valueInterpolator: ValueInterpolator[A]
+}
+
+object BarycentricInterpolator {
+
+  trait Create[D] {
+    def createBarycentricInterpolator[A: ValueInterpolator](m: TetrahedralMesh[D]): BarycentricInterpolator[D, A]
+  }
+
+  implicit object create3D extends Create[_3D] {
+    override def createBarycentricInterpolator[A: ValueInterpolator](m: TetrahedralMesh[_3D]): BarycentricInterpolator[_3D, A] = new BarycentricInterpolator3D[A](m)
+  }
+
+  def apply[D: NDSpace, A: ValueInterpolator](m: TetrahedralMesh[D])(implicit creator: Create[D]): BarycentricInterpolator[D, A] = {
+    creator.createBarycentricInterpolator(m)
+  }
+
+}
+
+case class BarycentricInterpolator3D[A: ValueInterpolator](m: TetrahedralMesh[_3D]) extends BarycentricInterpolator[_3D, A] {
+
+  override protected val valueInterpolator: ValueInterpolator[A] = ValueInterpolator[A]
+
+  private def getTetrahedralMeshCell(p: Point[_3D]): TetrahedralCell = {
+    val closestPoint = m.pointSet.findClosestPoint(p)
+    val adjacentTetrahedra = m.tetrahedralization.adjacentTetrahedronsForPoint(closestPoint.id)
+    val tetraId = adjacentTetrahedra.filter(tId => m.isInsideTetrahedralCell(p, m.tetrahedralization.tetrahedrons(tId.id))).head
+    m.tetrahedralization.tetrahedrons(tetraId.id)
+  }
+
+  override def interpolate(df: DiscreteField[_3D, UnstructuredPointsDomain[_3D], A]): Field[_3D, A] = {
+
+    def interpolateBarycentric(p: Point[_3D]): A = {
+      val cell = getTetrahedralMeshCell(p)
+      val vertexValues = cell.pointIds.map(df(_))
+      val barycentricCoordinates = m.getBarycentricCoordinates(p, cell)
+      val valueCoordinatePairs = vertexValues.zip(barycentricCoordinates)
+      ValueInterpolator[A].convexCombination(valueCoordinatePairs(0), valueCoordinatePairs(1), valueCoordinatePairs(2), valueCoordinatePairs(3))//vertexValues.zip(barycentricCoordinates.toIndexedSeq).map(t => t._1 * t._2).sum
+    }
+    Field(RealSpace[_3D], interpolateBarycentric)
+  }
+}

--- a/src/main/scala/scalismo/common/interpolation/BarycentricInterpolator.scala
+++ b/src/main/scala/scalismo/common/interpolation/BarycentricInterpolator.scala
@@ -1,8 +1,8 @@
 package scalismo.common.interpolation
 
 import scalismo.common._
-import scalismo.geometry.{NDSpace, Point, _3D}
-import scalismo.mesh.{TetrahedralCell, TetrahedralMesh}
+import scalismo.geometry.{ NDSpace, Point, _3D }
+import scalismo.mesh.{ TetrahedralCell, TetrahedralMesh }
 import scalismo.numerics.ValueInterpolator
 
 trait BarycentricInterpolator[D, A] extends FieldInterpolator[D, UnstructuredPointsDomain[D], A] {
@@ -43,7 +43,7 @@ case class BarycentricInterpolator3D[A: ValueInterpolator](m: TetrahedralMesh[_3
       val vertexValues = cell.pointIds.map(df(_))
       val barycentricCoordinates = m.getBarycentricCoordinates(p, cell)
       val valueCoordinatePairs = vertexValues.zip(barycentricCoordinates)
-      ValueInterpolator[A].convexCombination(valueCoordinatePairs(0), valueCoordinatePairs(1), valueCoordinatePairs(2), valueCoordinatePairs(3))//vertexValues.zip(barycentricCoordinates.toIndexedSeq).map(t => t._1 * t._2).sum
+      ValueInterpolator[A].convexCombination(valueCoordinatePairs(0), valueCoordinatePairs(1), valueCoordinatePairs(2), valueCoordinatePairs(3))
     }
     Field(RealSpace[_3D], interpolateBarycentric)
   }

--- a/src/main/scala/scalismo/mesh/TetrahedralMesh.scala
+++ b/src/main/scala/scalismo/mesh/TetrahedralMesh.scala
@@ -134,6 +134,19 @@ case class TetrahedralMesh3D(pointSet: UnstructuredPointsDomain[_3D], tetrahedra
     math.abs(signedVolume)
   }
 
+  /** Returns the Barycentric coordinates of a point inside the indicated cell. */
+  def getBarycentricCoordinates(point: Point[_3D], tetrathedron: TetrahedralCell): Array[Double] = {
+
+    val a = pointSet.point(tetrathedron.ptId1).toVector
+    val b = pointSet.point(tetrathedron.ptId2).toVector
+    val c = pointSet.point(tetrathedron.ptId3).toVector
+    val d = pointSet.point(tetrathedron.ptId4).toVector
+
+    val barycentricCoordinates = new Array[Double](4)
+    new vtkTetra().BarycentricCoords(point.toArray, a.toArray, b.toArray, c.toArray, d.toArray, barycentricCoordinates)
+    barycentricCoordinates
+  }
+
   /** Returns true for points within a tetrahedron defined by the indicated cell. */
   def isInsideTetrahedralCell(point: Point[_3D], tetrahedron: TetrahedralCell): Boolean = {
 
@@ -145,14 +158,8 @@ case class TetrahedralMesh3D(pointSet: UnstructuredPointsDomain[_3D], tetrahedra
       array.map(element => if (element == 0.0) 1 else 0).sum
     }
 
-    val a = pointSet.point(tetrahedron.ptId1).toVector
-    val b = pointSet.point(tetrahedron.ptId2).toVector
-    val c = pointSet.point(tetrahedron.ptId3).toVector
-    val d = pointSet.point(tetrahedron.ptId4).toVector
-
     // note: replace call to vtk with own implementation
-    val barycentricCoordinates = new Array[Double](4)
-    new vtkTetra().BarycentricCoords(point.toArray, a.toArray, b.toArray, c.toArray, d.toArray, barycentricCoordinates)
+    val barycentricCoordinates = getBarycentricCoordinates(point, tetrahedron)
 
     val normalized = barycentricCoordinates.map { e => if (Math.abs(e) <= 1E-8) 0.0 else e }
     val numberOfZeroEntries = countZeroEntries(normalized)

--- a/src/test/scala/scalismo/common/BarycentricInterpolatorTest.scala
+++ b/src/test/scala/scalismo/common/BarycentricInterpolatorTest.scala
@@ -1,0 +1,85 @@
+package scalismo.common
+
+import scalismo.ScalismoTestSuite
+import scalismo.common.interpolation.BarycentricInterpolator
+import scalismo.geometry.{Point, Point3D, _3D}
+import scalismo.mesh.{ScalarVolumeMeshField, TetrahedralCell, TetrahedralList, TetrahedralMesh3D}
+import scalismo.utils.Random
+
+
+class BarycentricInterpolatorTest extends ScalismoTestSuite {
+
+  implicit val rng = Random(42L)
+
+  def createTetrahedronsInUnitCube(): TetrahedralMesh3D = {
+    // points around unit cube
+    val points = IndexedSeq(
+      Point(0, 0, 0),
+      Point(1, 0, 0),
+      Point(1, 1, 0),
+      Point(0, 1, 0),
+      Point(0, 0, 1),
+      Point(1, 0, 1),
+      Point(1, 1, 1),
+      Point(0, 1, 1)
+    )
+    val domain = UnstructuredPointsDomain(points)
+
+    // cells covering the complete cube
+    implicit def intToPointId(i: Int): PointId = PointId(i)
+    val cells = IndexedSeq(
+      TetrahedralCell(0, 2, 7, 3),
+      TetrahedralCell(0, 2, 5, 1),
+      TetrahedralCell(2, 5, 7, 6),
+      TetrahedralCell(0, 5, 7, 4),
+      TetrahedralCell(0, 2, 5, 7)
+    )
+    val list = TetrahedralList(cells)
+
+    TetrahedralMesh3D(domain, list)
+  }
+
+  describe("A Barycentric Interpolator") {
+
+    it("returns correct value at vertex points.") {
+
+      val tetrahedralMesh = createTetrahedronsInUnitCube()
+      val scalars = IndexedSeq[Double](0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0)
+      val scalarVolumeMeshField = ScalarVolumeMeshField(tetrahedralMesh, scalars)
+      val interpolatedVolumeMeshField = scalarVolumeMeshField.interpolate(BarycentricInterpolator(tetrahedralMesh))
+
+      val vertexValues = tetrahedralMesh.pointSet.points.map(interpolatedVolumeMeshField(_))
+      vertexValues.toIndexedSeq.zip(scalars).foreach(p => {
+        p._1 shouldBe p._2
+      })
+
+    }
+
+    it("returns correct values inside cells.") {
+
+      def getTetrahedralMeshCell(m: TetrahedralMesh3D, p: Point[_3D]): TetrahedralCell = {
+        val closestPoint = m.pointSet.findClosestPoint(p)
+        val adjacentTetrahedra = m.tetrahedralization.adjacentTetrahedronsForPoint(closestPoint.id)
+        val tetraId = adjacentTetrahedra.filter(tId => m.isInsideTetrahedralCell(p, m.tetrahedralization.tetrahedrons(tId.id))).head
+        m.tetrahedralization.tetrahedrons(tetraId.id)
+      }
+
+      val tetrahedralMesh = createTetrahedronsInUnitCube()
+      val scalars = IndexedSeq[Double](0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0)
+      val scalarVolumeMeshField = ScalarVolumeMeshField(tetrahedralMesh, scalars)
+      val interpolatedVolumeMeshField = scalarVolumeMeshField.interpolate(BarycentricInterpolator(tetrahedralMesh))
+
+      val point = Point3D(0.0080570729074948, 0.4107871517927135,0.6832234717598454)
+      val cell = getTetrahedralMeshCell(tetrahedralMesh, point)
+      val vertexValues = cell.pointIds.map(pId => {scalars(pId.id)})
+      val barycentricCoordinates = tetrahedralMesh.getBarycentricCoordinates(point, cell)
+
+      val valueAtPoint = vertexValues.zip(barycentricCoordinates).map(t => t._1 * t._2).sum
+      val interpolatedValueAtPoint = interpolatedVolumeMeshField(point)
+
+      valueAtPoint shouldBe interpolatedValueAtPoint
+    }
+
+  }
+
+}


### PR DESCRIPTION
Adds a Barycentric interpolator that can be used with tetrahedral meshes. Includes basic unit tests.