### PR TITLE
make all triangle orientations consistent in a tetrahedron

### DIFF
--- a/src/main/scala/scalismo/mesh/TetrahedralMesh.scala
+++ b/src/main/scala/scalismo/mesh/TetrahedralMesh.scala
@@ -31,9 +31,9 @@ case class TetrahedralCell(ptId1: PointId, ptId2: PointId, ptId3: PointId, ptId4
 
   /** Ordered list of the triangles of the tetrahedron. */
   val triangles = Seq(TriangleCell(ptId1, ptId2, ptId3),
-                      TriangleCell(ptId1, ptId2, ptId4),
+                      TriangleCell(ptId1, ptId4, ptId2),
                       TriangleCell(ptId1, ptId3, ptId4),
-                      TriangleCell(ptId2, ptId3, ptId4))
+                      TriangleCell(ptId2, ptId4, ptId3))
 
   /** Returns true if @ptId is one of the point ids of the tetrahedral. */
   def containsPoint(ptId: PointId): Boolean = {


### PR DESCRIPTION
Currently the triangles specified in the TetrahedralCell do not have the same orientation. The normals do not consistently point outwards (or inwards) in the following example (the vertices 2 and 3 are more to the front and 1 and 4 more towards the back). This PR changes the orientation that the normals point all outwards in the shown example.
```scala
           3          
                      
          /|\         
         / | \        
        /  |  \       
       /   |   \      
      /    |    \     
     /     |     \    
    /      |      \   
 1  - - - -|- - - - 4 
    \      |      /   
     \     |     /    
      \    |    /     
       \   |   /      
        \  |  /       
         \ | /        
          \|/         
                      
           2          
```
Note: If the location of the points change, it can happen with this PR that all normals point inwards (e.g. vertex 4 change to the other side of the triangle 1,2,3). But also then with the PR the normals are consistently pointing inwards, without the PR they have different directions. If the normals point in- or outwards is just the tetrahedrons' orientation. This can be changed if the vertices are rotated by one (i.e. 1→2, 2→3, 3→4, and 4→1), and all normals would point outwards again if they pointed inwards before.