### PR TITLE
Two small improvements/bugfixes

### DIFF
--- a/src/main/scala/scalismo/common/DiscreteField.scala
+++ b/src/main/scala/scalismo/common/DiscreteField.scala
@@ -41,9 +41,11 @@ class DiscreteField[D, DDomain[D] <: DiscreteDomain[D], A](val domain: DDomain[D
   }
   override def isDefinedAt(ptId: PointId) = data.isDefinedAt(ptId.id)
 
-  def valuesWithIds = values zip pointSet.pointIds
-  def pointsWithValues = pointSet.points zip values
-  def pointsWithIds = pointSet.points.zipWithIndex
+  def valuesWithIds: Iterator[(A, PointId)] = values zip pointSet.pointIds
+  def pointsWithValues: Iterator[(Point[D], A)] = pointSet.points zip values
+  def pointsWithIds: Iterator[(Point[D], PointId)] = pointSet.points.zipWithIndex.map {
+    case (pt, id) => (pt, PointId(id))
+  }
 
   def foreach(f: A => Unit): Unit = values.foreach(f)
 

--- a/src/main/scala/scalismo/io/ActiveShapeModelIO.scala
+++ b/src/main/scala/scalismo/io/ActiveShapeModelIO.scala
@@ -120,7 +120,7 @@ object ActiveShapeModelIO {
       featureExtractor <- FeatureExtractorIOHandlers.load(h5file, feGroup)
       profiles <- readProfiles(h5file, profilesGroup, pdm.reference)
     } yield {
-      val shapeModel = StatisticalMeshModel(pdm.reference, pdm.gp)
+      val shapeModel = PointDistributionModel(pdm.gp)
       ActiveShapeModel(shapeModel, profiles, preprocessor, featureExtractor)
     }
 

--- a/src/test/scala/scalismo/io/ActiveShapeModelIOTests.scala
+++ b/src/test/scala/scalismo/io/ActiveShapeModelIOTests.scala
@@ -38,11 +38,11 @@ class ActiveShapeModelIOTests extends ScalismoTestSuite {
 
   private def createAsm(): ActiveShapeModel = {
     val statismoFile = new File(URLDecoder.decode(getClass.getResource("/facemodel.h5").getPath, "UTF-8"))
-    val shapeModel = StatisticalModelIO.readStatisticalMeshModel(statismoFile).get
+    val shapeModel = StatisticalModelIO.readStatisticalTriangleMeshModel3D(statismoFile).get
 
-    val (sprofilePoints, _) = new FixedPointsUniformMeshSampler3D(shapeModel.referenceMesh, 100).sample.unzip
+    val (sprofilePoints, _) = new FixedPointsUniformMeshSampler3D(shapeModel.reference, 100).sample.unzip
     val pointIds = sprofilePoints.map { point =>
-      shapeModel.referenceMesh.pointSet.findClosestPoint(point).id
+      shapeModel.reference.pointSet.findClosestPoint(point).id
     }
     val dists =
       for (i <- pointIds.indices)

--- a/src/test/scala/scalismo/statisticalmodel/ActiveShapeModelTests.scala
+++ b/src/test/scala/scalismo/statisticalmodel/ActiveShapeModelTests.scala
@@ -34,7 +34,7 @@ class ActiveShapeModelTests extends ScalismoTestSuite {
         FittingConfiguration(featureDistanceThreshold = 2.0, pointDistanceThreshold = 3.0, modelCoefficientBounds = 3.0)
 
       val path: String = URLDecoder.decode(getClass.getResource(s"/asmData/model.h5").getPath, "UTF-8")
-      val shapeModel = StatisticalModelIO.readStatisticalMeshModel(new File(path)).get
+      val shapeModel = StatisticalModelIO.readStatisticalTriangleMeshModel3D(new File(path)).get
       val nbFiles = 7
       // use iterators so files are only loaded when required (and memory can be reclaimed after use)
       val meshes = (0 until nbFiles).toIterator map { i =>
@@ -51,7 +51,7 @@ class ActiveShapeModelTests extends ScalismoTestSuite {
       val trainMeshes = meshes
       val trainImages = images
 
-      val dc = DataCollection.fromTriangleMesh3DSequence(shapeModel.referenceMesh, trainMeshes.toIndexedSeq)
+      val dc = DataCollection.fromTriangleMesh3DSequence(shapeModel.reference, trainMeshes.toIndexedSeq)
       def itemsToTransform(item: DiscreteField[_3D, TriangleMesh, EuclideanVector[_3D]]): Transformation[_3D] = {
         val field = item.interpolate(NearestNeighborInterpolator())
         Transformation((p: Point[_3D]) => p + field(p))


### PR DESCRIPTION
 This PR addresses two minor problems in v0.90.0. As both affect the API, we only change them in the upcoming 0.91 release. 

1. The internal model of an Active shape model should be a ```PointDistributionModel[_3D, TriangleMesh]``` and not a ```StatisticalMeshModel```
2. The method ```pointWithId``` on ```DiscreteField``` should return an iterator of ```(Point[D], PointId)``` instead of an iterator ```(Point[D], int)```. 