### PR TITLE
Introduced SampleLense and added GaussianRandomWalkProposal

### DIFF
--- a/src/main/scala/scalismo/sampling/SampleLens.scala
+++ b/src/main/scala/scalismo/sampling/SampleLens.scala
@@ -1,0 +1,33 @@
+package scalismo.sampling
+
+import breeze.linalg.DenseVector
+
+/**
+ * This trait is used in the context of an MCMC chain, where the we have a class Sample or
+ * generic type A, which contains an arbitrary number of parameters, with arbitrary structure.
+ * The lens focuses attention to one part of the parameter vector, which can then be read and updated
+ * using the provided getter and setter methods.
+ * To update different parts of a sample, different lenses must be implemented
+ */
+trait SampleLens[A] {
+
+  /**
+   * The number of parameters this lense focuses on
+   */
+  def numberOfParameters: Int
+
+  /**
+   * returns the part of the parameters on which this lense focuses as a dense vector
+   * The length of the vectors needs to correspond to numberOfParameters
+   */
+  def getAsVector(sample: A): DenseVector[Double]
+
+  /**
+   * returns a new sample, which the part, on which this lense focuses replaced by the values
+   * given in the vector. The option generatedBy argument is used to tag who has generated
+   * the resulting sample.
+   *
+   * The length of the given vectors needs to correspond to numberOfParameters
+   */
+  def setFromVector(sample: A, vector: DenseVector[Double], generatedBy: Option[String] = None): A
+}

--- a/src/main/scala/scalismo/sampling/SampleLens.scala
+++ b/src/main/scala/scalismo/sampling/SampleLens.scala
@@ -3,31 +3,25 @@ package scalismo.sampling
 import breeze.linalg.DenseVector
 
 /**
- * This trait is used in the context of an MCMC chain, where the we have a class Sample or
- * generic type A, which contains an arbitrary number of parameters, with arbitrary structure.
- * The lens focuses attention to one part of the parameter vector, which can then be read and updated
+ * This class is used in the context of an MCMC chain, where the we have a class Sample or
+ * generic type A, with arbitrary structure.
+ * The lens focuses attention to a part of the sample with type B, which can then be read and updated
  * using the provided getter and setter methods.
  * To update different parts of a sample, different lenses must be implemented
  */
