### PR TITLE
fixed corner cases of closestPointToVolume

### DIFF
--- a/src/main/scala/scalismo/mesh/boundingSpheres/BSDistance.scala
+++ b/src/main/scala/scalismo/mesh/boundingSpheres/BSDistance.scala
@@ -299,10 +299,10 @@ private object BSDistance {
     import BoundingSphereHelpers.calculateSignedVolume
 
     val sv = IndexedSeq(
-      calculateSignedVolume(p, tetrahedron.a, tetrahedron.b, tetrahedron.c) > 0,
-      calculateSignedVolume(p, tetrahedron.a, tetrahedron.d, tetrahedron.b) > 0,
-      calculateSignedVolume(p, tetrahedron.a, tetrahedron.c, tetrahedron.d) > 0,
-      calculateSignedVolume(p, tetrahedron.b, tetrahedron.d, tetrahedron.c) > 0
+      calculateSignedVolume(p, tetrahedron.a, tetrahedron.b, tetrahedron.c) >= 0,
+      calculateSignedVolume(p, tetrahedron.a, tetrahedron.d, tetrahedron.b) >= 0,
+      calculateSignedVolume(p, tetrahedron.a, tetrahedron.c, tetrahedron.d) >= 0,
+      calculateSignedVolume(p, tetrahedron.b, tetrahedron.d, tetrahedron.c) >= 0
     )
     if (sv.exists(b => b)) {
       IndexedSeq(


### PR DESCRIPTION
This PR fixes the function `closestPointToSurface` which before returned not the correct closest point for some of the vertices of a tetrahedral mesh. A test is added which checks that the correct vertices are returned.