### PR TITLE
update BarycentricInterpolator to use MeshOperations

### DIFF
--- a/src/main/scala/scalismo/common/interpolation/BarycentricInterpolator.scala
+++ b/src/main/scala/scalismo/common/interpolation/BarycentricInterpolator.scala
@@ -1,10 +1,10 @@
 package scalismo.common.interpolation
 
 import scalismo.common._
-import scalismo.geometry.{_3D, NDSpace, Point, Point3D}
-import scalismo.mesh.{TetrahedralCell, TetrahedralMesh, TetrahedronId}
+import scalismo.geometry.{_3D, NDSpace, Point}
+import scalismo.mesh.boundingSpheres._
+import scalismo.mesh.{MeshOperations, TetrahedralMesh}
 import scalismo.numerics.ValueInterpolator
-import scalismo.utils.Memoize
 
 trait BarycentricInterpolator[D, A] extends FieldInterpolator[D, UnstructuredPointsDomain[D], A] {
   implicit protected val valueInterpolator: ValueInterpolator[A]
@@ -33,40 +33,26 @@ object BarycentricInterpolator {
 case class BarycentricInterpolator3D[A: ValueInterpolator](mesh: TetrahedralMesh[_3D])
     extends BarycentricInterpolator[_3D, A] {
 
+  val meshOps = MeshOperations(mesh)
+
   override protected val valueInterpolator: ValueInterpolator[A] = ValueInterpolator[A]
-
-  // TODO: Temporary solution, replace for Milestone M2!
-  private def getTetrahedralMeshCell(p: Point[_3D]): Option[TetrahedralCell] = {
-
-    val numberOfTetrahedrons = mesh.tetrahedralization.tetrahedrons.length
-
-    def isInsideCell(tc: TetrahedralCell): Boolean = mesh.isInsideTetrahedralCell(p, tc)
-    val isInsideCellMemoized = Memoize(isInsideCell, numberOfTetrahedrons)
-
-    var cell: Option[TetrahedralCell] = None
-    var neighbourhood = Set[TetrahedronId]()
-
-    while (cell.isEmpty && neighbourhood.size != numberOfTetrahedrons) {
-      if (neighbourhood.isEmpty) {
-        // start from closest vertex point
-        val closestPoint = mesh.pointSet.findClosestPoint(p).id
-        neighbourhood = mesh.tetrahedralization.adjacentTetrahedronsForPoint(closestPoint).toSet
-      } else {
-        // increase neighbourhood
-        neighbourhood =
-          neighbourhood.union(neighbourhood.flatMap(mesh.tetrahedralization.adjacentTetrahedronsForTetrahedron))
-      }
-      val filterResult = neighbourhood.filter(tId => isInsideCellMemoized(mesh.tetrahedralization.tetrahedrons(tId.id)))
-      if (filterResult.nonEmpty) cell = Some(mesh.tetrahedralization.tetrahedrons(filterResult.head.id))
-    }
-    cell
-  }
 
   override def interpolate(df: DiscreteField[_3D, UnstructuredPointsDomain[_3D], A]): Field[_3D, A] = {
 
     def interpolateBarycentric(p: Point[_3D]): A = {
-      getTetrahedralMeshCell(p) match {
-        case Some(cell) =>
+
+      meshOps.closestPointToVolume(p) match {
+        case cp: ClosestPointIsVertex =>
+          df(cp.pid)
+        case cp: ClosestPointOnLine =>
+          ValueInterpolator[A].blend(df(cp.pids._1), df(cp.pids._2), cp.bc)
+        case cp: ClosestPointWithType =>
+          val cell = cp match {
+            case cp: ClosestPointInTriangleOfTetrahedron =>
+              mesh.tetrahedralization.tetrahedron(cp.tetId)
+            case cp: ClosestPointInTetrahedron =>
+              mesh.tetrahedralization.tetrahedron(cp.tid)
+          }
           val vertexValues = cell.pointIds.map(df(_))
           val barycentricCoordinates = mesh.getBarycentricCoordinates(p, cell)
           val valueCoordinatePairs = vertexValues.zip(barycentricCoordinates)
@@ -74,7 +60,6 @@ case class BarycentricInterpolator3D[A: ValueInterpolator](mesh: TetrahedralMesh
                                                  valueCoordinatePairs(1),
                                                  valueCoordinatePairs(2),
                                                  valueCoordinatePairs(3))
-        case None => throw new Exception(s"Point $p outside of domain.")
       }
     }
     Field(RealSpace[_3D], interpolateBarycentric)


### PR DESCRIPTION
This PR removes a temporary solution to find the corresponding mesh cell for a point. Instead it makes use of the recently added MeshOperations for tetrahedral meshes. The consequence is that, in contrast to the previous version, points outside of the mesh will be interpolated using a nearest neighbor scheme. The modifications in this PR should also make the interpolation more efficient.