### PR TITLE
adding closest point calculations for tetrahedral mesh with test cove…

### DIFF
--- a/src/main/scala/scalismo/mesh/MeshOperations.scala
+++ b/src/main/scala/scalismo/mesh/MeshOperations.scala
@@ -54,7 +54,7 @@ class TriangleMesh3DOperations(private val mesh: TriangleMesh3D) {
   def shortestDistanceToSurfaceSquared(point: Point[_3D]): Double =
     closestPointOnSurface.getSquaredShortestDistance(point: Point[_3D])
   def closestPoint(point: Point[_3D]): ClosestPoint = closestPointOnSurface.getClosestPoint(point)
-  def closestPointOnSurface(point: Point[_3D]): ClosestPointOnSurface =
+  def closestPointOnSurface(point: Point[_3D]): ClosestPointWithSquaredDistance =
     closestPointOnSurface.getClosestPointOnSurface(point)
 
   /**
@@ -226,6 +226,14 @@ class TetrahedralMesh3DOperations(private val mesh: TetrahedralMesh[_3D]) {
    */
   private lazy val tetrahedrons = BoundingSpheres.tetrahedronListFromTetrahedralMesh3D(mesh)
   private lazy val boundingSpheres = BoundingSpheres.createForTetrahedrons(tetrahedrons)
+
+  private lazy val closestPointIndex: VolumeSpatialIndex[_3D] =
+    new TetrahedralMesh3DSpatialIndex(boundingSpheres, mesh, tetrahedrons)
+  def shortestDistanceToVolumeSquared(point: Point[_3D]): Double =
+    closestPointIndex.getSquaredShortestDistance(point: Point[_3D])
+  def closestPoint(point: Point[_3D]): ClosestPoint = closestPointIndex.getClosestPoint(point)
+  def closestPointToVolume(point: Point[_3D]): ClosestPointWithSquaredDistance =
+    closestPointIndex.getClosestPointToVolume(point)
 
   private lazy val intersect: TetrahedralizedVolumeIntersectionIndex[_3D] =
     new LineTetrahedralMesh3DIntersectionIndex(boundingSpheres, mesh, tetrahedrons)

--- a/src/main/scala/scalismo/mesh/MeshOperations.scala
+++ b/src/main/scala/scalismo/mesh/MeshOperations.scala
@@ -54,7 +54,7 @@ class TriangleMesh3DOperations(private val mesh: TriangleMesh3D) {
   def shortestDistanceToSurfaceSquared(point: Point[_3D]): Double =
     closestPointOnSurface.getSquaredShortestDistance(point: Point[_3D])
   def closestPoint(point: Point[_3D]): ClosestPoint = closestPointOnSurface.getClosestPoint(point)
-  def closestPointOnSurface(point: Point[_3D]): ClosestPointWithSquaredDistance =
+  def closestPointOnSurface(point: Point[_3D]): ClosestPointSpecialized =
     closestPointOnSurface.getClosestPointOnSurface(point)
 
   /**
@@ -232,7 +232,7 @@ class TetrahedralMesh3DOperations(private val mesh: TetrahedralMesh[_3D]) {
   def shortestDistanceToVolumeSquared(point: Point[_3D]): Double =
     closestPointIndex.getSquaredShortestDistance(point: Point[_3D])
   def closestPoint(point: Point[_3D]): ClosestPoint = closestPointIndex.getClosestPoint(point)
-  def closestPointToVolume(point: Point[_3D]): ClosestPointWithSquaredDistance =
+  def closestPointToVolume(point: Point[_3D]): ClosestPointSpecialized =
     closestPointIndex.getClosestPointToVolume(point)
 
   private lazy val intersect: TetrahedralizedVolumeIntersectionIndex[_3D] =

--- a/src/main/scala/scalismo/mesh/MeshOperations.scala
+++ b/src/main/scala/scalismo/mesh/MeshOperations.scala
@@ -54,7 +54,7 @@ class TriangleMesh3DOperations(private val mesh: TriangleMesh3D) {
   def shortestDistanceToSurfaceSquared(point: Point[_3D]): Double =
     closestPointOnSurface.getSquaredShortestDistance(point: Point[_3D])
   def closestPoint(point: Point[_3D]): ClosestPoint = closestPointOnSurface.getClosestPoint(point)
-  def closestPointOnSurface(point: Point[_3D]): ClosestPointSpecialized =
+  def closestPointOnSurface(point: Point[_3D]): ClosestPointWithType =
     closestPointOnSurface.getClosestPointOnSurface(point)
 
   /**
@@ -232,7 +232,7 @@ class TetrahedralMesh3DOperations(private val mesh: TetrahedralMesh[_3D]) {
   def shortestDistanceToVolumeSquared(point: Point[_3D]): Double =
     closestPointIndex.getSquaredShortestDistance(point: Point[_3D])
   def closestPoint(point: Point[_3D]): ClosestPoint = closestPointIndex.getClosestPoint(point)
-  def closestPointToVolume(point: Point[_3D]): ClosestPointSpecialized =
+  def closestPointToVolume(point: Point[_3D]): ClosestPointWithType =
     closestPointIndex.getClosestPointToVolume(point)
 
   private lazy val intersect: TetrahedralizedVolumeIntersectionIndex[_3D] =

--- a/src/main/scala/scalismo/mesh/boundingSpheres/BSDistance.scala
+++ b/src/main/scala/scalismo/mesh/boundingSpheres/BSDistance.scala
@@ -17,9 +17,8 @@ package scalismo.mesh.boundingSpheres
 
 import breeze.numerics.abs
 import scalismo.geometry.{_3D, EuclideanVector}
-import scalismo.mesh.boundingSpheres.SurfaceSpatialIndex.SurfaceClosestPointType._
-import scalismo.mesh.boundingSpheres.VolumeSpatialIndex.VolumeClosestPointType
-import scalismo.mesh.boundingSpheres.VolumeSpatialIndex.VolumeClosestPointType.VolumeClosestPointType
+import scalismo.mesh.boundingSpheres.SurfaceClosestPointType._
+import scalismo.mesh.boundingSpheres.VolumeClosestPointType.VolumeClosestPointType
 
 /**
  * Holds triangles and precalculated vectors.

--- a/src/main/scala/scalismo/mesh/boundingSpheres/BoundingSpheres.scala
+++ b/src/main/scala/scalismo/mesh/boundingSpheres/BoundingSpheres.scala
@@ -19,7 +19,6 @@ import breeze.linalg.max
 import breeze.numerics.{abs, pow, sqrt}
 import scalismo.geometry.{_3D, EuclideanVector, Point}
 import scalismo.mesh.{TetrahedralMesh, TriangleMesh3D}
-import vtk.vtkTetra
 
 import scala.annotation.tailrec
 
@@ -355,15 +354,11 @@ private object Sphere {
   }
 
   /**
-   * Create sphere around a tetrahedron
+   * Create sphere around a triangle
    */
   def fromTetrahedron(tetrahedron: Tetrahedron): Sphere = {
-    val center = new Array[Double](3)
-    val t = new vtkTetra()
-    val sphereradus =
-      t.Circumsphere(tetrahedron.a.toArray, tetrahedron.b.toArray, tetrahedron.c.toArray, tetrahedron.d.toArray, center)
-    val c = EuclideanVector(center(0), center(1), center(2))
-    new Sphere(c, sphereradus)
+    val (center, r2) = minContainmentSphere(tetrahedron.a, tetrahedron.b, tetrahedron.c, tetrahedron.d)
+    Sphere(center, r2)
   }
 
 }
@@ -504,20 +499,113 @@ private[mesh] object BoundingSphereHelpers {
   /**
    * Calculate sphere around four points, e.g. a tetrahedron
    */
-  def tetrahedronCircumSphere(a: EuclideanVector[_3D],
-                              b: EuclideanVector[_3D],
-                              c: EuclideanVector[_3D],
-                              d: EuclideanVector[_3D]): (EuclideanVector[_3D], Double) = {
+  def minContainmentSphere(a: EuclideanVector[_3D],
+                           b: EuclideanVector[_3D],
+                           c: EuclideanVector[_3D],
+                           d: EuclideanVector[_3D]): (EuclideanVector[_3D], Double) = {
 
-    val v = Array[Double](3)
-    val tetra = new vtkTetra()
+    val triangles = IndexedSeq(
+      IndexedSeq(a, b, c),
+      IndexedSeq(a, d, b),
+      IndexedSeq(a, c, d),
+      IndexedSeq(b, d, c)
+    )
 
-    val redius = tetra.Circumsphere(a.toArray, b.toArray, c.toArray, d.toArray, v)
+    def testOrientation(circumCenter: EuclideanVector[_3D],
+                        a: EuclideanVector[_3D],
+                        b: EuclideanVector[_3D],
+                        c: EuclideanVector[_3D],
+                        d: EuclideanVector[_3D]): Seq[Double] = {
+      val signedTetrahedronVolume = calculateSignedVolume(a, b, c, d)
+      triangles
+        .map { t =>
+          calculateSignedVolume(circumCenter, t(0), t(1), t(2))
+        }
+        .map(_ * Math.signum(signedTetrahedronVolume))
+    }
 
-    (EuclideanVector(v(0), v(1), v(2)), redius)
+    val tetrahedronCircumsphere = calculateCircumsphere(a, b, c, d)
+    val directionTests = testOrientation(tetrahedronCircumsphere._1, a, b, c, d)
 
+    directionTests.count(_ <= 0) match {
+      case 4 => { // circum-center is inside the tetrahedron, no better possibility
+        tetrahedronCircumsphere
+      }
+      case 3 => { // circum-center is outside / on the wrong side of one triangle, use its circum-sphere
+        val t = triangles(directionTests.indexWhere(_ > 0))
+        minContainmentSphere(t(0), t(1), t(2))
+      }
+      case 2 => { // circum-center is outside / on the wrong side of two triangles
+        val i1 = directionTests.indexWhere(_ > 0)
+        val points1 = triangles(i1)
+        val i2 = directionTests.indexWhere(_ > 0, i1 + 1)
+        val points2 = triangles(i2)
+
+        val commonPoints = points1.filter(pt => {
+          points2.contains(pt)
+        })
+
+        val sphereContainingLine = minContainmentSphere(commonPoints(0), commonPoints(1))
+
+        val pts =
+          IndexedSeq(a, b, c, d).filter { p =>
+            !sphereContainsPoint(p, sphereContainingLine._1, Math.sqrt(sphereContainingLine._2))
+          }
+
+        if (pts.size > 0) {
+          minContainmentSphere(commonPoints.head, commonPoints.last, pts.head)
+        } else {
+          sphereContainingLine
+        }
+      }
+      case _ =>
+        throw new Exception(
+          "It should never be the case that more orientations are negative than 2."
+        )
+    }
   }
 
+  /**
+   * Calculate circumsphere, i.e. the sphere which touches all four points.
+   */
+  def calculateCircumsphere(
+    a: EuclideanVector[_3D],
+    b: EuclideanVector[_3D],
+    c: EuclideanVector[_3D],
+    d: EuclideanVector[_3D]
+  ): (EuclideanVector[_3D], Double) = {
+
+    val t = a - d
+    val u = b - d
+    val v = c - d
+
+    val q = u.crossproduct(v) * t.norm2 + v.crossproduct(t) * u.norm2 + t
+      .crossproduct(u) * v.norm2
+
+    val det2 = 2.0 * determinantVectorsInRows(t, u, v)
+    val center = d + q / det2
+    val radius = (q / det2).norm2
+    (center, radius)
+  }
+
+  /**
+   * Checks weather all points lie within the sphere described by the center and the radius.
+   */
+  def sphereContainsPoints(points: IndexedSeq[EuclideanVector[_3D]], center: EuclideanVector[_3D], radius: Double) = {
+    points.forall(pt => sphereContainsPoint(pt, center, radius))
+  }
+
+  /**
+   * Checks weather the point lies within the sphere described by the center and the radius.
+   */
+  def sphereContainsPoint(point: EuclideanVector[_3D], center: EuclideanVector[_3D], radius: Double) = {
+    val dist = (point - center).norm
+    dist - radius < 1e-8
+  }
+
+  /**
+   * Calculates the signed volume of the tetrahedron, i.e. if all normals point in- or out-wards
+   */
   def calculateSignedVolume(a: EuclideanVector[_3D],
                             b: EuclideanVector[_3D],
                             c: EuclideanVector[_3D],

--- a/src/main/scala/scalismo/mesh/boundingSpheres/ClosestPoint.scala
+++ b/src/main/scala/scalismo/mesh/boundingSpheres/ClosestPoint.scala
@@ -32,7 +32,7 @@ case class ClosestPoint(point: Point[_3D], distanceSquared: Double) {
     this.distanceSquared < that.distanceSquared
   }
 
-  def <(that: ClosestPointSpecialized): Boolean = {
+  def <(that: ClosestPointWithType): Boolean = {
     this.distanceSquared < that.distanceSquared
   }
 }
@@ -42,9 +42,9 @@ case class ClosestPoint(point: Point[_3D], distanceSquared: Double) {
  * @param point The closest point location on the surface.
  * @param distanceSquared The squared distance to the closest point location.
  */
-sealed abstract class ClosestPointSpecialized(val point: Point[_3D], val distanceSquared: Double) {
+sealed abstract class ClosestPointWithType(val point: Point[_3D], val distanceSquared: Double) {
 
-  def <(that: ClosestPointSpecialized): Boolean = {
+  def <(that: ClosestPointWithType): Boolean = {
     this.distanceSquared < that.distanceSquared
   }
 
@@ -57,7 +57,7 @@ sealed abstract class ClosestPointSpecialized(val point: Point[_3D], val distanc
  * @param pid PointId of the closest vertex.
  */
 case class ClosestPointIsVertex(override val point: Point[_3D], override val distanceSquared: Double, pid: PointId)
-    extends ClosestPointSpecialized(point, distanceSquared)
+    extends ClosestPointWithType(point, distanceSquared)
 
 /**
  * The closest point lies on a line.
@@ -69,7 +69,7 @@ case class ClosestPointOnLine(override val point: Point[_3D],
                               override val distanceSquared: Double,
                               pids: (PointId, PointId),
                               bc: Double)
-    extends ClosestPointSpecialized(point, distanceSquared)
+    extends ClosestPointWithType(point, distanceSquared)
 
 /**
  * The closest point is a vertex.
@@ -81,14 +81,14 @@ case class ClosestPointInTriangle(override val point: Point[_3D],
                                   override val distanceSquared: Double,
                                   tid: TriangleId,
                                   bc: BarycentricCoordinates)
-    extends ClosestPointSpecialized(point, distanceSquared)
+    extends ClosestPointWithType(point, distanceSquared)
 
 case class ClosestPointInTriangleOfTetrahedron(override val point: Point[_3D],
                                                override val distanceSquared: Double,
                                                tetId: TetrahedronId,
                                                triId: TriangleId,
                                                bc: BarycentricCoordinates)
-    extends ClosestPointSpecialized(point, distanceSquared)
+    extends ClosestPointWithType(point, distanceSquared)
 
 /**
  * The closest point is a vertex.
@@ -100,4 +100,4 @@ case class ClosestPointInTetrahedron(override val point: Point[_3D],
                                      override val distanceSquared: Double,
                                      tid: TetrahedronId,
                                      bc: BarycentricCoordinates4)
-    extends ClosestPointSpecialized(point, distanceSquared)
+    extends ClosestPointWithType(point, distanceSquared)

--- a/src/main/scala/scalismo/mesh/boundingSpheres/ClosestPoint.scala
+++ b/src/main/scala/scalismo/mesh/boundingSpheres/ClosestPoint.scala
@@ -17,7 +17,7 @@ package scalismo.mesh.boundingSpheres
 
 import scalismo.common.PointId
 import scalismo.geometry.{_3D, Point}
-import scalismo.mesh.{BarycentricCoordinates, TetrahedronId, TriangleId}
+import scalismo.mesh.{BarycentricCoordinates, BarycentricCoordinates4, TetrahedronId, TriangleId}
 
 /**
  * A class that contains the location and the distance to the closest point on a surface.
@@ -26,7 +26,7 @@ import scalismo.mesh.{BarycentricCoordinates, TetrahedronId, TriangleId}
  */
 case class ClosestPoint(point: Point[_3D], distanceSquared: Double) {
 
-  def <(that: ClosestPointOnSurface): Boolean = {
+  def <(that: ClosestPointWithSquaredDistance): Boolean = {
     this.distanceSquared < that.distanceSquared
   }
 }
@@ -36,9 +36,9 @@ case class ClosestPoint(point: Point[_3D], distanceSquared: Double) {
  * @param point The closest point location on the surface.
  * @param distanceSquared The squared distance to the closest point location.
  */
-sealed abstract class ClosestPointOnSurface(val point: Point[_3D], val distanceSquared: Double) {
+sealed abstract class ClosestPointWithSquaredDistance(val point: Point[_3D], val distanceSquared: Double) {
 
-  def <(that: ClosestPointOnSurface): Boolean = {
+  def <(that: ClosestPointWithSquaredDistance): Boolean = {
     this.distanceSquared < that.distanceSquared
   }
 }
@@ -49,7 +49,7 @@ sealed abstract class ClosestPointOnSurface(val point: Point[_3D], val distanceS
  * @param pid PointId of the closest vertex.
  */
 case class ClosestPointIsVertex(override val point: Point[_3D], override val distanceSquared: Double, pid: PointId)
-    extends ClosestPointOnSurface(point, distanceSquared)
+    extends ClosestPointWithSquaredDistance(point, distanceSquared)
 
 /**
  * The closest point lies on a line.
@@ -61,7 +61,7 @@ case class ClosestPointOnLine(override val point: Point[_3D],
                               override val distanceSquared: Double,
                               pids: (PointId, PointId),
                               bc: Double)
-    extends ClosestPointOnSurface(point, distanceSquared)
+    extends ClosestPointWithSquaredDistance(point, distanceSquared)
 
 /**
  * The closest point is a vertex.
@@ -73,7 +73,14 @@ case class ClosestPointInTriangle(override val point: Point[_3D],
                                   override val distanceSquared: Double,
                                   tid: TriangleId,
                                   bc: BarycentricCoordinates)
-    extends ClosestPointOnSurface(point, distanceSquared)
+    extends ClosestPointWithSquaredDistance(point, distanceSquared)
+
+case class ClosestPointInTriangleOfTetrahedron(override val point: Point[_3D],
+                                               override val distanceSquared: Double,
+                                               tetId: TetrahedronId,
+                                               triId: TriangleId,
+                                               bc: BarycentricCoordinates)
+    extends ClosestPointWithSquaredDistance(point, distanceSquared)
 
 /**
  * The closest point is a vertex.
@@ -84,5 +91,5 @@ case class ClosestPointInTriangle(override val point: Point[_3D],
 case class ClosestPointInTetrahedron(override val point: Point[_3D],
                                      override val distanceSquared: Double,
                                      tid: TetrahedronId,
-                                     bc: BarycentricCoordinates)
-    extends ClosestPointOnSurface(point, distanceSquared)
+                                     bc: BarycentricCoordinates4)
+    extends ClosestPointWithSquaredDistance(point, distanceSquared)

--- a/src/main/scala/scalismo/mesh/boundingSpheres/ClosestPoint.scala
+++ b/src/main/scala/scalismo/mesh/boundingSpheres/ClosestPoint.scala
@@ -26,7 +26,13 @@ import scalismo.mesh.{BarycentricCoordinates, BarycentricCoordinates4, Tetrahedr
  */
 case class ClosestPoint(point: Point[_3D], distanceSquared: Double) {
 
-  def <(that: ClosestPointWithSquaredDistance): Boolean = {
+  def distance = Math.sqrt(distanceSquared)
+
+  def <(that: ClosestPoint): Boolean = {
+    this.distanceSquared < that.distanceSquared
+  }
+
+  def <(that: ClosestPointSpecialized): Boolean = {
     this.distanceSquared < that.distanceSquared
   }
 }
@@ -36,11 +42,13 @@ case class ClosestPoint(point: Point[_3D], distanceSquared: Double) {
  * @param point The closest point location on the surface.
  * @param distanceSquared The squared distance to the closest point location.
  */
-sealed abstract class ClosestPointWithSquaredDistance(val point: Point[_3D], val distanceSquared: Double) {
+sealed abstract class ClosestPointSpecialized(val point: Point[_3D], val distanceSquared: Double) {
 
-  def <(that: ClosestPointWithSquaredDistance): Boolean = {
+  def <(that: ClosestPointSpecialized): Boolean = {
     this.distanceSquared < that.distanceSquared
   }
+
+  def distance = Math.sqrt(distanceSquared)
 }
 
 /**
@@ -49,7 +57,7 @@ sealed abstract class ClosestPointWithSquaredDistance(val point: Point[_3D], val
  * @param pid PointId of the closest vertex.
  */
 case class ClosestPointIsVertex(override val point: Point[_3D], override val distanceSquared: Double, pid: PointId)
-    extends ClosestPointWithSquaredDistance(point, distanceSquared)
+    extends ClosestPointSpecialized(point, distanceSquared)
 
 /**
  * The closest point lies on a line.
@@ -61,7 +69,7 @@ case class ClosestPointOnLine(override val point: Point[_3D],
                               override val distanceSquared: Double,
                               pids: (PointId, PointId),
                               bc: Double)
-    extends ClosestPointWithSquaredDistance(point, distanceSquared)
+    extends ClosestPointSpecialized(point, distanceSquared)
 
 /**
  * The closest point is a vertex.
@@ -73,14 +81,14 @@ case class ClosestPointInTriangle(override val point: Point[_3D],
                                   override val distanceSquared: Double,
                                   tid: TriangleId,
                                   bc: BarycentricCoordinates)
-    extends ClosestPointWithSquaredDistance(point, distanceSquared)
+    extends ClosestPointSpecialized(point, distanceSquared)
 
 case class ClosestPointInTriangleOfTetrahedron(override val point: Point[_3D],
                                                override val distanceSquared: Double,
                                                tetId: TetrahedronId,
                                                triId: TriangleId,
                                                bc: BarycentricCoordinates)
-    extends ClosestPointWithSquaredDistance(point, distanceSquared)
+    extends ClosestPointSpecialized(point, distanceSquared)
 
 /**
  * The closest point is a vertex.
@@ -92,4 +100,4 @@ case class ClosestPointInTetrahedron(override val point: Point[_3D],
                                      override val distanceSquared: Double,
                                      tid: TetrahedronId,
                                      bc: BarycentricCoordinates4)
-    extends ClosestPointWithSquaredDistance(point, distanceSquared)
+    extends ClosestPointSpecialized(point, distanceSquared)

--- a/src/main/scala/scalismo/mesh/boundingSpheres/SurfaceSpatialIndex.scala
+++ b/src/main/scala/scalismo/mesh/boundingSpheres/SurfaceSpatialIndex.scala
@@ -55,7 +55,7 @@ trait SurfaceSpatialIndex[D] extends SpatialIndex[D] {
    *
    * @return A desciption of the closest point.
    */
-  def getClosestPointOnSurface(pt: Point[D]): ClosestPointWithSquaredDistance
+  def getClosestPointOnSurface(pt: Point[D]): ClosestPointSpecialized
 }
 
 /**
@@ -137,7 +137,7 @@ private[mesh] class TriangleMesh3DSpatialIndex(private val bs: BoundingSphere,
   /**
    * Returns a description of the closest Point on the surface.
    */
-  override def getClosestPointOnSurface(point: Point[_3D]): ClosestPointWithSquaredDistance = {
+  override def getClosestPointOnSurface(point: Point[_3D]): ClosestPointSpecialized = {
 
     _getClosestPoint(point)
 

--- a/src/main/scala/scalismo/mesh/boundingSpheres/SurfaceSpatialIndex.scala
+++ b/src/main/scala/scalismo/mesh/boundingSpheres/SurfaceSpatialIndex.scala
@@ -55,7 +55,7 @@ trait SurfaceSpatialIndex[D] extends SpatialIndex[D] {
    *
    * @return A desciption of the closest point.
    */
-  def getClosestPointOnSurface(pt: Point[D]): ClosestPointSpecialized
+  def getClosestPointOnSurface(pt: Point[D]): ClosestPointWithType
 }
 
 /**
@@ -137,7 +137,7 @@ private[mesh] class TriangleMesh3DSpatialIndex(private val bs: BoundingSphere,
   /**
    * Returns a description of the closest Point on the surface.
    */
-  override def getClosestPointOnSurface(point: Point[_3D]): ClosestPointSpecialized = {
+  override def getClosestPointOnSurface(point: Point[_3D]): ClosestPointWithType = {
 
     _getClosestPoint(point)
 

--- a/src/main/scala/scalismo/mesh/boundingSpheres/SurfaceSpatialIndex.scala
+++ b/src/main/scala/scalismo/mesh/boundingSpheres/SurfaceSpatialIndex.scala
@@ -58,18 +58,15 @@ trait SurfaceSpatialIndex[D] extends SpatialIndex[D] {
   def getClosestPointOnSurface(pt: Point[D]): ClosestPointWithSquaredDistance
 }
 
-object SurfaceSpatialIndex {
-
-  /**
-   * Type of the closest point. At the moment the names are only suited for a triangular mesh.
-   */
-  private[boundingSpheres] object SurfaceClosestPointType extends Enumeration {
-    type SurfaceClosestPointType = Value
-    val POINT, ON_LINE, IN_TRIANGLE = Value
-  }
+/**
+ * Type of the closest point. At the moment the names are only suited for a triangular mesh.
+ */
+private[boundingSpheres] object SurfaceClosestPointType extends Enumeration {
+  type SurfaceClosestPointType = Value
+  val POINT, ON_LINE, IN_TRIANGLE = Value
 }
 
-import scalismo.mesh.boundingSpheres.SurfaceSpatialIndex.SurfaceClosestPointType._
+import scalismo.mesh.boundingSpheres.SurfaceClosestPointType._
 
 /**
  * Descritpion of a closest point

--- a/src/main/scala/scalismo/mesh/boundingSpheres/VolumeSpatialIndex.scala
+++ b/src/main/scala/scalismo/mesh/boundingSpheres/VolumeSpatialIndex.scala
@@ -33,7 +33,7 @@ trait VolumeSpatialIndex[D] extends SpatialIndex[D] {
    *
    * @return A desciption of the closest point.
    */
-  def getClosestPointToVolume(pt: Point[D]): ClosestPointSpecialized
+  def getClosestPointToVolume(pt: Point[D]): ClosestPointWithType
 }
 
 /**
@@ -113,7 +113,7 @@ private[mesh] class TetrahedralMesh3DSpatialIndex(private val bs: BoundingSphere
   /**
    * Returns a description of the closest Point on the surface.
    */
-  override def getClosestPointToVolume(point: Point[_3D]): ClosestPointSpecialized = {
+  override def getClosestPointToVolume(point: Point[_3D]): ClosestPointWithType = {
 
     _getClosestPoint(point)
 

--- a/src/main/scala/scalismo/mesh/boundingSpheres/VolumeSpatialIndex.scala
+++ b/src/main/scala/scalismo/mesh/boundingSpheres/VolumeSpatialIndex.scala
@@ -19,17 +19,9 @@ import breeze.numerics.pow
 import scalismo.common.PointId
 import scalismo.geometry.{_3D, EuclideanVector, Point}
 import scalismo.mesh.boundingSpheres.BSDistance._
-import scalismo.mesh.boundingSpheres.SurfaceSpatialIndex.SurfaceClosestPointType
-import scalismo.mesh.boundingSpheres.SurfaceSpatialIndex.SurfaceClosestPointType.SurfaceClosestPointType
-import scalismo.mesh.boundingSpheres.VolumeSpatialIndex.VolumeClosestPointType.VolumeClosestPointType
-import scalismo.mesh.{
-  BarycentricCoordinates,
-  BarycentricCoordinates4,
-  TetrahedralMesh3D,
-  TetrahedronId,
-  TriangleId,
-  TriangleMesh3D
-}
+import scalismo.mesh.boundingSpheres.SurfaceClosestPointType.SurfaceClosestPointType
+import scalismo.mesh.boundingSpheres.VolumeClosestPointType.VolumeClosestPointType
+import scalismo.mesh._
 
 /**
  * SurfaceDistance trait with the basic queries defined.
@@ -44,25 +36,21 @@ trait VolumeSpatialIndex[D] extends SpatialIndex[D] {
   def getClosestPointToVolume(pt: Point[D]): ClosestPointWithSquaredDistance
 }
 
-object VolumeSpatialIndex {
+/**
+ * Type of the closest point. At the moment the names are only suited for a triangular mesh.
+ */
+private[boundingSpheres] object VolumeClosestPointType extends Enumeration {
+  type VolumeClosestPointType = Value
+  val POINT, ON_LINE, IN_TRIANGLE, IN_TETRAHEDRON = Value
 
-  /**
-   * Type of the closest point. At the moment the names are only suited for a triangular mesh.
-   */
-  private[boundingSpheres] object VolumeClosestPointType extends Enumeration {
-    type VolumeClosestPointType = Value
-    val POINT, ON_LINE, IN_TRIANGLE, IN_TETRAHEDRON = Value
-
-    def fromSurfaceClosestPointType(scpt: SurfaceClosestPointType) = scpt match {
-      case SurfaceClosestPointType.POINT       => POINT
-      case SurfaceClosestPointType.ON_LINE     => ON_LINE
-      case SurfaceClosestPointType.IN_TRIANGLE => IN_TRIANGLE
-    }
+  def fromSurfaceClosestPointType(scpt: SurfaceClosestPointType) = scpt match {
+    case SurfaceClosestPointType.POINT       => POINT
+    case SurfaceClosestPointType.ON_LINE     => ON_LINE
+    case SurfaceClosestPointType.IN_TRIANGLE => IN_TRIANGLE
   }
-
 }
 
-import VolumeSpatialIndex.VolumeClosestPointType._
+import scalismo.mesh.boundingSpheres.VolumeClosestPointType._
 
 private[boundingSpheres] case class VolumeClosestPointMeta(distance2: Double,
                                                            pt: EuclideanVector[_3D],

--- a/src/main/scala/scalismo/mesh/boundingSpheres/VolumeSpatialIndex.scala
+++ b/src/main/scala/scalismo/mesh/boundingSpheres/VolumeSpatialIndex.scala
@@ -33,7 +33,7 @@ trait VolumeSpatialIndex[D] extends SpatialIndex[D] {
    *
    * @return A desciption of the closest point.
    */
-  def getClosestPointToVolume(pt: Point[D]): ClosestPointWithSquaredDistance
+  def getClosestPointToVolume(pt: Point[D]): ClosestPointSpecialized
 }
 
 /**
@@ -113,7 +113,7 @@ private[mesh] class TetrahedralMesh3DSpatialIndex(private val bs: BoundingSphere
   /**
    * Returns a description of the closest Point on the surface.
    */
-  override def getClosestPointToVolume(point: Point[_3D]): ClosestPointWithSquaredDistance = {
+  override def getClosestPointToVolume(point: Point[_3D]): ClosestPointSpecialized = {
 
     _getClosestPoint(point)
 

--- a/src/test/scala/scalismo/mesh/BarycentricCoordinateTests.scala
+++ b/src/test/scala/scalismo/mesh/BarycentricCoordinateTests.scala
@@ -189,14 +189,14 @@ class BarycentricCoordinateTests extends ScalismoTestSuite {
       val startVTK = System.currentTimeMillis()
       for (i <- 0 until N) {
         val randomPoint = genPoint()
-        val bcVTK = getBarycentricCoordinatesFromVTK(a, b, c, d, randomPoint)
+        getBarycentricCoordinatesFromVTK(a, b, c, d, randomPoint)
       }
       val vtkTime = System.currentTimeMillis() - startVTK
 
       val startScala = System.currentTimeMillis()
       for (i <- 0 until N) {
         val randomPoint = genPoint()
-        val bc = BarycentricCoordinates4.pointInTetrahedron(randomPoint, a, b, c, d)
+        BarycentricCoordinates4.pointInTetrahedron(randomPoint, a, b, c, d)
       }
       val scalaTime = System.currentTimeMillis() - startScala
 

--- a/src/test/scala/scalismo/mesh/boundingSpheres/MeshSurfaceDistanceTests.scala
+++ b/src/test/scala/scalismo/mesh/boundingSpheres/MeshSurfaceDistanceTests.scala
@@ -19,7 +19,6 @@ import breeze.linalg.{max, min}
 import scalismo.ScalismoTestSuite
 import scalismo.common.{PointId, UnstructuredPointsDomain}
 import scalismo.geometry.{_3D, EuclideanVector, Point, Point3D}
-import scalismo.mesh.boundingSpheres.SurfaceSpatialIndex.SurfaceClosestPointType
 import scalismo.mesh.{
   BarycentricCoordinates4,
   TetrahedralCell,


### PR DESCRIPTION
This PR adds to the tetrahedral mesh operations the query for the closest point. Additional tests cover the most important parts of the added functionality.

Behavior:
- For all points outside of the mesh, it returns the distance to the closest point.
- For points within one of the tetrahedrons, it returns the distance 0.