### PR TITLE
added Metropolis-hastings variant with prefetching.

### DIFF
--- a/src/test/scala/scalismo/sampling/MetropolisHastingsTests.scala
+++ b/src/test/scala/scalismo/sampling/MetropolisHastingsTests.scala
@@ -1,0 +1,60 @@
+package scalismo.sampling
+
+import breeze.linalg.{DenseMatrix, DenseVector}
+import scalismo.ScalismoTestSuite
+import scalismo.sampling.algorithms.{MetropolisHastings, MetropolisHastingsWithPrefetching}
+import scalismo.sampling.evaluators.GaussianEvaluator
+import scalismo.statisticalmodel.MultivariateNormalDistribution
+
+class MetropolisHastingsTests extends ScalismoTestSuite {
+
+  implicit val rng = scalismo.utils.Random(42)
+
+  val gaussianProposal =
+    new ProposalGenerator[Double] with TransitionProbability[Double] with SymmetricTransitionRatio[Double] {
+      val sdev = 1.0
+
+      /** draw a sample from this proposal distribution, may depend on current state */
+      override def propose(current: Double): Double = rng.scalaRandom.nextGaussian() * sdev + current
+
+      /** rate of transition from to (log value) */
+      override def logTransitionProbability(from: Double, to: Double): Double =
+        GaussianEvaluator.logDensity(to, from, sdev)
+    }
+
+  describe("The metropolis-hastings algorithm") {
+
+    it("approximates the mean and covariance of a normal distribution") {
+      val mean = 1.0
+      val sdev = 3.5
+      val evaluator = GaussianEvaluator(mean, sdev)
+
+      val mh = MetropolisHastings(gaussianProposal, evaluator)
+      val samples = mh.iterator(0.0).drop(100000).take(100000).toIndexedSeq
+      val approximatedMean = samples.sum / samples.size
+      val approximatedVariance =
+        samples.map(sample => (sample - mean) * (sample - mean)).sum / samples.size
+
+      approximatedMean should be(mean +- 1e-1)
+      Math.sqrt(approximatedVariance) should be(sdev +- 5e-1)
+    }
+  }
+
+  describe("The metropolis-hastings algorithm with prefetching") {
+
+    it("approximates the mean and covariance of a normal distribution") {
+      val mean = 1.0
+      val sdev = 3.5
+      val evaluator = GaussianEvaluator(mean, sdev)
+
+      val mh = MetropolisHastingsWithPrefetching(gaussianProposal, evaluator)
+      val samples = mh.iterator(0.0).drop(100000).take(100000).toIndexedSeq
+      val approximatedMean = samples.sum / samples.size
+      val approximatedVariance =
+        samples.map(sample => (sample - mean) * (sample - mean)).sum / samples.size
+
+      approximatedMean should be(mean +- 1e-1)
+      Math.sqrt(approximatedVariance) should be(sdev +- 5e-1)
+    }
+  }
+}


### PR DESCRIPTION
This PR introduces a variant of the metropolis-hastings algorithm, which pre-computes the log-probability of a number of proposed solutions in advance. This allows to evaluate computationally expensive likelihood functions in parallel. It may lead to a speedup compared to the traditional MH algorithm in cases where computing the likelihood is expensive acceptance rate is low.

The interface is the same as for the standard MH algorithm. 