-trait SampleLens[A] {
+abstract class SampleLens[A, B] {
 
   /**
-   * The number of parameters this lense focuses on
+   * returns the part of the parameters on which this lens focuses
    */
-  def numberOfParameters: Int
+  def get(sample: A): B
 
   /**
-   * returns the part of the parameters on which this lense focuses as a dense vector
-   * The length of the vectors needs to correspond to numberOfParameters
-   */
-  def getAsVector(sample: A): DenseVector[Double]
-
-  /**
-   * returns a new sample, which the part, on which this lense focuses replaced by the values
+   * returns a new sample, which the part, on which this lens focuses replaced by the values
    * given in the vector. The option generatedBy argument is used to tag who has generated
    * the resulting sample.
    *
    * The length of the given vectors needs to correspond to numberOfParameters
    */
-  def setFromVector(sample: A, vector: DenseVector[Double], generatedBy: Option[String] = None): A
+  def replace(full: A, part: B, generatedBy: Option[String] = None): A
 }

--- a/src/main/scala/scalismo/sampling/proposals/GaussianRandomWalkProposal.scala
+++ b/src/main/scala/scalismo/sampling/proposals/GaussianRandomWalkProposal.scala
@@ -1,0 +1,31 @@
+package scalismo.sampling.proposals
+
+import breeze.linalg.{DenseMatrix, DenseVector}
+import scalismo.sampling.{ProposalGenerator, SampleLens, TransitionProbability}
+import scalismo.statisticalmodel.MultivariateNormalDistribution
+
+/**
+ * Classical Random Walk proposal, where the current state is perturbed using a step, which is generated
+ * by an isotropic gaussian with the given standard deviation.
+ */
+case class GaussianRandomWalkProposal[A](stddev: Double, sampleLens: SampleLens[A])(implicit rng: scalismo.utils.Random)
+    extends ProposalGenerator[A]
+    with TransitionProbability[A] {
+
+  private val normalDist = new MultivariateNormalDistribution(
+    DenseVector.zeros(sampleLens.numberOfParameters),
+    DenseMatrix.eye[Double](sampleLens.numberOfParameters) * stddev * stddev
+  )
+
+  override def propose(sample: A): A = {
+    val perturbation = normalDist.sample()
+
+    val newParameters = sampleLens.getAsVector(sample) + normalDist.sample()
+    sampleLens.setFromVector(sample, newParameters, Some(s"GaussianRandomWalkProposal ($stddev"))
+  }
+
+  override def logTransitionProbability(from: A, to: A): Double = {
+    val residual = sampleLens.getAsVector(to) - sampleLens.getAsVector(from)
+    normalDist.logpdf(residual)
+  }
+}

--- a/src/main/scala/scalismo/sampling/proposals/PartialProposalAdapter.scala
+++ b/src/main/scala/scalismo/sampling/proposals/PartialProposalAdapter.scala
@@ -1,0 +1,25 @@
+package scalismo.sampling.proposals
+
+import scalismo.sampling.{ProposalGenerator, SampleLens, TransitionProbability}
+
+/**
+ * Adapter to obtain a full proposal from a proposal generator that is only defined on a part of the
+ * parameter space. The part on which the proposal generator is defined is defined by the given sampleLens
+ *
+ * @param proposal A proposal generator that generates a new proposal for a given part
+ * @param lens A lense that focuses on the desired part of the parameter vector
+ */
+class PartialProposalAdapter[A, Part](proposal: ProposalGenerator[Part] with TransitionProbability[Part],
+                                      lens: SampleLens[A, Part])
+    extends ProposalGenerator[A]
+    with TransitionProbability[A] {
+
+  override def propose(current: A): A = {
+    val partialProposal = proposal.propose(lens.get(current))
+    lens.replace(current, partialProposal)
+  }
+
+  override def logTransitionProbability(from: A, to: A): Double = {
+    proposal.logTransitionProbability(lens.get(from), lens.get(to))
+  }
+}


### PR DESCRIPTION
This commit introduced the trait ```SampleLense``` , which is a general way to access parts of a generic sample for the mcmc framework. This mechanism makes it possible to keep the samples completely generic, but still be able to provide useful proposal generators. As an example, the ```GaussianRandomWalkProposal``` is introduced. While this might seems like an overkill for this simple proposal generator, a lot of errors can be avoided when we  introduce more complicated proposals. Indeed, the motivation for this is the Mala proposal, which will be introduced in a separate PR:

The following code shows a complete example of how the lense can be used. Proposals are generated blockwise, where each parameter (mu, sigma) is updated separatly using the ```GaussianRandomWalkProposal```. 

```scala
import breeze.linalg.DenseVector
import scalismo.sampling.algorithms.MetropolisHastings
import scalismo.sampling.evaluators.ProductEvaluator
import scalismo.sampling.proposals.{GaussianRandomWalkProposal, MalaProposal, MixtureProposal}
import scalismo.sampling.{DistributionEvaluator, GradientEvaluator, SampleLens}

// Parameter class - This is generic and every application chooses its
// own structures of the parameters
case class Parameters(mu: Double, sigma: Double)
case class Sample(parameters: Parameters, generatedBy: String)

// The lense for accessing the mean from the parameter vector
object MeanParamLens extends SampleLens[Sample] {

  override def numberOfParameters: Int = 1

  override def getAsVector(sample: Sample): DenseVector[Double] = {
    val v = DenseVector.zeros[Double](1)
    v(0) = sample.parameters.mu
    v
  }
  override def setFromVector(sample: Sample, vector: DenseVector[Double], generatedBy: Option[String]): Sample = {
    sample.copy(parameters = sample.parameters.copy(mu = vector(0)))
  }
}

// The lense for accessing the staddev from the parameter vector
object StddevParamLens extends SampleLens[Sample] {

  override def numberOfParameters: Int = 1

  override def getAsVector(sample: Sample): DenseVector[Double] = {
    val v = DenseVector.zeros[Double](1)
    v(0) = sample.parameters.sigma
    v
  }

  override def setFromVector(sample: Sample, vector: DenseVector[Double], generatedBy: Option[String]): Sample = {
    sample.copy(parameters = sample.parameters.copy(sigma = vector(0)))
  }
}

case class Evaluator(data: Seq[Double]) extends DistributionEvaluator[Sample] {

  override def logValue(theta: Sample): Double = {
    val likelihood = breeze.stats.distributions.Gaussian(
      theta.parameters.mu,
      theta.parameters.sigma
    )
    val likelihoods = for (x <- data) yield {
      likelihood.logPdf(x)
    }
    likelihoods.sum
  }
}

object MinimalExample {

  def generateSyntheticData(numDataPoints: Int): Seq[Double] = {
    // The true distribution to sample from
    val mu = -1
    val sigma = 3

    val trueDistribution = breeze.stats.distributions.Gaussian(mu, sigma)
    for (_ <- 0 until numDataPoints) yield {
      trueDistribution.draw()
    }
  }

  def main(args: Array[String]): Unit = {

    scalismo.initialize()
    implicit val rng = scalismo.utils.Random(42)

    val data = generateSyntheticData(100)
    val evaluator = Evaluator(data)

    // Using the new Mala proposal as a gradient
    val generatorForMean = GaussianRandomWalkProposal(1, MeanParamLens)
    val generatorForStddev = GaussianRandomWalkProposal(0.1, StddevParamLens)
    val generator = MixtureProposal.fromProposalsWithTransition((0.5, generatorForMean), (0.5, generatorForStddev))

    val chain = MetropolisHastings(generator, evaluator)

    val initialSample = Sample(Parameters(0, 1), generatedBy = "initial")
    val mhIterator = chain.iterator(initialSample)
    val samples = mhIterator.drop(1000).take(100000).toIndexedSeq

    val estimatedMean = samples.map(sample => sample.parameters.mu).sum / samples.size
    val estimatedSigma = samples.map(sample => sample.parameters.sigma).sum / samples.size

    println((estimatedMean, estimatedSigma))
  }
}
```