### PR TITLE
StatisticalVolumeIntensityModel 

### DIFF
--- a/src/main/scala/scalismo/common/Scalar.scala
+++ b/src/main/scala/scalismo/common/Scalar.scala
@@ -435,16 +435,4 @@ object ScalarArray {
     }
   }
 
-  case class ScalarVectorizer[S: Scalar]() extends Vectorizer[S] {
-    override def dim: Int = 1
-
-    def toArray(v: S): Array[Double] = Array[Double](Scalar[S].toDouble(v))
-
-    override def vectorize(v: S): DenseVector[Double] = new DenseVector(toArray(v))
-
-    override def unvectorize(d: DenseVector[Double]): S = {
-      Scalar[S].fromDouble(d(0))
-    }
-  }
-
 }

--- a/src/main/scala/scalismo/common/Scalar.scala
+++ b/src/main/scala/scalismo/common/Scalar.scala
@@ -423,21 +423,15 @@ object ScalarArray {
     }
   }
 
-  class ScalarVectorizer[S: Scalar] extends Vectorizer[S] {
+  case class ScalarVectorizer[S: Scalar]() extends Vectorizer[S] {
     override def dim: Int = 1
 
     def toArray(v: S): Array[Double] = Array[Double](Scalar[S].toDouble(v))
+
     override def vectorize(v: S): DenseVector[Double] = new DenseVector(toArray(v))
 
     override def unvectorize(d: DenseVector[Double]): S = {
       Scalar[S].fromDouble(d(0))
-    }
-
-    override def equals(that: Any): Boolean = {
-      that match {
-        case t: ScalarVectorizer[S] => true
-        case _ => false
-      }
     }
   }
 

--- a/src/main/scala/scalismo/common/Scalar.scala
+++ b/src/main/scala/scalismo/common/Scalar.scala
@@ -15,6 +15,7 @@
  */
 package scalismo.common
 
+import breeze.linalg.DenseVector
 import scalismo.utils.ArrayUtils
 import spire.math._
 
@@ -419,6 +420,24 @@ object ScalarArray {
         v.convertArray[T](array, { t =>
           t
         })
+    }
+  }
+
+  class ScalarVectorizer[S: Scalar] extends Vectorizer[S] {
+    override def dim: Int = 1
+
+    def toArray(v: S): Array[Double] = Array[Double](Scalar[S].toDouble(v))
+    override def vectorize(v: S): DenseVector[Double] = new DenseVector(toArray(v))
+
+    override def unvectorize(d: DenseVector[Double]): S = {
+      Scalar[S].fromDouble(d(0))
+    }
+
+    override def equals(that: Any): Boolean = {
+      that match {
+        case t: ScalarVectorizer[S] => true
+        case _ => false
+      }
     }
   }
 

--- a/src/main/scala/scalismo/statisticalmodel/SVIMCoefficients.scala
+++ b/src/main/scala/scalismo/statisticalmodel/SVIMCoefficients.scala
@@ -12,16 +12,16 @@ case class SVIMCoefficients(shape: DenseVector[Double],
 
 object SVIMCoefficients {
   def apply(shape: IndexedSeq[Double],
-    color: IndexedSeq[Double]) = new SVIMCoefficients(DenseVector(shape.toArray), DenseVector(color.toArray))
+            intensity: IndexedSeq[Double]) = new SVIMCoefficients(DenseVector(shape.toArray), DenseVector(intensity.toArray))
 
   def apply(shape: DenseVector[Double],
-    color: DenseVector[Double]) = new SVIMCoefficients(shape, color)
+            intensity: DenseVector[Double]) = new SVIMCoefficients(shape, intensity)
 
   /** get 0 coefficients of specified length */
   def zeros(shapeComponents: Int,
-    colorComponents: Int): SVIMCoefficients = {
+            intensityComponents: Int): SVIMCoefficients = {
     new SVIMCoefficients(
       DenseVector.zeros(shapeComponents),
-      DenseVector.zeros(colorComponents))
+      DenseVector.zeros(intensityComponents))
   }
 }

