### PR TITLE
Adds BarycentricCoordinates4 for tetrahedrons

### DIFF
--- a/src/main/scala/scalismo/mesh/BarycentricCoordinates.scala
+++ b/src/main/scala/scalismo/mesh/BarycentricCoordinates.scala
@@ -111,3 +111,102 @@ object BarycentricCoordinates {
       new BarycentricCoordinates(1.0 - s, 1.0 - t, s + t - 1.0)
   }
 }
+
+/** barycentric coordinates for localization within a tetrahedron */
+case class BarycentricCoordinates4(a: Double, b: Double, c: Double, d: Double) {
+
+  def normalized: BarycentricCoordinates4 = {
+    val s = a + b + c + d
+    new BarycentricCoordinates4(a / s, b / s, c / s, d / s)
+  }
+
+  /** perform bcc interpolation: interpolate vertex values within triangle, needs Interpolation[T] */
+  def interpolateProperty[@specialized(Float, Double) A](v1: A, v2: A, v3: A, v4: A)(
+    implicit blender: ValueInterpolator[A]
+  ): A = {
+    blender.barycentricInterpolation(v1, a, v2, b, v3, c, v4, d)
+  }
+
+  def toArray = Array(a, b, c, d)
+}
+
+/** barycentric coordinates: localization within triangles */
+object BarycentricCoordinates4 {
+
+  /** coordinates of first vertex */
+  val v0 = new BarycentricCoordinates4(1.0, 0.0, 0.0, 0.0)
+
+  /** coordinates of second vertex */
+  val v1 = new BarycentricCoordinates4(0.0, 1.0, 0.0, 0.0)
+
+  /** coordinates of third vertex */
+  val v2 = new BarycentricCoordinates4(0.0, 0.0, 1.0, 0.0)
+
+  /** coordinates of forth vertex */
+  val v3 = new BarycentricCoordinates4(0.0, 0.0, 0.0, 1.0)
+
+  /** coordinates of center point in triangle */
+  val center = BarycentricCoordinates4(1.0, 1.0, 1.0, 1.0).normalized
+
+  /** get vertex coordinates, vertexIndex must be 0, 1, 2, or 3 */
+  def canonical(vertexIndex: Int): BarycentricCoordinates4 = (vertexIndex: @switch) match {
+    case 0 => v0
+    case 1 => v1
+    case 2 => v2
+    case 3 => v3
+    case _ => throw new IndexOutOfBoundsException("BarycentricCoordinates4 can only handle 4 vertices: 0-3")
+  }
+
+  def pointInTetrahedron(pt: Point[_3D],
+                         a: Point[_3D],
+                         b: Point[_3D],
+                         c: Point[_3D],
+                         d: Point[_3D]): BarycentricCoordinates4 = {
+    // following https://www.cdsimpson.net/2014/10/barycentric-coordinates.html
+    val vap = pt - a
+    val vbp = pt - b
+
+    val vab = b - a
+    val vac = c - a
+    val vad = d - a
+
+    val vbc = c - b
+    val vbd = d - b
+
+    def scalarTripleProduct(v1: EuclideanVector[_3D], v2: EuclideanVector[_3D], v3: EuclideanVector[_3D]): Double = {
+      v1.dot(v2.crossproduct(v3))
+    }
+
+    val va6 = scalarTripleProduct(vbp, vbd, vbc)
+    val vb6 = scalarTripleProduct(vap, vac, vad)
+    val vc6 = scalarTripleProduct(vap, vad, vab)
+    val vd6 = scalarTripleProduct(vap, vab, vac)
+    val v6 = 1.0 / scalarTripleProduct(vab, vac, vad)
+    BarycentricCoordinates4(va6 * v6, vb6 * v6, vc6 * v6, vd6 * v6)
+  }
+
+  /** Generate random barycentric coordinates, guaranteed to lie within the tetrahedron, uniformly distributed */
+  def randomUniform(implicit rng: Random): BarycentricCoordinates4 = {
+    var s = rng.scalaRandom.nextDouble()
+    var t = rng.scalaRandom.nextDouble()
+    var u = rng.scalaRandom.nextDouble()
+
+    if (s + t > 1) {
+      s = 1.0 - s
+      t = 1.0 - t
+    }
+
+    if (s + t + u > 1) {
+      val tu = u
+      if (t + u > 1) {
+        u = 1.0 - s - t
+        t = 1.0 - tu
+      } else {
+        u = s + t + u - 1.0
+        s = 1.0 - t - tu
+      }
+    }
+
+    BarycentricCoordinates4(1.0 - s - t - u, s, t, u)
+  }
+}

