### PR TITLE
parallelized discretization of fields

### DIFF
--- a/src/main/scala/scalismo/common/PointSet.scala
+++ b/src/main/scala/scalismo/common/PointSet.scala
@@ -33,6 +33,17 @@ trait PointSet[D] extends Equals {
 
   def points: Iterator[Point[D]]
 
+  /**
+   * *
+   * Returns the domain points in n chunks. Each chunk of the points is given as an iterator
+   *
+   * The main idea behind this method is to be able to easily parallelize on the domain points, as parallel operations
+   * on a single iterator in Scala end up more costly than sequential access in our case. Using this method, one would parallelize on the
+   * Seq of iterators instead.
+   *
+   */
+  def pointsInChunks(nChunks: Int): Seq[Iterator[Point[D]]]
+
   def pointIds: Iterator[PointId] = Iterator.range(0, numberOfPoints).map(id => PointId(id))
 
   def isDefinedAt(pt: Point[D]): Boolean

--- a/src/main/scala/scalismo/common/UnstructuredPoints.scala
+++ b/src/main/scala/scalismo/common/UnstructuredPoints.scala
@@ -66,8 +66,8 @@ sealed abstract class UnstructuredPoints[D: NDSpace: Create] private[scalismo] (
   }
 
   override def pointsInChunks(nChunks: Int): Seq[Iterator[Point[D]]] = {
-    val chunkSize = pointSequence.size / nChunks
-    val chunks = for (i <- 0 until (nChunks + 1)) yield {
+    val chunkSize = Math.ceil(pointSequence.size / nChunks.toDouble).toInt
+    val chunks = for (i <- 0 until nChunks) yield {
       pointSequence.slice(i * chunkSize, Math.min((i + 1) * chunkSize, pointSequence.size)).iterator
     }
     chunks.toSeq

--- a/src/main/scala/scalismo/common/UnstructuredPoints.scala
+++ b/src/main/scala/scalismo/common/UnstructuredPoints.scala
@@ -65,6 +65,14 @@ sealed abstract class UnstructuredPoints[D: NDSpace: Create] private[scalismo] (
 
   }
 
+  override def pointsInChunks(nChunks: Int): Seq[Iterator[Point[D]]] = {
+    val chunkSize = pointSequence.size / nChunks
+    val chunks = for (i <- 0 until (nChunks + 1)) yield {
+      pointSequence.slice(i * chunkSize, Math.min((i + 1) * chunkSize, pointSequence.size)).iterator
+    }
+    chunks.toSeq
+  }
+
   override def findNClosestPoints(pt: Point[D], n: Int): Seq[PointWithId[D]] = {
     kdTreeMap.findNearest(pt, n).map { case (p, id) => PointWithId(p, PointId(id)) }
   }

--- a/src/main/scala/scalismo/image/StructuredPoints.scala
+++ b/src/main/scala/scalismo/image/StructuredPoints.scala
@@ -133,16 +133,7 @@ abstract class StructuredPoints[D: NDSpace] extends PointSet[D] with Equals {
   private[scalismo] def indexToPhysicalCoordinateTransform: Transformation[D]
   private[scalismo] def physicalCoordinateToContinuousIndex: Transformation[D]
 
-  /**
-   * *
-   * Returns a sequence of iterators on the domain points, the size of the sequence being indicated by the user.
-   *
-   * The main idea behind this method is to be able to easily parallelize on the domain points, as parallel operations
-   * on a single iterator in Scala end up more costly than sequential access in our case. Using this method, one would parallelize on the
-   * IndexedSeq of iterators instead.
-   *
-   */
-  private[scalismo] def pointsInChunks(nbChunks: Int): IndexedSeq[Iterator[Point[D]]]
+  def pointsInChunks(nbChunks: Int): IndexedSeq[Iterator[Point[D]]]
 
   // define the canEqual method
   override def canEqual(a: Any) = a.isInstanceOf[StructuredPoints[D]]
@@ -211,7 +202,7 @@ case class StructuredPoints1D(origin: Point[_1D], spacing: EuclideanVector[_1D],
 
   override def boundingBox: BoxDomain[_1D] = BoxDomain1D(origin, origin + EuclideanVector(size(0) * spacing(0)))
 
-  override private[scalismo] def pointsInChunks(nbChunks: Int): IndexedSeq[Iterator[Point1D]] = {
+  override def pointsInChunks(nbChunks: Int): IndexedSeq[Iterator[Point1D]] = {
     require(nbChunks > 1)
     val chunkSize = size(0) / nbChunks
     val ranges = (0 until nbChunks).map { chunkId =>
@@ -287,7 +278,7 @@ case class StructuredPoints2D(origin: Point[_2D], spacing: EuclideanVector[_2D],
     BoxDomain2D(origin, oppositeCorner)
   }
 
-  override private[scalismo] def pointsInChunks(nbChunks: Int): IndexedSeq[Iterator[Point2D]] = {
+  override def pointsInChunks(nbChunks: Int): IndexedSeq[Iterator[Point2D]] = {
     require(nbChunks > 1)
     val chunkSize = size(1) / nbChunks
     val ranges = (0 until nbChunks).map { chunkId =>
@@ -392,7 +383,7 @@ case class StructuredPoints3D(origin: Point[_3D],
   }
   override def points = generateIterator(0, size(2), 0, size(1), 0, size(0))
 
-  override private[scalismo] def pointsInChunks(nbChunks: Int): IndexedSeq[Iterator[Point3D]] = {
+  override def pointsInChunks(nbChunks: Int): IndexedSeq[Iterator[Point3D]] = {
     require(nbChunks > 1)
     val chunkSize = size(2) / nbChunks
     val ranges = (0 until nbChunks).map { chunkId =>

--- a/src/test/scala/scalismo/common/UnstructuredPointsTests.scala
+++ b/src/test/scala/scalismo/common/UnstructuredPointsTests.scala
@@ -38,5 +38,17 @@ class UnstructuredPointsTests extends ScalismoTestSuite {
     it("has the same hash value as the underlying point sequence") {
       dom.hashCode() shouldBe points.hashCode()
     }
+
+    it("returns the correct points when retrieved in chunks ") {
+      for (chunkSize <- 2 until points.length) {
+        val pointsFromChunked = dom.pointsInChunks(3).flatten
+
+        pointsFromChunked.size should equal(points.size)
+        for (pt <- points) {
+          pointsFromChunked.contains(pt) should be(true)
+        }
+      }
+    }
+
   }
 }

--- a/src/test/scala/scalismo/common/UnstructuredPointsTests.scala
+++ b/src/test/scala/scalismo/common/UnstructuredPointsTests.scala
@@ -50,5 +50,12 @@ class UnstructuredPointsTests extends ScalismoTestSuite {
       }
     }
 
+    it ("correctly chunks points into n chunks") {
+      for (numChunks <- 2 until points.length) {
+        val chunks = dom.pointsInChunks(numChunks)
+        chunks.size should equal(numChunks)
+      }
+    }
+
   }
 }


### PR DESCRIPTION
Added parallelisation of discretization of fields. This functionality was already there for images in the previous version of scalismo, but was removed in the redesign. Now it is reintroduced for more general fields.