--- a/src/main/scala/scalismo/statisticalmodel/SVIMCoefficients.scala
+++ b/src/main/scala/scalismo/statisticalmodel/SVIMCoefficients.scala
@@ -1,0 +1,27 @@
+package scalismo.statisticalmodel
+
+import breeze.linalg.DenseVector
+
+case class SVIMCoefficients(shape: DenseVector[Double],
+    intensity: DenseVector[Double]) {
+  def *(f: Float): SVIMCoefficients = this * f.toDouble
+  def *(d: Double): SVIMCoefficients = copy(shape = shape * d, intensity = intensity * d)
+  def +(other: SVIMCoefficients): SVIMCoefficients = copy(shape = shape + other.shape, intensity = intensity + other.intensity)
+  def -(other: SVIMCoefficients): SVIMCoefficients = copy(shape = shape - other.shape, intensity = intensity - other.intensity)
+}
+
+object SVIMCoefficients {
+  def apply(shape: IndexedSeq[Double],
+    color: IndexedSeq[Double]) = new SVIMCoefficients(DenseVector(shape.toArray), DenseVector(color.toArray))
+
+  def apply(shape: DenseVector[Double],
+    color: DenseVector[Double]) = new SVIMCoefficients(shape, color)
+
+  /** get 0 coefficients of specified length */
+  def zeros(shapeComponents: Int,
+    colorComponents: Int): SVIMCoefficients = {
+    new SVIMCoefficients(
+      DenseVector.zeros(shapeComponents),
+      DenseVector.zeros(colorComponents))
+  }
+}

--- a/src/main/scala/scalismo/statisticalmodel/SVIMCoefficients.scala
+++ b/src/main/scala/scalismo/statisticalmodel/SVIMCoefficients.scala
@@ -2,26 +2,23 @@ package scalismo.statisticalmodel
 
 import breeze.linalg.DenseVector
 
