### PR TITLE
Bugfixes and improvement regarding nifti image reading and representation

### DIFF
--- a/src/main/scala/scalismo/common/interpolation/BSplineImageInterpolator.scala
+++ b/src/main/scala/scalismo/common/interpolation/BSplineImageInterpolator.scala
@@ -196,7 +196,7 @@ case class BSplineImageInterpolator3D[A: Scalar](degree: Int) extends BSplineIma
     val pointSet = domain.pointSet
 
     val ck = determineCoefficients3D(degree, discreteField)
-    val pointToIdx = pointSet.physicalCoordinateToContinuousIndex
+    val pointToIdx = pointSet.pointToContinuousIndex _
 
     def iterateOnPoints(x: Point[_3D], splineBasis: ((Double, Double, Double) => Double)): Double = {
 

--- a/src/main/scala/scalismo/image/DiscreteImageDomain.scala
+++ b/src/main/scala/scalismo/image/DiscreteImageDomain.scala
@@ -49,7 +49,7 @@ case class DiscreteImageDomain[D: NDSpace](structuredPoints: StructuredPoints[D]
     // (The voxel that is defined by each grid point extends by the length spacing(i) into the
     // i-th space direction).
     val bb = structuredPoints.boundingBox
-    BoxDomain(bb.origin, bb.oppositeCorner + spacing)
+    BoxDomain(bb.origin, bb.oppositeCorner +  structuredPoints.directions * spacing)
   }
 
 }
