### PR TITLE
fixes BarycentricCoordinates for triangles in 3d

### DIFF
--- a/src/main/scala/scalismo/mesh/BarycentricCoordinates.scala
+++ b/src/main/scala/scalismo/mesh/BarycentricCoordinates.scala
@@ -87,9 +87,10 @@ object BarycentricCoordinates {
   }
 
   def pointInTriangle3D(point: Point[_3D], v1: Point[_3D], v2: Point[_3D], v3: Point[_3D]): BarycentricCoordinates = {
-    val a: EuclideanVector[_3D] = v2 - v1
-    val b: EuclideanVector[_3D] = v3 - v1
-    val c: EuclideanVector[_3D] = point - v1
+    val a = v2 - v1
+    val b = v3 - v1
+    val c = point - v1
+
     val d00 = a dot a
     val d01 = a dot b
     val d11 = b dot b
@@ -98,7 +99,8 @@ object BarycentricCoordinates {
     val d = d00 * d11 - d01 * d01
     val t = (d11 * d20 - d01 * d21) / d
     val s = (d00 * d21 - d01 * d20) / d
-    new BarycentricCoordinates(s, t, 1f - t - s)
+
+    new BarycentricCoordinates(1f - t - s, t, s)
   }
 
   /** Generate random barycentric coordinates, guaranteed to lie within the triangle, uniform distribution */

--- a/src/test/scala/scalismo/mesh/BarycentricCoordinateTests.scala
+++ b/src/test/scala/scalismo/mesh/BarycentricCoordinateTests.scala
@@ -2,13 +2,16 @@ package scalismo.mesh
 
 import scalismo.ScalismoTestSuite
 import scalismo.common.PointId
-import scalismo.geometry.{_3D, EuclideanVector, Point, Point3D}
+import scalismo.geometry.{_3D, Point, Point3D}
+import scalismo.mesh.boundingSpheres.BoundingSphereHelpers
 import scalismo.utils.Random
-import vtk.vtkTetra
+import vtk.{vtkTetra, vtkTriangle}
 
 class BarycentricCoordinateTests extends ScalismoTestSuite {
 
   implicit val rng: Random = Random(1024L)
+
+  val epsilon = 1.0e-8
 
   def genPoint()(implicit rng: Random) = Point3D(
     rng.scalaRandom.nextDouble() * 20 - 10,
@@ -16,31 +19,30 @@ class BarycentricCoordinateTests extends ScalismoTestSuite {
     rng.scalaRandom.nextDouble() * 20 - 10
   )
 
-  def determinantVectorsInRows(t: EuclideanVector[_3D], u: EuclideanVector[_3D], v: EuclideanVector[_3D]): Double =
-    t.x * u.y * v.z + u.x * v.y * t.z + v.x * t.y * u.z - t.x * v.y * u.z - v.x * u.y * t.z - u.x * t.y * v.z
-
-  def calculateSignedVolume(
-    a: Point3D,
-    b: Point3D,
-    c: Point3D,
-    d: Point3D
-  ): Double = {
-    val t = b - a
-    val u = c - a
-    val v = d - a
-    determinantVectorsInRows(t, u, v)
-  }
-
   def generatePositiveOrientedSingleTetrahedronMesh(): TetrahedralMesh3D = {
     val points = {
       val points = IndexedSeq.fill(4)(genPoint)
-      if (calculateSignedVolume(points(0), points(1), points(2), points(3)) < 0) {
+      if (BoundingSphereHelpers.calculateSignedVolume(points(0).toVector,
+                                                      points(1).toVector,
+                                                      points(2).toVector,
+                                                      points(3).toVector) < 0) {
         IndexedSeq(points(1), points(2), points(3), points(0))
       } else
         points
     }
     TetrahedralMesh3D(points,
                       TetrahedralList(IndexedSeq(TetrahedralCell(PointId(0), PointId(1), PointId(2), PointId(3)))))
+  }
+
+  def getBarycentricCoordinatesFromVTK(a: Point[_3D],
+                                       b: Point[_3D],
+                                       c: Point[_3D],
+                                       point: Point[_3D]): IndexedSeq[Double] = {
+    val barycentricCoordinates = new Array[Double](3)
+    val vtkTriangle = new vtkTriangle()
+    vtkTriangle.BarycentricCoords(point.toArray, a.toArray, b.toArray, c.toArray, barycentricCoordinates)
+    vtkTriangle.Delete()
+    barycentricCoordinates.toIndexedSeq
   }
 
   def getBarycentricCoordinatesFromVTK(a: Point[_3D],
@@ -53,6 +55,101 @@ class BarycentricCoordinateTests extends ScalismoTestSuite {
     vtkTetra.BarycentricCoords(point.toArray, a.toArray, b.toArray, c.toArray, d.toArray, barycentricCoordinates)
     vtkTetra.Delete()
     barycentricCoordinates.toIndexedSeq
+  }
+
+  describe("Barycentric coordinates for a triangle") {
+
+    it("should calculate the same values as defined for the vertices") {
+      for (j <- 0 until 10) {
+        val a = genPoint()
+        val b = genPoint()
+        val c = genPoint()
+
+        {
+          val bc = BarycentricCoordinates.pointInTriangle3D(a, a, b, c)
+          val bcDef = BarycentricCoordinates.v0
+
+          bc.a should be(bcDef.a +- epsilon)
+          bc.b should be(bcDef.b +- epsilon)
+          bc.c should be(bcDef.c +- epsilon)
+        }
+
+        {
+          val bc = BarycentricCoordinates.pointInTriangle3D(a, a, b, c)
+          val bcDef = BarycentricCoordinates.v0
+
+          bc.a should be(bcDef.a +- epsilon)
+          bc.b should be(bcDef.b +- epsilon)
+          bc.c should be(bcDef.c +- epsilon)
+        }
+
+        {
+          val bc = BarycentricCoordinates.pointInTriangle3D(a, a, b, c)
+          val bcDef = BarycentricCoordinates.v0
+
+          bc.a should be(bcDef.a +- epsilon)
+          bc.b should be(bcDef.b +- epsilon)
+          bc.c should be(bcDef.c +- epsilon)
+        }
+      }
+    }
+
+    it("should return the same coordinates for a point as VTK") {
+      for (j <- 0 until 10) {
+        val a = genPoint()
+        val b = genPoint()
+        val c = genPoint()
+        for (i <- 0 until 20) {
+          val randomBC = BarycentricCoordinates.randomUniform
+          val randomPointInTriangle =
+            (a.toVector * randomBC.a + b.toVector * randomBC.b + c.toVector * randomBC.c).toPoint
+          val bc = BarycentricCoordinates.pointInTriangle3D(randomPointInTriangle, a, b, c)
+          val bcVTK = getBarycentricCoordinatesFromVTK(a, b, c, randomPointInTriangle)
+
+          bc.a should be(bcVTK(0) +- epsilon)
+          bc.b should be(bcVTK(1) +- epsilon)
+          bc.c should be(bcVTK(2) +- epsilon)
+        }
+      }
+    }
+
+    it("should return the same coordinates in 2d as in 3d for flat triangles") {
+      for (j <- 0 until 10) {
+        val a = genPoint.copy(z = 0.0)
+        val b = genPoint.copy(z = 0.0)
+        val c = genPoint.copy(z = 0.0)
+
+        def to2d(pt: Point[_3D]) = Point(pt.x, pt.y)
+
+        for (i <- 0 until 20) {
+          val randomPoint = genPoint.copy(z = 0.0)
+          val bc3D = BarycentricCoordinates.pointInTriangle3D(randomPoint, a, b, c)
+          val bc2D = BarycentricCoordinates.pointInTriangle(to2d(randomPoint), to2d(a), to2d(b), to2d(c))
+
+          bc3D.a should be(bc2D.a +- epsilon)
+          bc3D.b should be(bc2D.b +- epsilon)
+          bc3D.c should be(bc2D.c +- epsilon)
+        }
+      }
+    }
+
+    it("should calculate the barycentric coordinates form the generated point") {
+      for (j <- 0 until 10) {
+        val a = genPoint()
+        val b = genPoint()
+        val c = genPoint()
+        for (i <- 0 until 20) {
+          val randomBC = BarycentricCoordinates.randomUniform
+          val pointFromBC =
+            (a.toVector * randomBC.a + b.toVector * randomBC.b + c.toVector * randomBC.c).toPoint
+          val bc = BarycentricCoordinates.pointInTriangle3D(pointFromBC, a, b, c)
+
+          bc.a should be(randomBC.a +- epsilon)
+          bc.b should be(randomBC.b +- epsilon)
+          bc.c should be(randomBC.c +- epsilon)
+        }
+      }
+    }
   }
 
   describe("Barycentric coordinates for a tetrahedron") {
@@ -70,7 +167,10 @@ class BarycentricCoordinateTests extends ScalismoTestSuite {
           val bc = BarycentricCoordinates4.pointInTetrahedron(randomPoint, a, b, c, d)
           val bcVTK = getBarycentricCoordinatesFromVTK(a, b, c, d, randomPoint)
 
-          bc.a should be(bcVTK(0) +- 1e-13)
+          bc.a should be(bcVTK(0) +- epsilon)
+          bc.b should be(bcVTK(1) +- epsilon)
+          bc.c should be(bcVTK(2) +- epsilon)
+          bc.d should be(bcVTK(3) +- epsilon)
         }
       }
     }


### PR DESCRIPTION
BarycentricCoordinates for triangles in 3d where broken. Now the BCs are tested, compared against some well-defined cases and against the VTK implementation.

This PR adds:
- Tests for the BC of a triangle in 2d and 3d.
- Moves some function from the tests of the BC to the BoundingSpheres as it will be used later in a following PR.
- Cleans up some parts of the BoundingSpheres.