-case class SVIMCoefficients(shape: DenseVector[Double],
-    intensity: DenseVector[Double]) {
+case class SVIMCoefficients(shape: DenseVector[Double], intensity: DenseVector[Double]) {
   def *(f: Float): SVIMCoefficients = this * f.toDouble
   def *(d: Double): SVIMCoefficients = copy(shape = shape * d, intensity = intensity * d)
-  def +(other: SVIMCoefficients): SVIMCoefficients = copy(shape = shape + other.shape, intensity = intensity + other.intensity)
-  def -(other: SVIMCoefficients): SVIMCoefficients = copy(shape = shape - other.shape, intensity = intensity - other.intensity)
+  def +(other: SVIMCoefficients): SVIMCoefficients =
+    copy(shape = shape + other.shape, intensity = intensity + other.intensity)
+  def -(other: SVIMCoefficients): SVIMCoefficients =
+    copy(shape = shape - other.shape, intensity = intensity - other.intensity)
 }
 
 object SVIMCoefficients {
-  def apply(shape: IndexedSeq[Double],
-    intensity: IndexedSeq[Double]) = new SVIMCoefficients(DenseVector(shape.toArray), DenseVector(intensity.toArray))
+//  def apply(shape: IndexedSeq[Double], intensity: IndexedSeq[Double]) =
+//    new SVIMCoefficients(DenseVector(shape.toArray), DenseVector(intensity.toArray))
 
-  def apply(shape: DenseVector[Double],
-    intensity: DenseVector[Double]) = new SVIMCoefficients(shape, intensity)
+  def apply(shape: DenseVector[Double], intensity: DenseVector[Double]) = new SVIMCoefficients(shape, intensity)
 
   /** get 0 coefficients of specified length */
-  def zeros(shapeComponents: Int,
-    intensityComponents: Int): SVIMCoefficients = {
-    new SVIMCoefficients(
-      DenseVector.zeros(shapeComponents),
-      DenseVector.zeros(intensityComponents))
+  def zeros(shapeComponents: Int, intensityComponents: Int): SVIMCoefficients = {
+    new SVIMCoefficients(DenseVector.zeros(shapeComponents), DenseVector.zeros(intensityComponents))
   }
 }

--- a/src/main/scala/scalismo/statisticalmodel/SVIMCoefficients.scala
+++ b/src/main/scala/scalismo/statisticalmodel/SVIMCoefficients.scala
@@ -12,14 +12,14 @@ case class SVIMCoefficients(shape: DenseVector[Double],
 
 object SVIMCoefficients {
   def apply(shape: IndexedSeq[Double],
-            intensity: IndexedSeq[Double]) = new SVIMCoefficients(DenseVector(shape.toArray), DenseVector(intensity.toArray))
+    intensity: IndexedSeq[Double]) = new SVIMCoefficients(DenseVector(shape.toArray), DenseVector(intensity.toArray))
 
   def apply(shape: DenseVector[Double],
-            intensity: DenseVector[Double]) = new SVIMCoefficients(shape, intensity)
+    intensity: DenseVector[Double]) = new SVIMCoefficients(shape, intensity)
 
   /** get 0 coefficients of specified length */
   def zeros(shapeComponents: Int,
-            intensityComponents: Int): SVIMCoefficients = {
+    intensityComponents: Int): SVIMCoefficients = {
     new SVIMCoefficients(
       DenseVector.zeros(shapeComponents),
       DenseVector.zeros(intensityComponents))

--- a/src/main/scala/scalismo/statisticalmodel/StatisticalVolumeIntensityModel.scala
+++ b/src/main/scala/scalismo/statisticalmodel/StatisticalVolumeIntensityModel.scala
@@ -28,24 +28,29 @@ trait StatisticalVolumeIntensityModel[S] {
 
 object StatisticalVolumeIntensityModel {
 
-  def apply[S: Scalar: TypeTag: ClassTag](referenceMeshField: ScalarVolumeMeshField[S],
-    shape: StatisticalVolumeMeshModel, intensity: DiscreteLowRankGaussianProcess[_3D, UnstructuredPointsDomain[_3D], S]): SVIM[S] = {
+  def apply[S: Scalar: TypeTag: ClassTag](
+    referenceMeshField: ScalarVolumeMeshField[S],
+    shape: StatisticalVolumeMeshModel,
+    intensity: DiscreteLowRankGaussianProcess[_3D, UnstructuredPointsDomain[_3D], S]
+  ): SVIM[S] = {
     SVIM(referenceMeshField, shape, intensity)
   }
 
 }
 
-case class SVIM[S: Scalar: TypeTag: ClassTag](referenceMeshField: ScalarVolumeMeshField[S],
+case class SVIM[S: Scalar: TypeTag: ClassTag](
+  referenceMeshField: ScalarVolumeMeshField[S],
   shape: StatisticalVolumeMeshModel,
-  intensity: DiscreteLowRankGaussianProcess[_3D, UnstructuredPointsDomain[_3D], S])
-    extends StatisticalVolumeIntensityModel[S] {
+  intensity: DiscreteLowRankGaussianProcess[_3D, UnstructuredPointsDomain[_3D], S]
+) extends StatisticalVolumeIntensityModel[S] {
 
   override def mean: ScalarVolumeMeshField[S] = {
     ScalarVolumeMeshField(shape.mean, warpReferenceIntensity(intensity.mean.data))
   }
 
   override def instance(coefficients: SVIMCoefficients): ScalarVolumeMeshField[S] = {
-    ScalarVolumeMeshField(shape.instance(coefficients.shape), warpReferenceIntensity(intensity.instance(coefficients.intensity).data))
+    ScalarVolumeMeshField(shape.instance(coefficients.shape),
+                          warpReferenceIntensity(intensity.instance(coefficients.intensity).data))
   }
 
   override def sample()(implicit rnd: Random): ScalarVolumeMeshField[S] = {
@@ -69,6 +74,11 @@ case class SVIM[S: Scalar: TypeTag: ClassTag](referenceMeshField: ScalarVolumeMe
   }
 
   private def warpReferenceIntensity(scalarData: IndexedSeq[S]): ScalarArray[S] = {
-    ScalarArray[S](referenceMeshField.data.zip(ScalarArray[S](scalarData.toArray)).map { case (r, s) => Scalar[S].plus(r, s) }.toArray)
+    ScalarArray[S](
+      referenceMeshField.data
+        .zip(ScalarArray[S](scalarData.toArray))
+        .map { case (r, s) => Scalar[S].plus(r, s) }
+        .toArray
+    )
   }
 }

--- a/src/main/scala/scalismo/statisticalmodel/StatisticalVolumeIntensityModel.scala
+++ b/src/main/scala/scalismo/statisticalmodel/StatisticalVolumeIntensityModel.scala
@@ -13,8 +13,6 @@ trait StatisticalVolumeIntensityModel[S] {
 
   def referenceMesh: TetrahedralMesh3D
 
-  def referenceMeshField: ScalarVolumeMeshField[S]
-
   def shape: StatisticalVolumeMeshModel
 
   def intensity: DiscreteLowRankGaussianProcess[_3D, UnstructuredPointsDomain[_3D], S]
@@ -32,14 +30,14 @@ trait StatisticalVolumeIntensityModel[S] {
 
 object StatisticalVolumeIntensityModel {
 
-  def apply[S: Scalar: TypeTag: ClassTag](referenceMeshField: ScalarVolumeMeshField[S],
+  def apply[S: Scalar: TypeTag: ClassTag](referenceMesh: TetrahedralMesh3D,
     shape: StatisticalVolumeMeshModel, intensity: DiscreteLowRankGaussianProcess[_3D, UnstructuredPointsDomain[_3D], S]): SVIM[S] = {
-    SVIM(referenceMeshField, shape, intensity)
+    SVIM(referenceMesh, shape, intensity)
   }
 
 }
 
-case class SVIM[S: Scalar: TypeTag: ClassTag](referenceMeshField: ScalarVolumeMeshField[S],
+case class SVIM[S: Scalar: TypeTag: ClassTag](referenceMesh: TetrahedralMesh3D,
   shape: StatisticalVolumeMeshModel,
   intensity: DiscreteLowRankGaussianProcess[_3D, UnstructuredPointsDomain[_3D], S])
     extends StatisticalVolumeIntensityModel[S] {
@@ -66,11 +64,9 @@ case class SVIM[S: Scalar: TypeTag: ClassTag](referenceMeshField: ScalarVolumeMe
     require(colorComps >= 0 && colorComps <= intensity.rank, "illegal number of reduced color components")
 
     SVIM(
-      referenceMeshField,
+      referenceMesh,
       shape.truncate(shapeComps),
       intensity.truncate(colorComps)
     )
   }
-
-  override def referenceMesh: TetrahedralMesh3D = referenceMeshField.mesh
 }

--- a/src/main/scala/scalismo/statisticalmodel/StatisticalVolumeIntensityModel.scala
+++ b/src/main/scala/scalismo/statisticalmodel/StatisticalVolumeIntensityModel.scala
@@ -1,0 +1,100 @@
+package scalismo.statisticalmodel
+
+import breeze.linalg.DenseVector
+import scalismo.common._
+import scalismo.geometry._
+import scalismo.mesh._
+import scalismo.utils.Random
+
+import scala.reflect.ClassTag
+import scala.reflect.runtime.universe.TypeTag
+
+trait StatisticalVolumeIntensityModel[S] {
+
+  def referenceMesh: TetrahedralMesh3D
+
+  def referenceMeshField: ScalarVolumeMeshField[S]
+
+  def shape: StatisticalVolumeMeshModel
+
+  def intensity: DiscreteLowRankGaussianProcess[_3D, UnstructuredPointsDomain[_3D], S]
+
+  def landmarks: Map[String, Landmark[_3D]] = Map.empty[String, Landmark[_3D]]
+
+  def mean: ScalarVolumeMeshField[S]
+
+  def instance(coefficients: SVIMCoefficients): ScalarVolumeMeshField[S]
+
+  def sample()(implicit rnd: Random): ScalarVolumeMeshField[S]
+
+  def withLandmarks(landmarksMap: Map[String, Landmark[_3D]]): StatisticalVolumeIntensityModel[S]
+
+  def hasLandmarks: Boolean = landmarks.nonEmpty
+
+  def landmarkPointId(id: String): Option[PointId] = {
+    for {
+      lm <- landmarks.get(id)
+      id <- referenceMesh.pointSet.pointId(lm.point)
+    } yield id
+  }
+
+  def landmarksWithPointIds: Map[String, Option[PointId]] = landmarks.map { case (id, lm) => id -> referenceMesh.pointSet.pointId(lm.point) }
+
+  def landmarksWithClosestPointIds: Map[String, PointId] = landmarks.map { case (id, lm) => id -> referenceMesh.pointSet.findClosestPoint(lm.point).id }
+
+  def zeroCoefficients: SVIMCoefficients
+}
+
+object StatisticalVolumeIntensityModel {
+
+  def apply[S: Scalar: TypeTag: ClassTag](referenceMeshField: ScalarVolumeMeshField[S],
+    shape: StatisticalVolumeMeshModel, intensity: DiscreteLowRankGaussianProcess[_3D, UnstructuredPointsDomain[_3D], S],
+    landmarks: Map[String, Landmark[_3D]]): SVIM[S] = {
+    SVIM(referenceMeshField, shape, intensity, landmarks)
+  }
+
+  def apply[S: Scalar: TypeTag: ClassTag](referenceMeshField: ScalarVolumeMeshField[S],
+    shape: StatisticalVolumeMeshModel, intensity: DiscreteLowRankGaussianProcess[_3D, UnstructuredPointsDomain[_3D], S]): SVIM[S] = {
+    SVIM(referenceMeshField, shape, intensity, Map.empty)
+  }
+
+}
+
+case class SVIM[S: Scalar: TypeTag: ClassTag](referenceMeshField: ScalarVolumeMeshField[S],
+  shape: StatisticalVolumeMeshModel,
+  intensity: DiscreteLowRankGaussianProcess[_3D, UnstructuredPointsDomain[_3D], S],
+  override val landmarks: Map[String, Landmark[_3D]] = Map.empty[String, Landmark[_3D]])
+    extends StatisticalVolumeIntensityModel[S] {
+
+  override def mean: ScalarVolumeMeshField[S] = {
+    ScalarVolumeMeshField(shape.mean, intensity.mean.data)
+  }
+
+  override def instance(coefficients: SVIMCoefficients): ScalarVolumeMeshField[S] = {
+    ScalarVolumeMeshField(shape.instance(coefficients.shape), intensity.instance(coefficients.intensity).data)
+  }
+
+  override def sample()(implicit rnd: Random): ScalarVolumeMeshField[S] = {
+    ScalarVolumeMeshField(shape.sample(), intensity.sample().data)
+  }
+
+  override def withLandmarks(landmarksMap: Map[String, Landmark[_3D]]): SVIM[S] = SVIM(referenceMeshField, shape, intensity, landmarksMap)
+
+  override def zeroCoefficients: SVIMCoefficients = SVIMCoefficients(
+    DenseVector.zeros[Double](shape.rank),
+    DenseVector.zeros[Double](intensity.rank)
+  )
+
+  def truncate(shapeComps: Int, colorComps: Int): SVIM[S] = {
+    require(shapeComps >= 0 && shapeComps <= shape.rank, "illegal number of reduced shape components")
+    require(colorComps >= 0 && colorComps <= intensity.rank, "illegal number of reduced color components")
+
+    SVIM(
+      referenceMeshField,
+      shape.truncate(shapeComps),
+      intensity.truncate(colorComps),
+      landmarks)
+  }
+
+  override def referenceMesh: TetrahedralMesh3D = referenceMeshField.mesh
+}

--- a/src/main/scala/scalismo/statisticalmodel/StatisticalVolumeIntensityModel.scala
+++ b/src/main/scala/scalismo/statisticalmodel/StatisticalVolumeIntensityModel.scala
@@ -17,8 +17,6 @@ trait StatisticalVolumeIntensityModel[S] {
 
   def intensity: DiscreteLowRankGaussianProcess[_3D, UnstructuredPointsDomain[_3D], S]
 
-  def landmarks: Map[String, Landmark[_3D]] = Map.empty[String, Landmark[_3D]]
-
   def mean: ScalarVolumeMeshField[S]
 
   def instance(coefficients: SVIMCoefficients): ScalarVolumeMeshField[S]


### PR DESCRIPTION
This is a first implementation of a StatisticalVolumeIntensityModel. Dot not merge this pull-request yet, as many elements are still missing.

A simple model can be created from a reference ScalarVolumeMeshField, a StatisiticalVolumeMeshModel (shape) and a DiscreteLowRankGaussianProcess (intensity).

A vectorizer for objects of type Scalar is also provided. 