### PR TITLE
added boundary predicates for tetrahedral meshes

### DIFF
--- a/src/main/scala/scalismo/mesh/MeshBoundaryPredicates.scala
+++ b/src/main/scala/scalismo/mesh/MeshBoundaryPredicates.scala
@@ -17,10 +17,7 @@ package scalismo.mesh
 
 import breeze.linalg
 import breeze.linalg.CSCMatrix
-import org.junit.runner.manipulation.Sortable
 import scalismo.common.PointId
-
-import scala.collection.mutable
 
 /**
  * MeshBoundary is a property to test if points or an edge between two points is on the boundary of the mesh.
@@ -78,9 +75,9 @@ trait TetrahedralMeshBoundaryPredicates extends MeshBoundaryPredicates {
  *
  * @note the implementation with a Map instead of a CSCMatrix was three times slower using our test mesh.
  */
-private class BoundaryOfATriangleMeshPredicates(private var vertexIsOnBorder: IndexedSeq[Boolean],
-                                                private var edgeIsOnBorder: CSCMatrix[Boolean],
-                                                private var triangleIsOnBorder: IndexedSeq[Boolean])
+private class BoundaryOfATriangleMeshPredicates(private val vertexIsOnBorder: IndexedSeq[Boolean],
+                                                private val edgeIsOnBorder: CSCMatrix[Boolean],
+                                                private val triangleIsOnBorder: IndexedSeq[Boolean])
     extends TriangularMeshBoundaryPredicates {
 
   override def pointIsOnBoundary(id: PointId): Boolean = {
@@ -99,10 +96,10 @@ private class BoundaryOfATriangleMeshPredicates(private var vertexIsOnBorder: In
 /**
  * Implementation of a TetrahedralMeshBoundary
  */
-private class BoundaryOfATetrahedralMeshPredicates(private var vertexIsOnBorder: IndexedSeq[Boolean],
-                                                   private var edgeIsOnBorder: CSCMatrix[Boolean],
-                                                   private var triangleIsOnBorder: Map[TriangleCell, Boolean],
-                                                   private var tetrahedronIsOnBorder: IndexedSeq[Boolean])
+private class BoundaryOfATetrahedralMeshPredicates(private val vertexIsOnBorder: IndexedSeq[Boolean],
+                                                   private val edgeIsOnBorder: CSCMatrix[Boolean],
+                                                   private val triangleIsOnBorder: Map[TriangleCell, Boolean],
+                                                   private val tetrahedronIsOnBorder: IndexedSeq[Boolean])
     extends TetrahedralMeshBoundaryPredicates {
 
   override def pointIsOnBoundary(id: PointId): Boolean = {

--- a/src/test/scala/scalismo/mesh/MeshBoundaryTests.scala
+++ b/src/test/scala/scalismo/mesh/MeshBoundaryTests.scala
@@ -15,9 +15,14 @@
  */
 package scalismo.mesh
 
+import java.io.File
+import java.net.URLDecoder
+
 import scalismo.ScalismoTestSuite
 import scalismo.common.PointId
 import scalismo.geometry.Point
+import scalismo.io.MeshIO
+
 import scala.language.implicitConversions
 
 class MeshBoundaryTests extends ScalismoTestSuite {
@@ -286,5 +291,48 @@ class MeshBoundaryTests extends ScalismoTestSuite {
         b.triangleIsOnBoundary(TriangleId(id)) shouldBe true
       }
     }
+  }
+
+  describe("a tetrahedral mesh boundary") {
+    it("should return the correct labels for the tetrahedrons in the test mesh") {
+
+      val path = getClass.getResource("/tetraMesh.vtk").getPath
+      val tmesh = MeshIO.readTetrahedralMesh(new File(URLDecoder.decode(path, "UTF-8"))).get
+
+      val tetsOnBoundary = IndexedSeq(0, 1, 3, 4, 8, 9, 11, 12, 16, 17, 19, 20, 24, 25, 27, 28, 32, 33, 35, 36, 40, 41,
+        43, 47, 48, 49, 51, 52, 56, 57, 59, 60, 64, 65, 67, 68, 72, 73, 75, 76, 80, 81, 83, 84, 88, 89, 91, 95, 96, 97,
+        99, 100, 104, 105, 107, 111, 112, 113, 115, 116, 120, 121, 123, 124, 128, 129, 131, 132, 136, 137, 139, 140,
+        144, 145, 147, 148, 152, 153, 155, 156).map(i => TetrahedronId(i))
+      tetsOnBoundary.map { tet =>
+        require(tmesh.operations.tetrahedronIsOnBoundary(tet))
+      }
+
+      val tetsInside = IndexedSeq(2, 5, 6, 7, 10, 13, 14, 15, 18, 21, 22, 23, 26, 29, 30, 31, 34, 37, 38, 39, 42, 44,
+        45, 46, 50, 53, 54, 55, 58, 61, 62, 63, 66, 69, 70, 71, 74, 77, 78, 79, 82, 85, 86, 87, 90, 92, 93, 94, 98, 101,
+        102, 103, 106, 108, 109, 110, 114, 117, 118, 119, 122, 125, 126, 127, 130, 133, 134, 135, 138, 141, 142, 143,
+        146, 149, 150, 151, 154, 157, 158, 159).map(i => TetrahedronId(i))
+      tetsInside.map { tet =>
+        require(!tmesh.operations.tetrahedronIsOnBoundary(tet))
+      }
+    }
+
+    it("should return the correct labels for the points in the test mesh") {
+
+      val path = getClass.getResource("/tetraMesh.vtk").getPath
+      val tmesh = MeshIO.readTetrahedralMesh(new File(URLDecoder.decode(path, "UTF-8"))).get
+
+      val innerPoints = IndexedSeq(12, 14, 15, 18, 20, 21, 24, 26, 33, 35, 36, 45, 51).map(i => PointId(i))
+      innerPoints.map { pid =>
+        require(!tmesh.operations.pointIsOnBoundary(pid))
+      }
+
+      val surfacePoints = IndexedSeq(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 16, 17, 19, 22, 23, 25, 27, 28, 29, 30,
+        31, 32, 34, 37, 38, 39, 40, 41, 42, 43, 44, 46, 47, 48, 49, 50, 52, 53, 54).map(i => PointId(i))
+      surfacePoints.map { pid =>
+        require(tmesh.operations.pointIsOnBoundary(pid))
+      }
+    }
+
+    it("should return the correct labels") {}
   }
 }

--- a/src/test/scala/scalismo/mesh/boundingSpheres/MeshSurfaceDistanceTests.scala
+++ b/src/test/scala/scalismo/mesh/boundingSpheres/MeshSurfaceDistanceTests.scala
@@ -595,7 +595,6 @@ class MeshSurfaceDistanceTests extends ScalismoTestSuite {
       def isInside(pt: Point[_3D]) = {
         tmesh.tetrahedrons.exists { cell =>
           val bc = tmesh.getBarycentricCoordinates(pt, cell)
-          println()
           bc.forall(d => d >= 0.0) &&
           bc.forall(d => d <= 1.0) &&
           bc.sum <= 1.0 + 1.0e-8


### PR DESCRIPTION
This PR replaces #324 

The PR adds the boundary predicate to TetrahedralMesh3D in the same way as it exists for TriangleMesh3D. It also lets you extract the surface of the tetrahedral mesh as a TriangleMesh3D.

Tests for the tetrahedron and point predicate are added.