### PR TITLE
fixes wrong PointIds when closest point is vertex

### DIFF
--- a/src/main/scala/scalismo/mesh/boundingSpheres/VolumeSpatialIndex.scala
+++ b/src/main/scala/scalismo/mesh/boundingSpheres/VolumeSpatialIndex.scala
@@ -124,7 +124,7 @@ private[mesh] class TetrahedralMesh3DSpatialIndex(private val bs: BoundingSphere
       case POINT =>
         ClosestPointIsVertex(res.get().pt.toPoint,
                              res.get().distance2,
-                             PointId(tetrahedron.pointIds(res.get().idx._1).id))
+                             PointId(tetrahedron.triangles(res.get().idx._1).pointIds(res.get().idx._2).id))
 
       case ON_LINE =>
         val idx = res.get().idx

--- a/src/test/scala/scalismo/mesh/boundingSpheres/MeshSurfaceDistanceTests.scala
+++ b/src/test/scala/scalismo/mesh/boundingSpheres/MeshSurfaceDistanceTests.scala
@@ -729,5 +729,14 @@ class MeshSurfaceDistanceTests extends ScalismoTestSuite {
         require(cp.isInstanceOf[ClosestPointIsVertex])
       }
     }
+
+    it("should return the correct pointId when queried with points from the mesh") {
+      val mesh = createTetrahedronsInUnitCube()
+      for (i <- 0 until mesh.pointSet.numberOfPoints) {
+        val query = mesh.pointSet.point(PointId(i))
+        val cp = mesh.operations.closestPointToVolume(query)
+        cp.asInstanceOf[ClosestPointIsVertex].pid.id shouldBe i
+      }
+    }
   }
 }


### PR DESCRIPTION
So far, if the function `closestPointToVolume` returned a vertex, the point-id was wrong. This PR corrects this issue and adds a test to check it.