### PR TITLE
use imageBoundingBox instead of boundingBox

### DIFF
--- a/src/main/scala/scalismo/common/interpolation/BSplineImageInterpolator.scala
+++ b/src/main/scala/scalismo/common/interpolation/BSplineImageInterpolator.scala
@@ -88,7 +88,7 @@ case class BSplineImageInterpolator1D[A: Scalar](degree: Int) extends BSplineIma
       }
       EuclideanVector(iterateOnPoints(x, splineBasisD1))
     }
-    DifferentiableField[_1D, A, EuclideanVector[_1D]](domain.boundingBox, f, df)
+    DifferentiableField[_1D, A, EuclideanVector[_1D]](domain.imageBoundingBox, f, df)
   }
 
   /* determine the b-spline coefficients for a 1D image */
@@ -158,7 +158,7 @@ case class BSplineImageInterpolator2D[A: Scalar](degree: Int) extends BSplineIma
       EuclideanVector(dfx, dfy)
     }
 
-    DifferentiableField[_2D, A, EuclideanVector[_2D]](discreteField.domain.boundingBox, f, df)
+    DifferentiableField[_2D, A, EuclideanVector[_2D]](discreteField.domain.imageBoundingBox, f, df)
   }
 
   /* determine the b-spline coefficients for a 2D image. The coefficients are returned
@@ -254,7 +254,7 @@ case class BSplineImageInterpolator3D[A: Scalar](degree: Int) extends BSplineIma
       EuclideanVector(dfx, dfy, dfz)
     }
 
-    val bbox = domain.boundingBox
+    val bbox = domain.imageBoundingBox
     DifferentiableField(BoxDomain3D(bbox.origin, bbox.oppositeCorner), f, df)
   }
 

--- a/src/main/scala/scalismo/mesh/VertexColorMesh3D.scala
+++ b/src/main/scala/scalismo/mesh/VertexColorMesh3D.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 University of Basel, Graphics and Vision Research Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package scalismo.mesh
 
 import scalismo.color.RGBA


### PR DESCRIPTION
Fixes the first part of #344 by using the imageBoundingBox instead of boundingBox for the interpolated image.