### PR TITLE
Barycentric interpolator: increase search space to find correct tetrahedron of Point[_3D] 

### DIFF
--- a/src/main/scala/scalismo/common/interpolation/BarycentricInterpolator.scala
+++ b/src/main/scala/scalismo/common/interpolation/BarycentricInterpolator.scala
@@ -59,11 +59,14 @@ case class BarycentricInterpolator3D[A: ValueInterpolator](mesh: TetrahedralMesh
   override def interpolate(df: DiscreteField[_3D, UnstructuredPointsDomain[_3D], A]): Field[_3D, A] = {
 
     def interpolateBarycentric(p: Point[_3D]): A = {
-      val cell = getTetrahedralMeshCell(p).get
-      val vertexValues = cell.pointIds.map(df(_))
-      val barycentricCoordinates = mesh.getBarycentricCoordinates(p, cell)
-      val valueCoordinatePairs = vertexValues.zip(barycentricCoordinates)
-      ValueInterpolator[A].convexCombination(valueCoordinatePairs(0), valueCoordinatePairs(1), valueCoordinatePairs(2), valueCoordinatePairs(3))
+      getTetrahedralMeshCell(p) match {
+        case Some(cell) =>
+          val vertexValues = cell.pointIds.map(df(_))
+          val barycentricCoordinates = mesh.getBarycentricCoordinates(p, cell)
+          val valueCoordinatePairs = vertexValues.zip(barycentricCoordinates)
+          ValueInterpolator[A].convexCombination(valueCoordinatePairs(0), valueCoordinatePairs(1), valueCoordinatePairs(2), valueCoordinatePairs(3))
+        case None => throw new Exception("Point outside of domain.")
+      }
     }
     Field(RealSpace[_3D], interpolateBarycentric)
   }

--- a/src/main/scala/scalismo/common/interpolation/BarycentricInterpolator.scala
+++ b/src/main/scala/scalismo/common/interpolation/BarycentricInterpolator.scala
@@ -30,8 +30,8 @@ case class BarycentricInterpolator3D[A: ValueInterpolator](m: TetrahedralMesh[_3
   override protected val valueInterpolator: ValueInterpolator[A] = ValueInterpolator[A]
 
   private def getTetrahedralMeshCell(p: Point[_3D]): TetrahedralCell = {
-    val closestPoint = m.pointSet.findClosestPoint(p)
-    val adjacentTetrahedra = m.tetrahedralization.adjacentTetrahedronsForPoint(closestPoint.id)
+    val closestPoints = m.pointSet.findNClosestPoints(p, 4)
+    val adjacentTetrahedra = closestPoints.flatMap(cp => m.tetrahedralization.adjacentTetrahedronsForPoint(cp.id))
     val tetraId = adjacentTetrahedra.filter(tId => m.isInsideTetrahedralCell(p, m.tetrahedralization.tetrahedrons(tId.id))).head
     m.tetrahedralization.tetrahedrons(tetraId.id)
   }

--- a/src/main/scala/scalismo/common/interpolation/BarycentricInterpolator.scala
+++ b/src/main/scala/scalismo/common/interpolation/BarycentricInterpolator.scala
@@ -65,7 +65,7 @@ case class BarycentricInterpolator3D[A: ValueInterpolator](mesh: TetrahedralMesh
           val barycentricCoordinates = mesh.getBarycentricCoordinates(p, cell)
           val valueCoordinatePairs = vertexValues.zip(barycentricCoordinates)
           ValueInterpolator[A].convexCombination(valueCoordinatePairs(0), valueCoordinatePairs(1), valueCoordinatePairs(2), valueCoordinatePairs(3))
-        case None => throw new Exception("Point outside of domain.")
+        case None => throw new Exception(s"Point $p outside of domain.")
       }
     }
     Field(RealSpace[_3D], interpolateBarycentric)

--- a/src/test/scala/scalismo/common/BarycentricInterpolatorTest.scala
+++ b/src/test/scala/scalismo/common/BarycentricInterpolatorTest.scala
@@ -6,7 +6,6 @@ import scalismo.geometry.{ Point, Point3D, _3D }
 import scalismo.mesh.{ ScalarVolumeMeshField, TetrahedralCell, TetrahedralList, TetrahedralMesh3D }
 import scalismo.utils.Random
 
-
 class BarycentricInterpolatorTest extends ScalismoTestSuite {
 
   implicit val rng = Random(42L)

--- a/src/test/scala/scalismo/common/BarycentricInterpolatorTest.scala
+++ b/src/test/scala/scalismo/common/BarycentricInterpolatorTest.scala
@@ -2,8 +2,8 @@ package scalismo.common
 
 import scalismo.ScalismoTestSuite
 import scalismo.common.interpolation.BarycentricInterpolator
-import scalismo.geometry.{Point, Point3D, _3D}
-import scalismo.mesh.{ScalarVolumeMeshField, TetrahedralCell, TetrahedralList, TetrahedralMesh3D}
+import scalismo.geometry.{ Point, Point3D, _3D }
+import scalismo.mesh.{ ScalarVolumeMeshField, TetrahedralCell, TetrahedralList, TetrahedralMesh3D }
 import scalismo.utils.Random
 
 
@@ -69,9 +69,9 @@ class BarycentricInterpolatorTest extends ScalismoTestSuite {
       val scalarVolumeMeshField = ScalarVolumeMeshField(tetrahedralMesh, scalars)
       val interpolatedVolumeMeshField = scalarVolumeMeshField.interpolate(BarycentricInterpolator(tetrahedralMesh))
 
-      val point = Point3D(0.0080570729074948, 0.4107871517927135,0.6832234717598454)
+      val point = Point3D(0.0080570729074948, 0.4107871517927135, 0.6832234717598454)
       val cell = getTetrahedralMeshCell(tetrahedralMesh, point)
-      val vertexValues = cell.pointIds.map(pId => {scalars(pId.id)})
+      val vertexValues = cell.pointIds.map(pId => { scalars(pId.id) })
       val barycentricCoordinates = tetrahedralMesh.getBarycentricCoordinates(point, cell)
 
       val valueAtPoint = vertexValues.zip(barycentricCoordinates).map(t => t._1 * t._2).sum


### PR DESCRIPTION
Fixes #303 by looping over the adjacent cells of the 4 closest vertex points of a given Point[_3D].