--- a/src/main/scala/scalismo/mesh/TetrahedralMesh.scala
+++ b/src/main/scala/scalismo/mesh/TetrahedralMesh.scala
@@ -142,16 +142,11 @@ case class TetrahedralMesh3D(pointSet: UnstructuredPointsDomain[_3D], tetrahedra
   /** Returns the Barycentric coordinates of a point inside the indicated cell. */
   def getBarycentricCoordinates(point: Point[_3D], tetrathedron: TetrahedralCell): Array[Double] = {
 
-    val a = pointSet.point(tetrathedron.ptId1).toVector
-    val b = pointSet.point(tetrathedron.ptId2).toVector
-    val c = pointSet.point(tetrathedron.ptId3).toVector
-    val d = pointSet.point(tetrathedron.ptId4).toVector
-
-    val barycentricCoordinates = new Array[Double](4)
-    val vtkTetra = new vtkTetra()
-    vtkTetra.BarycentricCoords(point.toArray, a.toArray, b.toArray, c.toArray, d.toArray, barycentricCoordinates)
-    vtkTetra.Delete()
-    barycentricCoordinates
+    val a = pointSet.point(tetrathedron.ptId1)
+    val b = pointSet.point(tetrathedron.ptId2)
+    val c = pointSet.point(tetrathedron.ptId3)
+    val d = pointSet.point(tetrathedron.ptId4)
+    BarycentricCoordinates4.pointInTetrahedron(point, a, b, c, d).toArray
   }
 
   /** Returns true for points within a tetrahedron defined by the indicated cell. */
@@ -186,31 +181,11 @@ case class TetrahedralMesh3D(pointSet: UnstructuredPointsDomain[_3D], tetrahedra
    * @param rnd implicit [[Random]] object
    */
   def samplePointInTetrahedralCell(tc: TetrahedralCell)(implicit rnd: Random): Point[_3D] = {
-    var s = rnd.scalaRandom.nextDouble()
-    var t = rnd.scalaRandom.nextDouble()
-    var u = rnd.scalaRandom.nextDouble()
-
-    if (s + t > 1) {
-      s = 1.0 - s
-      t = 1.0 - t
-    }
-
-    if (s + t + u > 1) {
-      val tu = u
-      if (t + u > 1) {
-        u = 1.0 - s - t
-        t = 1.0 - tu
-      } else {
-        u = s + t + u - 1.0
-        s = 1.0 - t - tu
-      }
-    }
-
-    val a = 1.0 - s - t - u
-    (a *: pointSet.point(tc.ptId1).toVector +
-      s *: pointSet.point(tc.ptId2).toVector +
-      t *: pointSet.point(tc.ptId3).toVector +
-      u *: pointSet.point(tc.ptId4).toVector).toPoint
+    val bc = BarycentricCoordinates4.randomUniform
+    (bc.a *: pointSet.point(tc.ptId1).toVector +
+      bc.b *: pointSet.point(tc.ptId2).toVector +
+      bc.c *: pointSet.point(tc.ptId3).toVector +
+      bc.d *: pointSet.point(tc.ptId4).toVector).toPoint
   }
 }
 

--- a/src/main/scala/scalismo/numerics/ValueInterpolator.scala
+++ b/src/main/scala/scalismo/numerics/ValueInterpolator.scala
@@ -48,6 +48,29 @@ trait ValueInterpolator[@specialized(Double, Float) A] {
       v3
   }
 
+  /** fast explicit barycentric interpolation, most used case of multiple blends */
+  def barycentricInterpolation(v1: A, f1: Double, v2: A, f2: Double, v3: A, f3: Double, v4: A, f4: Double): A = {
+    val f12 = f1 + f2
+    val f123 = f12 + f3
+    if (f123 > 0) {
+      blend(
+        if (f12 > 0) {
+          blend(
+            blend(v1, v2, f1 / f12),
+            v3,
+            f12 / (f3 + f12)
+          )
+        } else {
+          v3
+        },
+        v4,
+        f123 / (f4 + f123)
+      )
+    } else {
+      v4
+    }
+  }
+
   /** direct access to averaging function, warning: unstable for large sequences! (implement hierarchical blending for better stability) */
   def average(first: A, rest: A*): A = {
     var mix: A = first

--- a/src/test/scala/scalismo/mesh/BarycentricCoordinateTests.scala
+++ b/src/test/scala/scalismo/mesh/BarycentricCoordinateTests.scala
@@ -1,0 +1,124 @@
+package scalismo.mesh
+
+import scalismo.ScalismoTestSuite
+import scalismo.common.PointId
+import scalismo.geometry.{_3D, EuclideanVector, Point, Point3D}
+import scalismo.utils.Random
+import vtk.vtkTetra
+
+class BarycentricCoordinateTests extends ScalismoTestSuite {
+
+  implicit val rng: Random = Random(1024L)
+
+  def genPoint()(implicit rng: Random) = Point3D(
+    rng.scalaRandom.nextDouble() * 20 - 10,
+    rng.scalaRandom.nextDouble() * 20 - 10,
+    rng.scalaRandom.nextDouble() * 20 - 10
+  )
+
+  def determinantVectorsInRows(t: EuclideanVector[_3D], u: EuclideanVector[_3D], v: EuclideanVector[_3D]): Double =
+    t.x * u.y * v.z + u.x * v.y * t.z + v.x * t.y * u.z - t.x * v.y * u.z - v.x * u.y * t.z - u.x * t.y * v.z
+
+  def calculateSignedVolume(
+    a: Point3D,
+    b: Point3D,
+    c: Point3D,
+    d: Point3D
+  ): Double = {
+    val t = b - a
+    val u = c - a
+    val v = d - a
+    determinantVectorsInRows(t, u, v)
+  }
+
+  def generatePositiveOrientedSingleTetrahedronMesh(): TetrahedralMesh3D = {
+    val points = {
+      val points = IndexedSeq.fill(4)(genPoint)
+      if (calculateSignedVolume(points(0), points(1), points(2), points(3)) < 0) {
+        IndexedSeq(points(1), points(2), points(3), points(0))
+      } else
+        points
+    }
+    TetrahedralMesh3D(points,
+                      TetrahedralList(IndexedSeq(TetrahedralCell(PointId(0), PointId(1), PointId(2), PointId(3)))))
+  }
+
+  def getBarycentricCoordinatesFromVTK(a: Point[_3D],
+                                       b: Point[_3D],
+                                       c: Point[_3D],
+                                       d: Point[_3D],
+                                       point: Point[_3D]): IndexedSeq[Double] = {
+    val barycentricCoordinates = new Array[Double](4)
+    val vtkTetra = new vtkTetra()
+    vtkTetra.BarycentricCoords(point.toArray, a.toArray, b.toArray, c.toArray, d.toArray, barycentricCoordinates)
+    vtkTetra.Delete()
+    barycentricCoordinates.toIndexedSeq
+  }
+
+  describe("Barycentric coordinates for a tetrahedron") {
+
+    it("should return the same coordinates for a point as VTK") {
+      for (j <- 0 until 10) {
+        val tmesh = generatePositiveOrientedSingleTetrahedronMesh()
+        val cell = tmesh.cells.head
+        val a = tmesh.pointSet.point(cell.ptId1)
+        val b = tmesh.pointSet.point(cell.ptId2)
+        val c = tmesh.pointSet.point(cell.ptId3)
+        val d = tmesh.pointSet.point(cell.ptId4)
+        for (i <- 0 until 20) {
+          val randomPoint = genPoint()
+          val bc = BarycentricCoordinates4.pointInTetrahedron(randomPoint, a, b, c, d)
+          val bcVTK = getBarycentricCoordinatesFromVTK(a, b, c, d, randomPoint)
+
+          bc.a should be(bcVTK(0) +- 1e-13)
+        }
+      }
+    }
+
+    it("should calculate coordinates faster than using VTK") {
+
+      val tmesh = generatePositiveOrientedSingleTetrahedronMesh()
+      val cell = tmesh.cells.head
+      val a = tmesh.pointSet.point(cell.ptId1)
+      val b = tmesh.pointSet.point(cell.ptId2)
+      val c = tmesh.pointSet.point(cell.ptId3)
+      val d = tmesh.pointSet.point(cell.ptId4)
+
+      val N = 1000
+
+      val startVTK = System.currentTimeMillis()
+      for (i <- 0 until N) {
+        val randomPoint = genPoint()
+        val bcVTK = getBarycentricCoordinatesFromVTK(a, b, c, d, randomPoint)
+      }
+      val vtkTime = System.currentTimeMillis() - startVTK
+
+      val startScala = System.currentTimeMillis()
+      for (i <- 0 until N) {
+        val randomPoint = genPoint()
+        val bc = BarycentricCoordinates4.pointInTetrahedron(randomPoint, a, b, c, d)
+      }
+      val scalaTime = System.currentTimeMillis() - startScala
+
+      scalaTime should be < vtkTime
+    }
+
+    it("should reconstruct the point from the bc coordinates") {
+      val tmesh = generatePositiveOrientedSingleTetrahedronMesh()
+      val cell = tmesh.cells.head
+      val a = tmesh.pointSet.point(cell.ptId1)
+      val b = tmesh.pointSet.point(cell.ptId2)
+      val c = tmesh.pointSet.point(cell.ptId3)
+      val d = tmesh.pointSet.point(cell.ptId4)
+
+      for (i <- 0 until 1000) {
+        val randomPoint = genPoint()
+        val bc = BarycentricCoordinates4.pointInTetrahedron(randomPoint, a, b, c, d)
+        val pt = bc.a *: a.toVector + bc.b *: b.toVector + bc.c *: c.toVector + bc.d *: d.toVector
+
+        (randomPoint.toVector - pt).norm should be < 1e-8
+      }
+
+    }
+  }
+}


### PR DESCRIPTION
This PR adds the class BarycentricCoordinates4. The class represents the barycentric coordinates (bc) for a tetrahedron. With this class, the bc calculations can be made entirely in scala which is faster than accessing VTK.

Tests also cover that the calculation returns the same result as VTK, and that the calculation is faster than using VTK.