### PR TITLE
Fix remove scalariform

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,8 +3,6 @@ resolvers += Resolver.url("bintray-sbt-plugin-releases", url("http://dl.bintray.
 
 resolvers += "sonatype-releases" at "https://oss.sonatype.org/content/repositories/releases/"
 
-addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.3")
-
 addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.4.0")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.6.3")


### PR DESCRIPTION
Removes scalariform from the plugins. If it is not removed it breaks the new sfmt formatting when running `sbt test`.