### PR TITLE
fixed bug in tetrahedralmeshConversion and introduced template option

### DIFF
--- a/src/main/scala/scalismo/io/MeshIO.scala
+++ b/src/main/scala/scalismo/io/MeshIO.scala
@@ -281,7 +281,7 @@ object MeshIO {
    */
   def writeTetrahedralMesh(mesh: TetrahedralMesh[_3D], file: File): Try[Unit] = {
     val filename = file.getAbsolutePath
-    val conversionFunction = TetrahedralMeshConversion.tetrahedralMeshToVTKUnstructuredGrid _
+    val conversionFunction = (m: TetrahedralMesh[_3D]) => TetrahedralMeshConversion.tetrahedralMeshToVTKUnstructuredGrid(m, None)
     filename match {
       case f if f.endsWith(".vtk") => writeToVTKFileThenDelete(mesh, writeVTKUgasVTK, conversionFunction, file)
       case f if f.endsWith(".vtu") => writeToVTKFileThenDelete(mesh, writeVTKUgasVTU, conversionFunction, file)
@@ -332,7 +332,7 @@ object MeshIO {
 
   def writeScalarVolumeMeshField[S: Scalar: TypeTag: ClassTag](meshData: ScalarVolumeMeshField[S], file: File): Try[Unit] = {
     val filename = file.getAbsolutePath
-    val conversionFunction = TetrahedralMeshConversion.scalarVolumeMeshFieldToVtkUnstructuredGrid[S] _
+    val conversionFunction = (smf: ScalarVolumeMeshField[S]) => TetrahedralMeshConversion.scalarVolumeMeshFieldToVtkUnstructuredGrid[S](smf, None)
     filename match {
       case f if f.endsWith(".vtk") => writeToVTKFileThenDelete(meshData, writeVTKUgasVTK, conversionFunction, file)
       case f if f.endsWith(".vtu") => writeToVTKFileThenDelete(meshData, writeVTKUgasVTU, conversionFunction, file)

--- a/src/test/scala/scalismo/utils/ConversionTests.scala
+++ b/src/test/scala/scalismo/utils/ConversionTests.scala
@@ -52,4 +52,22 @@ class ConversionTests extends ScalismoTestSuite {
     }
   }
 
+  describe("a tetrahedral mesh ") {
+
+    it("can be converted to and from vtk") {
+      val path = getClass.getResource("/tetraMesh.vtk").getPath
+      val origmesh = MeshIO.readTetrahedralMesh(new java.io.File(URLDecoder.decode(path, "UTF-8"))).get
+
+      val vtkug = TetrahedralMeshConversion.tetrahedralMeshToVTKUnstructuredGrid(origmesh)
+      val restoredMesh = TetrahedralMeshConversion.vtkUnstructuredGridToTetrahedralMesh(vtkug).get
+      origmesh should equal(restoredMesh)
+
+      // test conversion with template
+      val vtkug2 = TetrahedralMeshConversion.tetrahedralMeshToVTKUnstructuredGrid(origmesh, Some(vtkug))
+      val restoredMesh2 = TetrahedralMeshConversion.vtkUnstructuredGridToTetrahedralMesh(vtkug2).get
+      origmesh should equal(restoredMesh2)
+
+    }
+  }
+
 }


### PR DESCRIPTION
The conversion method for converting a tetrahedral mesh to a vtkUnstructuredGrid takes now an additional (optional) parameter template. This parameter  makes it possible to specify an existing
tetrahedral mesh as a blueprint. The basic structure of the tetrahedral mesh is then taken from this template and only the points are changed. This greatly speeds up the conversion.

At the same time the conversion to vtk was simplified and a bug (wrong allocation of cell types) was fixed.