@@ -84,18 +84,19 @@ object DiscreteImageDomain2D {
   def apply(origin: Point[_2D],
             spacing: EuclideanVector[_2D],
             size: IntVector[_2D],
-            phi: Double = 0.0): DiscreteImageDomain[_2D] = {
-    DiscreteImageDomain(StructuredPoints2D(origin, spacing, size, phi))
+            iVec: EuclideanVector[_2D] = EuclideanVector2D(1, 0),
+            jVec: EuclideanVector[_2D] = EuclideanVector2D(0, 1)): DiscreteImageDomain[_2D] = {
+    DiscreteImageDomain(StructuredPoints2D(origin, spacing, size, iVec, jVec))
   }
 
   def apply(boundingBox: BoxDomain[_2D], size: IntVector[_2D]): DiscreteImageDomain[_2D] = {
-    val spacing = EuclideanVector2D(boundingBox.extent(0) / (size(0) + 1), boundingBox.extent(1) / (size(1) + 1))
+    val spacing = EuclideanVector2D(boundingBox.extent(0) / size(0), boundingBox.extent(1) / size(1) )
     DiscreteImageDomain(StructuredPoints2D(boundingBox.origin, spacing, size))
   }
 
   def apply(boundingBox: BoxDomain[_2D], spacing: EuclideanVector[_2D]): DiscreteImageDomain[_2D] = {
-    val size = IntVector2D(Math.ceil(boundingBox.extent(0) / spacing(0)).toInt - 1,
-                           Math.ceil(boundingBox.extent(1) / spacing(1)).toInt - 1)
+    val size = IntVector2D(Math.ceil(boundingBox.extent(0) / spacing(0)).toInt ,
+                           Math.ceil(boundingBox.extent(1) / spacing(1)).toInt )
 
     DiscreteImageDomain(StructuredPoints2D(boundingBox.origin, spacing, size))
   }
@@ -114,24 +115,24 @@ object DiscreteImageDomain3D {
   def apply(origin: Point[_3D],
             spacing: EuclideanVector[_3D],
             size: IntVector[_3D],
-            phi: Double,
-            theta: Double,
-            psi: Double): DiscreteImageDomain[_3D] = {
-    DiscreteImageDomain(StructuredPoints3D(origin, spacing, size, phi, theta, psi))
+            iVec: EuclideanVector[_3D],
+            jVec: EuclideanVector[_3D],
+            kVec: EuclideanVector[_3D]): DiscreteImageDomain[_3D] = {
+    DiscreteImageDomain(StructuredPoints3D(origin, spacing, size, iVec, jVec, kVec))
   }
 
   def apply(boundingBox: BoxDomain[_3D], size: IntVector[_3D]): DiscreteImageDomain[_3D] = {
-    val spacing = EuclideanVector3D(boundingBox.extent(0) / (size(0) + 1),
-                                    boundingBox.extent(1) / (size(1) + 1),
-                                    boundingBox.extent(2) / (size(2) + 1))
+    val spacing = EuclideanVector3D(boundingBox.extent(0) / size(0) ,
+                                    boundingBox.extent(1) / size(1) ,
+                                    boundingBox.extent(2) / size(2))
     DiscreteImageDomain(StructuredPoints3D(boundingBox.origin, spacing, size))
   }
 
   def apply(boundingBox: BoxDomain[_3D], spacing: EuclideanVector[_3D]): DiscreteImageDomain[_3D] = {
     val size = IntVector3D(
-      Math.ceil(boundingBox.extent(0) / spacing(0)).toInt - 1,
-      Math.ceil(boundingBox.extent(1) / spacing(1)).toInt - 1,
-      Math.ceil(boundingBox.extent(2) / spacing(2)).toInt - 1
+      Math.ceil(boundingBox.extent(0) / spacing(0)).toInt ,
+      Math.ceil(boundingBox.extent(1) / spacing(1)).toInt ,
+      Math.ceil(boundingBox.extent(2) / spacing(2)).toInt
     )
 
     DiscreteImageDomain(StructuredPoints3D(boundingBox.origin, spacing, size))

--- a/src/main/scala/scalismo/image/DiscreteImageDomain.scala
+++ b/src/main/scala/scalismo/image/DiscreteImageDomain.scala
@@ -49,7 +49,7 @@ case class DiscreteImageDomain[D: NDSpace](structuredPoints: StructuredPoints[D]
     // (The voxel that is defined by each grid point extends by the length spacing(i) into the
     // i-th space direction).
     val bb = structuredPoints.boundingBox
-    BoxDomain(bb.origin, bb.oppositeCorner +  structuredPoints.directions * spacing)
+    BoxDomain(bb.origin, bb.oppositeCorner + structuredPoints.directions * spacing)
   }
 
 }
@@ -90,13 +90,13 @@ object DiscreteImageDomain2D {
   }
 
   def apply(boundingBox: BoxDomain[_2D], size: IntVector[_2D]): DiscreteImageDomain[_2D] = {
-    val spacing = EuclideanVector2D(boundingBox.extent(0) / size(0), boundingBox.extent(1) / size(1) )
+    val spacing = EuclideanVector2D(boundingBox.extent(0) / size(0), boundingBox.extent(1) / size(1))
     DiscreteImageDomain(StructuredPoints2D(boundingBox.origin, spacing, size))
   }
 
   def apply(boundingBox: BoxDomain[_2D], spacing: EuclideanVector[_2D]): DiscreteImageDomain[_2D] = {
-    val size = IntVector2D(Math.ceil(boundingBox.extent(0) / spacing(0)).toInt ,
-                           Math.ceil(boundingBox.extent(1) / spacing(1)).toInt )
+    val size = IntVector2D(Math.ceil(boundingBox.extent(0) / spacing(0)).toInt,
+                           Math.ceil(boundingBox.extent(1) / spacing(1)).toInt)
 
     DiscreteImageDomain(StructuredPoints2D(boundingBox.origin, spacing, size))
   }
@@ -122,16 +122,16 @@ object DiscreteImageDomain3D {
   }
 
   def apply(boundingBox: BoxDomain[_3D], size: IntVector[_3D]): DiscreteImageDomain[_3D] = {
-    val spacing = EuclideanVector3D(boundingBox.extent(0) / size(0) ,
-                                    boundingBox.extent(1) / size(1) ,
+    val spacing = EuclideanVector3D(boundingBox.extent(0) / size(0),
+                                    boundingBox.extent(1) / size(1),
                                     boundingBox.extent(2) / size(2))
     DiscreteImageDomain(StructuredPoints3D(boundingBox.origin, spacing, size))
   }
 
   def apply(boundingBox: BoxDomain[_3D], spacing: EuclideanVector[_3D]): DiscreteImageDomain[_3D] = {
     val size = IntVector3D(
-      Math.ceil(boundingBox.extent(0) / spacing(0)).toInt ,
-      Math.ceil(boundingBox.extent(1) / spacing(1)).toInt ,
+      Math.ceil(boundingBox.extent(0) / spacing(0)).toInt,
+      Math.ceil(boundingBox.extent(1) / spacing(1)).toInt,
       Math.ceil(boundingBox.extent(2) / spacing(2)).toInt
     )
 

--- a/src/main/scala/scalismo/image/StructuredPoints.scala
+++ b/src/main/scala/scalismo/image/StructuredPoints.scala
@@ -290,10 +290,9 @@ case class StructuredPoints3D(origin: Point[_3D],
   require(Math.abs(jVec.norm - 1.0) < 1e-10)
 
   override def indexToPoint(idx: IntVector[_3D]): Point[_3D] = {
-    val pointOnIVec = iVec * idx(0) * spacing(0)
-    val pointOnJVec = jVec * idx(1) * spacing(1)
-    val pointOnKVec = kVec * idx(2) * spacing(2)
-    origin + pointOnIVec + pointOnJVec + pointOnKVec
+    val indexVec = EuclideanVector3D(idx(0).toDouble, idx(1).toDouble, idx(2).toDouble)
+    origin + directions * SquareMatrix.diag(EuclideanVector3D(spacing(0), spacing(1), spacing(2))) * indexVec
+
   }
 
   override def pointToContinuousIndex(pt: Point[_3D]): EuclideanVector[_3D] = {

--- a/src/main/scala/scalismo/image/StructuredPoints.scala
+++ b/src/main/scala/scalismo/image/StructuredPoints.scala
@@ -109,7 +109,7 @@ abstract class StructuredPoints[D: NDSpace] extends PointSet[D] with Equals {
    */
   override def findNClosestPoints(pt: Point[D], n: Int): Seq[PointWithId[D]] = throw new UnsupportedOperationException
 
-   def continuousIndextoIndex(cidx: EuclideanVector[D]): IntVector[D] = {
+  def continuousIndextoIndex(cidx: EuclideanVector[D]): IntVector[D] = {
     var d = 0
     val indexData = new Array[Int](dimensionality)
     while (d < dimensionality) {
@@ -123,7 +123,7 @@ abstract class StructuredPoints[D: NDSpace] extends PointSet[D] with Equals {
     (0 until dimensionality).forall(i => continuousIndex(i) - Math.round(continuousIndex(i)) < 1e-8)
 
   def pointToContinuousIndex(pt: Point[D]): EuclideanVector[D]
-  def pointToIndex(pt : Point[D]) : IntVector[D] = continuousIndextoIndex(pointToContinuousIndex(pt))
+  def pointToIndex(pt: Point[D]): IntVector[D] = continuousIndextoIndex(pointToContinuousIndex(pt))
   def indexToPoint(idx: IntVector[D]): Point[D]
 
   def pointsInChunks(nbChunks: Int): IndexedSeq[Iterator[Point[D]]]

--- a/src/main/scala/scalismo/image/filter/DiscreteImageFilter.scala
+++ b/src/main/scala/scalismo/image/filter/DiscreteImageFilter.scala
@@ -37,7 +37,7 @@ object DiscreteImageFilter {
     val scalar = implicitly[Scalar[A]]
 
     def doDistanceTransformVTK(img: DiscreteImage[D, A]) = {
-      val imgvtk = ImageConversion.imageToVtkStructuredPoints(img)
+      val imgvtk = ImageConversion.imageToVtkStructuredPoints(img, ImageConversion.VtkNearestNeighborInterpolation)
 
       val vtkdistTransform = new vtkImageEuclideanDistance()
 
@@ -91,7 +91,7 @@ object DiscreteImageFilter {
     vtkConversion: CanConvertToVtk[D]
   ): DiscreteImage[D, A] = {
 
-    val vtkImg = vtkConversion.toVtk[A](img)
+    val vtkImg = vtkConversion.toVtk[A](img, ImageConversion.VtkCubicInterpolation)
     val dim = NDSpace[D].dimensionality
     val gaussianFilter = new vtkImageGaussianSmooth()
     gaussianFilter.SetInputData(vtkImg)

--- a/src/main/scala/scalismo/io/FastReadOnlyNiftiVolume.scala
+++ b/src/main/scala/scalismo/io/FastReadOnlyNiftiVolume.scala
@@ -132,7 +132,6 @@ class FastReadOnlyNiftiVolume private (private val filename: String) {
       toScalarArray(data)
     }
 
-
     /**
      * Loads the the data from the nifti volume, but transforms it first using the transform.
      * The result type is guaranteed to be of type float. The reason for converting to float is,
@@ -142,8 +141,8 @@ class FastReadOnlyNiftiVolume private (private val filename: String) {
      * to be what ITK (and hence 3D Slicer and itkSnap) is doing.
      */
     def loadArrayWithTransform[U: ClassTag](sizeof: Int,
-                                  load: MappedByteBuffer => U,
-                                   toFloat: U => Float): ScalarArray[Float] = {
+                                            load: MappedByteBuffer => U,
+                                            toFloat: U => Float): ScalarArray[Float] = {
       val file = new RandomAccessFile(filename, "r")
       val channel = file.getChannel
       val mapped = channel.map(FileChannel.MapMode.READ_ONLY, header.vox_offset.toLong, arrayLength * sizeof)
@@ -168,7 +167,6 @@ class FastReadOnlyNiftiVolume private (private val filename: String) {
 
       FloatIsScalar.createArray(data)
     }
-
 
     import Scalar._
 
@@ -225,7 +223,9 @@ class FastReadOnlyNiftiVolume private (private val filename: String) {
           if (x >= 0) x.toFloat else Math.abs(x.toFloat) + (1 << 15)
         }
         if (hasTransform) {
-          loadArrayWithTransform[Char](2, loadChar, { x => toFloat(x.toShort) })
+          loadArrayWithTransform[Char](2, loadChar, { x =>
+            toFloat(x.toShort)
+          })
         } else {
           loadArray[Char, UShort](2, loadChar, UShortIsScalar.createArray)
         }
@@ -255,7 +255,7 @@ class FastReadOnlyNiftiVolume private (private val filename: String) {
           loadArrayWithTransform[Double](8, loadDouble, _.toFloat)
         } else {
           loadArray[Double, Double](8, loadDouble, DoubleIsScalar.createArray)
-    }
+        }
       case _ => throw new UnsupportedOperationException(f"Unsupported Nifti data type ${header.datatype}")
     }
 

--- a/src/main/scala/scalismo/io/FastReadOnlyNiftiVolume.scala
+++ b/src/main/scala/scalismo/io/FastReadOnlyNiftiVolume.scala
@@ -15,11 +15,12 @@
  */
 package scalismo.io
 
+import scalismo.common.Scalar.{FloatIsScalar, IntIsScalar}
+
 import java.io.{File, RandomAccessFile}
 import java.lang.{Double => JDouble, Float => JFloat, Long => JLong, Short => JShort}
 import java.nio.channels.FileChannel
 import java.nio.{ByteBuffer, MappedByteBuffer}
-
 import scalismo.common.{Scalar, ScalarArray}
 import scalismo.io.FastReadOnlyNiftiVolume.NiftiHeader
 import spire.math.{UByte, UInt, UShort}
@@ -63,7 +64,7 @@ class FastReadOnlyNiftiVolume private (private val filename: String) {
     new NiftiHeader(buf)
   }
 
-  private val hasTransform = {
+  val hasTransform = {
     // scl_slope == 0 -> no transformations
     // performance optimization: special case of slope=1, inter=0 is also detected and ignored (because a * 1 + 0 == a)
     val notransform = header.scl_slope == 0 || (header.scl_slope == 1.0f && header.scl_inter == 0.0f)
@@ -74,7 +75,7 @@ class FastReadOnlyNiftiVolume private (private val filename: String) {
   private val doTransform = {
     val slope = header.scl_slope
     val inter = header.scl_inter
-    def adjust(value: Double): Double = value * slope + inter
+    def adjust(value: Float): Float = value * slope + inter
     adjust _
   }
 
@@ -95,12 +96,18 @@ class FastReadOnlyNiftiVolume private (private val filename: String) {
 
     val arrayLength = nx * ny * nz * dim
 
+    /**
+     * This method loads the nifty data into a scalismo ScalarArray of the right type.
+     * The output type O can be different from the input type U, due to the issue
+     * with unsigned and signed types in Scala, which needs to be handled correctly.
+     *
+     * This method must only be called if the nifty file does not specify a transform
+     * of the intensities. Otherwise loadArrayWithTransform,
+     */
     def loadArray[U: ClassTag, O](sizeof: Int,
                                   load: MappedByteBuffer => U,
-                                  toDouble: U => Double,
-                                  fromDouble: Double => O,
-                                  downcast: O => U,
                                   toScalarArray: Array[U] => ScalarArray[O]): ScalarArray[O] = {
+      assert(!hasTransform)
       val file = new RandomAccessFile(filename, "r")
       val channel = file.getChannel
       val mapped = channel.map(FileChannel.MapMode.READ_ONLY, header.vox_offset.toLong, arrayLength * sizeof)
@@ -110,8 +117,7 @@ class FastReadOnlyNiftiVolume private (private val filename: String) {
 
       var i = 0
       while (i < arrayLength) {
-        val d = load(mapped)
-        data(i) = if (hasTransform) downcast(fromDouble(doTransform(toDouble(d)))) else d
+        data(i) = load(mapped)
         i += 1
       }
 
@@ -125,6 +131,44 @@ class FastReadOnlyNiftiVolume private (private val filename: String) {
 
       toScalarArray(data)
     }
+
+
+    /**
+     * Loads the the data from the nifti volume, but transforms it first using the transform.
+     * The result type is guaranteed to be of type float. The reason for converting to float is,
+     * that if we kept the original type (e.g. unsigned short) but the intensities are shifted to
+     * the negative, it would result in data loss. Converting everything to float might be a bit
+     * wasteful in terms of memory, but avoids to many different type variants and also seems
+     * to be what ITK (and hence 3D Slicer and itkSnap) is doing.
+     */
+    def loadArrayWithTransform[U: ClassTag](sizeof: Int,
+                                  load: MappedByteBuffer => U,
+                                   toFloat: U => Float): ScalarArray[Float] = {
+      val file = new RandomAccessFile(filename, "r")
+      val channel = file.getChannel
+      val mapped = channel.map(FileChannel.MapMode.READ_ONLY, header.vox_offset.toLong, arrayLength * sizeof)
+      val data = Array.ofDim[Float](arrayLength)
+
+      mapped.load()
+
+      var i = 0
+      while (i < arrayLength) {
+        val d = load(mapped)
+        data(i) = doTransform(toFloat(d))
+        i += 1
+      }
+
+      channel.close()
+      file.close()
+
+      // ByteBuffer is only freed on garbage collection, so try to force that
+      for (i <- 1 to 3) {
+        System.gc()
+      }
+
+      FloatIsScalar.createArray(data)
+    }
+
 
     import Scalar._
 
@@ -154,54 +198,64 @@ class FastReadOnlyNiftiVolume private (private val filename: String) {
 
     val out = header.datatype match {
       case NIFTI_TYPE_INT8 =>
-        loadArray[Byte, Byte](1, _.get, _.toDouble, _.toByte, { x =>
-          x
-        }, Scalar.ByteIsScalar.createArray)
+        if (hasTransform) {
+          loadArrayWithTransform[Byte](1, _.get, _.toFloat)
+        } else {
+          loadArray[Byte, Byte](1, _.get, Scalar.ByteIsScalar.createArray)
+        }
 
       case NIFTI_TYPE_UINT8 =>
-        val toDouble = { x: Byte =>
-          if (x >= 0) x.toDouble else x.toDouble + 256.0
+        val toFloat = { x: Byte =>
+          if (x >= 0) x.toFloat else x.toFloat + 256.0f
         }
-        loadArray[Byte, UByte](1, _.get, toDouble, UByteIsScalar.fromDouble, _.toByte, UByteIsScalar.createArray)
-
+        if (hasTransform) {
+          loadArrayWithTransform[Byte](1, _.get, toFloat)
+        } else {
+          loadArray[Byte, UByte](1, _.get, UByteIsScalar.createArray)
+        }
       case NIFTI_TYPE_INT16 =>
-        loadArray[Short, Short](2, loadShort, _.toDouble, _.toShort, { x =>
-          x
-        }, ShortIsScalar.createArray)
+        if (hasTransform) {
+          loadArrayWithTransform[Byte](1, _.get, _.toFloat)
+        } else {
+          loadArray[Short, Short](2, loadShort, ShortIsScalar.createArray)
+        }
 
       case NIFTI_TYPE_UINT16 =>
-        val toDouble = { x: Short =>
-          if (x >= 0) x.toDouble else Math.abs(x.toDouble) + (1 << 15)
+        val toFloat = { x: Short =>
+          if (x >= 0) x.toFloat else Math.abs(x.toFloat) + (1 << 15)
         }
-        loadArray[Char, UShort](2, loadChar, { x =>
-          toDouble(x.toShort)
-        }, UShortIsScalar.fromDouble, _.toChar, UShortIsScalar.createArray)
-
+        if (hasTransform) {
+          loadArrayWithTransform[Char](2, loadChar, { x => toFloat(x.toShort) })
+        } else {
+          loadArray[Char, UShort](2, loadChar, UShortIsScalar.createArray)
+        }
       case NIFTI_TYPE_INT32 =>
-        loadArray[Int, Int](4, loadInt, _.toDouble, _.toInt, { x =>
-          x
-        }, IntIsScalar.createArray)
-
-      case NIFTI_TYPE_UINT32 =>
-        val toDouble = { x: Int =>
-          if (x >= 0) x.toDouble else Math.abs(x.toDouble) + (1 << 31)
+        if (hasTransform) {
+          loadArrayWithTransform[Int](4, _.get, _.toFloat)
+        } else {
+          loadArray[Int, Int](4, loadInt, IntIsScalar.createArray)
         }
-        loadArray[Int, UInt](4, loadInt, toDouble, UIntIsScalar.fromDouble, _.toInt, UIntIsScalar.createArray)
+      case NIFTI_TYPE_UINT32 =>
+        val toFloat = { x: Int =>
+          if (x >= 0) x.toFloat else Math.abs(x.toFloat) + (1 << 31)
+        }
+        if (hasTransform) {
+          loadArrayWithTransform[Int](4, loadInt, toFloat)
+        }
+        loadArray[Int, UInt](4, loadInt, UIntIsScalar.createArray)
 
       case NIFTI_TYPE_FLOAT32 =>
-        loadArray[Float, Float](4, loadFloat, _.toDouble, _.toFloat, { x =>
-          x
-        }, FloatIsScalar.createArray)
-
+        if (hasTransform) {
+          loadArrayWithTransform[Float](4, loadFloat, _.toFloat)
+        } else {
+          loadArray[Float, Float](4, loadFloat, FloatIsScalar.createArray)
+        }
       case NIFTI_TYPE_FLOAT64 =>
-        loadArray[Double, Double](8, loadDouble, { x =>
-          x
-        }, { x =>
-          x
-        }, { x =>
-          x
-        }, DoubleIsScalar.createArray)
-
+        if (hasTransform) {
+          loadArrayWithTransform[Double](8, loadDouble, _.toFloat)
+        } else {
+          loadArray[Double, Double](8, loadDouble, DoubleIsScalar.createArray)
+    }
       case _ => throw new UnsupportedOperationException(f"Unsupported Nifti data type ${header.datatype}")
     }
 

--- a/src/main/scala/scalismo/io/ImageIO.scala
+++ b/src/main/scala/scalismo/io/ImageIO.scala
@@ -278,9 +278,11 @@ object ImageIO {
       else ScalarDataType.fromNiftiId(volume.header.datatype)
 
     if (expectedScalarType != foundScalarType) {
-      Failure(new IllegalArgumentException(
-        s"Invalid scalar type (expected $expectedScalarType, found $foundScalarType)"
-      ))
+      Failure(
+        new IllegalArgumentException(
+          s"Invalid scalar type (expected $expectedScalarType, found $foundScalarType)"
+        )
+      )
     } else {
 
       // First we compute origin, spacing and size
@@ -415,10 +417,7 @@ object ImageIO {
       def computeInnerAffineMatrix(domain: StructuredPoints[_3D]): DenseMatrix[Double] = {
         val scalingParams = DenseVector[Double](domain.spacing(0), domain.spacing(1), domain.spacing(2))
         val scalingMatrix = diag(scalingParams)
-        val innerAffineMatrix = RotationSpace3D
-          .eulerAnglesToRotMatrix(0, 0, 0) // TODO fix me
-          .toBreezeMatrix * scalingMatrix
-        innerAffineMatrix
+        domain.directions.toBreezeMatrix * scalingMatrix
       }
 
       val innerAffineMatrix = computeInnerAffineMatrix(img.domain.pointSet)

--- a/src/main/scala/scalismo/utils/Conversions.scala
+++ b/src/main/scala/scalismo/utils/Conversions.scala
@@ -531,16 +531,16 @@ object CanConvertToVtk {
       sp.SetDimensions(domain.size(0), domain.size(1), domain.size(2))
 
       val corners = List(
-        Point(0, 0, 0),
-        Point(domain.size(0) - 1, 0, 0),
-        Point(0, domain.size(1) - 1, 0),
-        Point(0, 0, domain.size(2) - 1),
-        Point(domain.size(0) - 1, domain.size(1) - 1, 0),
-        Point(domain.size(0) - 1, 0, domain.size(2) - 1),
-        Point(0, domain.size(1) - 1, domain.size(2) - 1),
-        Point(domain.size(0) - 1, domain.size(1) - 1, domain.size(2) - 1)
+        IntVector3D(0, 0, 0),
+        IntVector3D(domain.size(0) - 1, 0, 0),
+        IntVector3D(0, domain.size(1) - 1, 0),
+        IntVector3D(0, 0, domain.size(2) - 1),
+        IntVector3D(domain.size(0) - 1, domain.size(1) - 1, 0),
+        IntVector3D(domain.size(0) - 1, 0, domain.size(2) - 1),
+        IntVector3D(0, domain.size(1) - 1, domain.size(2) - 1),
+        IntVector3D(domain.size(0) - 1, domain.size(1) - 1, domain.size(2) - 1)
       )
-      val cornerImages = corners.map(domain.indexToPhysicalCoordinateTransform)
+      val cornerImages = corners.map(domain.indexToPoint)
       val newOriginX = cornerImages.map(p => p(0)).min
       val newOriginY = cornerImages.map(p => p(1)).min
       val newOriginZ = cornerImages.map(p => p(2)).min

--- a/src/main/scala/scalismo/utils/Conversions.scala
+++ b/src/main/scala/scalismo/utils/Conversions.scala
@@ -22,7 +22,12 @@ import scalismo.image.{DiscreteImage, DiscreteImageDomain, StructuredPoints}
 import scalismo.io.{ImageIO, ScalarDataType}
 import scalismo.mesh._
 import scalismo.mesh.{TetrahedralCell, TetrahedralList, TetrahedralMesh, TetrahedralMesh3D}
-import scalismo.utils.ImageConversion.{VtkCubicInterpolation, VtkInterpolationMode, VtkLinearInterpolation, VtkNearestNeighborInterpolation}
+import scalismo.utils.ImageConversion.{
+  VtkCubicInterpolation,
+  VtkInterpolationMode,
+  VtkLinearInterpolation,
+  VtkNearestNeighborInterpolation
+}
 import spire.math.{UByte, UInt, ULong, UShort}
 import vtk._
 
@@ -441,7 +446,8 @@ object CommonConversions {
 }
 
 trait CanConvertToVtk[D] {
-  def toVtk[Pixel: Scalar: ClassTag](img: DiscreteImage[D, Pixel], interpolationMode : VtkInterpolationMode): vtkStructuredPoints = {
+  def toVtk[Pixel: Scalar: ClassTag](img: DiscreteImage[D, Pixel],
+                                     interpolationMode: VtkInterpolationMode): vtkStructuredPoints = {
     val sp = new vtkStructuredPoints()
     sp.SetNumberOfScalarComponents(1, new vtkInformation())
     val dataArray = img.data match {
@@ -460,7 +466,9 @@ trait CanConvertToVtk[D] {
     orientedSP
   }
 
-  def setDomainInfo(domain: StructuredPoints[D], sp: vtkStructuredPoints, interpolationMode : VtkInterpolationMode): vtkStructuredPoints
+  def setDomainInfo(domain: StructuredPoints[D],
+                    sp: vtkStructuredPoints,
+                    interpolationMode: VtkInterpolationMode): vtkStructuredPoints
 
   def fromVtk[Pixel: Scalar: ClassTag](sp: vtkImageData): Try[DiscreteImage[D, Pixel]]
 
@@ -484,7 +492,9 @@ object CanConvertToVtk {
 
   implicit object _2DCanConvertToVtk$ extends CanConvertToVtk[_2D] {
 
-    override def setDomainInfo(domain: StructuredPoints[_2D], sp: vtkStructuredPoints, interpolationMode: VtkInterpolationMode): vtkStructuredPoints = {
+    override def setDomainInfo(domain: StructuredPoints[_2D],
+                               sp: vtkStructuredPoints,
+                               interpolationMode: VtkInterpolationMode): vtkStructuredPoints = {
       sp.SetDimensions(domain.size(0), domain.size(1), 1)
       sp.SetOrigin(domain.origin(0), domain.origin(1), 0)
       sp.SetSpacing(domain.spacing(0), domain.spacing(1), 0)
@@ -523,7 +533,9 @@ object CanConvertToVtk {
   }
 
   implicit object _3DCanConvertToVtk$ extends CanConvertToVtk[_3D] {
-    override def setDomainInfo(domain: StructuredPoints[_3D], sp: vtkStructuredPoints, interpolationMode : VtkInterpolationMode): vtkStructuredPoints = {
+    override def setDomainInfo(domain: StructuredPoints[_3D],
+                               sp: vtkStructuredPoints,
+                               interpolationMode: VtkInterpolationMode): vtkStructuredPoints = {
 
       // Here depending on the image directions (if read from Nifti, can be anything RAS, ASL, LAS, ..),
       // we need to reslice the image in vtk's voxel ordering that is RAI (which in our LPS world coordinates system
@@ -564,8 +576,8 @@ object CanConvertToVtk {
       reslice.SetInputData(sp)
       reslice.SetResliceTransform(landmarkTransform)
       interpolationMode match {
-        case VtkCubicInterpolation =>  reslice.SetInterpolationModeToCubic()
-        case VtkLinearInterpolation => reslice.SetInterpolationModeToLinear()
+        case VtkCubicInterpolation           => reslice.SetInterpolationModeToCubic()
+        case VtkLinearInterpolation          => reslice.SetInterpolationModeToLinear()
         case VtkNearestNeighborInterpolation => reslice.SetInterpolationModeToNearestNeighbor()
       }
       reslice.SetInterpolationModeToNearestNeighbor()
@@ -622,14 +634,14 @@ object CanConvertToVtk {
 
 object ImageConversion {
 
-
   sealed trait VtkInterpolationMode
   case object VtkCubicInterpolation extends VtkInterpolationMode
   case object VtkNearestNeighborInterpolation extends VtkInterpolationMode
   case object VtkLinearInterpolation extends VtkInterpolationMode
 
   def imageToVtkStructuredPoints[D: CanConvertToVtk, Pixel: Scalar: ClassTag](
-    img: DiscreteImage[D, Pixel], interpolationMode : VtkInterpolationMode
+    img: DiscreteImage[D, Pixel],
+    interpolationMode: VtkInterpolationMode
   ): vtkStructuredPoints = {
     implicitly[CanConvertToVtk[D]].toVtk(img, interpolationMode)
   }

--- a/src/test/scala/scalismo/image/DiscreteImageDomainTests.scala
+++ b/src/test/scala/scalismo/image/DiscreteImageDomainTests.scala
@@ -9,6 +9,7 @@ class DiscreteImageDomainTests extends ScalismoTestSuite {
   describe("A DiscreteImageDomain") {
     it("keeps the same bounding box when it is created with a new size") {
       val domain = DiscreteImageDomain2D(Point2D(1.0, 3.5), EuclideanVector2D(1.0, 2.1), IntVector2D(42, 49))
+
       val newDomain = DiscreteImageDomain2D(domain.boundingBox, size = domain.size.map(i => (i * 1.5).toInt))
 
       newDomain.boundingBox.origin should equal(domain.boundingBox.origin)

--- a/src/test/scala/scalismo/image/StructuredPointsTests.scala
+++ b/src/test/scala/scalismo/image/StructuredPointsTests.scala
@@ -112,7 +112,7 @@ class StructuredPointsTests extends ScalismoTestSuite {
 
       // this test implicitly tests also the method pointToContinuousIndex
 
-      val domain = StructuredPoints[_3D]((1.0, 2.0, 3.0), (2.0, 1.0, 0.0), (42, 49, 74))
+      val domain = StructuredPoints[_3D]((1.0, 2.0, 3.0), (2.0, 1.0, 1.0), (42, 49, 74))
 
       val distx = rng.breezeRandBasis.uniform.map(u => domain.spacing(0) * 0.4)
       val disty = rng.breezeRandBasis.uniform.map(u => domain.spacing(1) * 0.4)

--- a/src/test/scala/scalismo/image/StructuredPointsTests.scala
+++ b/src/test/scala/scalismo/image/StructuredPointsTests.scala
@@ -137,7 +137,7 @@ class StructuredPointsTests extends ScalismoTestSuite {
 
       assert((trans(IntVector3D(0, 0, 0)) - img.domain.origin).norm < 0.1)
 
-      val upperRightMostPoint = IntVector3D(img.domain.size(0) - 1 , img.domain.size(1) - 1, img.domain.size(2) - 1)
+      val upperRightMostPoint = IntVector3D(img.domain.size(0) - 1, img.domain.size(1) - 1, img.domain.size(2) - 1)
       (trans(upperRightMostPoint) - img.domain.pointSet.boundingBox.oppositeCorner).norm should be < 0.1
 
       val index = IntVector3D(3, 7, 1)

--- a/src/test/scala/scalismo/image/StructuredPointsTests.scala
+++ b/src/test/scala/scalismo/image/StructuredPointsTests.scala
@@ -130,22 +130,18 @@ class StructuredPointsTests extends ScalismoTestSuite {
       assert(domain1 == domain2)
     }
 
-    it("the anisotropic similarity transform defining the domain is correct and invertible") {
-
+    it("the internal transformations are correct") {
       val img = Fixture.img
+      val trans = img.domain.pointSet.indexToPoint _
+      val inverseTrans = img.domain.pointSet.pointToIndex _
 
-      val trans = img.domain.pointSet.indexToPhysicalCoordinateTransform
-      val inverseTrans = img.domain.pointSet.physicalCoordinateToContinuousIndex
+      assert((trans(IntVector3D(0, 0, 0)) - img.domain.origin).norm < 0.1)
 
-      assert((trans(Point(0, 0, 0)) - img.domain.origin).norm < 0.1)
-      assert(inverseTrans(img.domain.origin).toVector.norm < 0.1)
+      val upperRightMostPoint = IntVector3D(img.domain.size(0) - 1 , img.domain.size(1) - 1, img.domain.size(2) - 1)
+      (trans(upperRightMostPoint) - img.domain.pointSet.boundingBox.oppositeCorner).norm should be < 0.1
 
-      (trans(Point(img.domain.size(0) - 1, img.domain.size(1) - 1, img.domain.size(2) - 1)) - img.domain.pointSet.boundingBox.oppositeCorner).norm should be < 0.1
-      (inverseTrans(img.domain.pointSet.boundingBox.oppositeCorner) - Point(
-        img.domain.size(0) - 1,
-        img.domain.size(1) - 1,
-        img.domain.size(2) - 1
-      )).norm should be < 0.1
+      val index = IntVector3D(3, 7, 1)
+      inverseTrans(trans(index)) should equal(index)
     }
 
     it("Domain points in chunks returns the correct list of points") {

--- a/src/test/scala/scalismo/io/ImageIOTests.scala
+++ b/src/test/scala/scalismo/io/ImageIOTests.scala
@@ -17,13 +17,11 @@ package scalismo.io
 
 import java.io.File
 import java.net.URLDecoder
-
 import breeze.linalg.{DenseMatrix, DenseVector}
 import niftijio.NiftiVolume
 import scalismo.ScalismoTestSuite
 import scalismo.common.{PointId, Scalar, ScalarArray}
 import scalismo.geometry._
-
 import scalismo.image.{
   DiscreteImage,
   DiscreteImageDomain,
@@ -31,6 +29,7 @@ import scalismo.image.{
   DiscreteImageDomain3D,
   StructuredPoints
 }
+import scalismo.transformations.Rotation3D
 import scalismo.utils.CanConvertToVtk
 import spire.math.{UByte, UInt, UShort}
 

--- a/src/test/scala/scalismo/io/ImageIOTests.scala
+++ b/src/test/scala/scalismo/io/ImageIOTests.scala
@@ -249,6 +249,30 @@ class ImageIOTests extends ScalismoTestSuite {
     }
   }
 
+  describe("An 3D image in non-standard orientation 3D scalar image") {
+    it("can be written and reread again") {
+      val pathH5 = getClass.getResource("/3Dimage-in-nonstandard-orientation.nii").getPath
+      val origImg = ImageIO.read3DScalarImage[Short](new File(URLDecoder.decode(pathH5, "UTF-8"))).get
+      val tmpfile = File.createTempFile("dummy", ".nii")
+      tmpfile.deleteOnExit()
+
+      ImageIO.writeNifti(origImg, tmpfile).get
+
+      val rereadImg = ImageIO.read3DScalarImage[Short](tmpfile).get
+
+      (origImg.domain.origin - rereadImg.domain.origin).norm should be(0.0 +- 1e-2)
+
+      (origImg.domain.spacing - rereadImg.domain.spacing).norm should be(0.0 +- 1e-2)
+      origImg.domain.size should equal(rereadImg.domain.size)
+      origImg.domain.pointSet.directions should equal(rereadImg.domain.pointSet.directions)
+
+      origImg.domain.pointSet.points.toIndexedSeq should equal(rereadImg.domain.pointSet.points.toIndexedSeq)
+      for (id <- origImg.domain.pointSet.pointIds) {
+        origImg(id) should equal(rereadImg(id))
+      }
+    }
+  }
+
   describe("ImageIO") {
     it("is type safe") {
 

--- a/src/test/scala/scalismo/utils/ConversionTests.scala
+++ b/src/test/scala/scalismo/utils/ConversionTests.scala
@@ -44,7 +44,7 @@ class ConversionTests extends ScalismoTestSuite {
     it("can be converted to and from vtk") {
       val path = getClass.getResource("/lena.vtk").getPath
       val origimg = ImageIO.read2DScalarImage[Short](new java.io.File(URLDecoder.decode(path, "UTF-8"))).get
-      val vtksp = ImageConversion.imageToVtkStructuredPoints(origimg)
+      val vtksp = ImageConversion.imageToVtkStructuredPoints(origimg, ImageConversion.VtkCubicInterpolation)
       val restoredImg = ImageConversion.vtkStructuredPointsToScalarImage[_2D, Short](vtksp).get
 
       origimg should equal(restoredImg)


### PR DESCRIPTION
This PR fixes two issues regarding volume images read from nifti. The first concerns the handling of images, whose axis are not the standard coordinate axis used in Scalismo. The second fixes the datatype that is assigned when a transformation of the intensities is specified. Here some more details regarding the two issues:

1. Some image formats allow that images are not aligned to the standard coordinate axis, but rotated by a given transformation. So far this was  handled by specifying an anisotropic transformation in the structuredpointsdomain. In this commit we change this to use three  direction vectors instead. Specifying the direction vectors seems more intuitive than specifying a transformation and it is also  what tools like Slicer and itkSnap report. Furthermore, by specifying the direction vectors we can deal with reflections, without having to  introduce new transformations into the already complicated  transformation hierarchy.

2. The nifti format allows for the specification of a linear transformation for transforming the intensities. If such a transformation is specified, it makes most sense to  change the datatype to float, as otherwise the range of the transformation might not be captured. This commit changes  the code such that whenever a transform is specified,  the datatype is fixed to float.