### PR TITLE
Intensity model io

### DIFF
--- a/src/main/scala/scalismo/io/StatismoIO.scala
+++ b/src/main/scala/scalismo/io/StatismoIO.scala
@@ -556,7 +556,7 @@ object StatismoIO {
     DenseMatrix.create(array.dims(1).toInt, array.dims(0).toInt, array.data).t
   }
 
-  def readIntensityModel[D : NDSpace, DDomain[D] <: DiscreteDomain[D], S: Scalar : Vectorizer](
+  def readIntensityModel[D: NDSpace, DDomain[D] <: DiscreteDomain[D], S: Scalar: Vectorizer](
     file: File,
     modelPath: String = "/"
   )(implicit domainIO: StatismoDomainIO[D, DDomain]): Try[DiscreteLowRankGaussianProcess[D, DDomain, S]] = {
@@ -588,15 +588,14 @@ object StatismoIO {
     modelOrFailure
   }
 
-  def writeIntensityModel[D : NDSpace, DDomain[D] <: DiscreteDomain[D], S: Scalar](
+  def writeIntensityModel[D: NDSpace, DDomain[D] <: DiscreteDomain[D], S: Scalar](
     gp: DiscreteLowRankGaussianProcess[D, DDomain, S],
     file: File,
     modelPath: String = "/"
-  )(implicit domainIO : StatismoDomainIO[D, DDomain]): Try[Unit] = {
+  )(implicit domainIO: StatismoDomainIO[D, DDomain]): Try[Unit] = {
     val meanVector = gp.meanVector.toArray
     val variance = gp.variance
     val pcaBasis = gp.basisMatrix.copy
-
 
     val maybeError = for {
       h5file <- HDF5Utils.createFile(file = file)
@@ -605,8 +604,8 @@ object StatismoIO {
       _ <- h5file.writeArray[Float](s"$modelPath/model/mean", meanVector.map(_.toFloat))
       _ <- h5file.writeArray[Float](s"$modelPath/model/noiseVariance", Array(0f))
       _ <- h5file.writeNDArray[Float](s"$modelPath/model/pcaBasis",
-        NDArray(Array(pcaBasis.rows, pcaBasis.cols).map(_.toLong).toIndexedSeq,
-          pcaBasis.t.flatten(false).toArray.map(_.toFloat)))
+                                      NDArray(Array(pcaBasis.rows, pcaBasis.cols).map(_.toLong).toIndexedSeq,
+                                              pcaBasis.t.flatten(false).toArray.map(_.toFloat)))
       _ <- h5file.writeArray[Float](s"$modelPath/model/pcaVariance", variance.toArray.map(_.toFloat))
       _ <- h5file.writeString(s"$modelPath/modelinfo/build-time", Calendar.getInstance.getTime.toString)
       _ <- h5file.writeInt("/version/majorVersion", 0)

--- a/src/main/scala/scalismo/io/StatisticalModelIO.scala
+++ b/src/main/scala/scalismo/io/StatisticalModelIO.scala
@@ -338,7 +338,7 @@ object StatisticalModelIO {
    * @return Success if model could be read, Failure otherwise
    */
   def writeVolumeMeshIntensityModel3D(gp: DiscreteLowRankGaussianProcess[_3D, TetrahedralMesh, Float],
-                                                 file: File): Try[Unit] = {
+                                      file: File): Try[Unit] = {
     StatismoIO.writeIntensityModel[_3D, TetrahedralMesh, Float](gp, file, "/")
   }
 

--- a/src/main/scala/scalismo/io/StatisticalModelIO.scala
+++ b/src/main/scala/scalismo/io/StatisticalModelIO.scala
@@ -16,8 +16,7 @@
 package scalismo.io
 
 import java.io._
-
-import scalismo.common.UnstructuredPointsDomain
+import scalismo.common.{Scalar, UnstructuredPointsDomain, Vectorizer}
 import scalismo.geometry.{_1D, _2D, _3D, EuclideanVector}
 import scalismo.image.DiscreteImageDomain
 import scalismo.mesh.{LineMesh, TetrahedralMesh, TriangleMesh}
@@ -318,4 +317,54 @@ object StatisticalModelIO {
                               file: File): Try[Unit] = {
     StatismoIO.writeStatismoImageModel[_3D, EuclideanVector[_3D]](gp, file, "/")
   }
+
+  /**
+   * Reads an intensity model defined on a tetrahedral mesh
+   *
+   * @param file the file to which the model is written
+   * @return A try, where the success case holds the model, and the failure case the corresponding exception
+   */
+  def readVolumeMeshIntensityModel3D(
+    file: File
+  ): Try[DiscreteLowRankGaussianProcess[_3D, TetrahedralMesh, Float]] = {
+    StatismoIO.readIntensityModel[_3D, TetrahedralMesh, Float](file, "/")
+  }
+
+  /**
+   * Writes a model of 3D deformation fields defined on a 3D tetrahedral mesh
+   *
+   * @param gp the deformation model
+   * @param file the file to which the model is written
+   * @return Success if model could be read, Failure otherwise
+   */
+  def writeVolumeMeshIntensityModel3D(gp: DiscreteLowRankGaussianProcess[_3D, TetrahedralMesh, Float],
+                                                 file: File): Try[Unit] = {
+    StatismoIO.writeIntensityModel[_3D, TetrahedralMesh, Float](gp, file, "/")
+  }
+
+  /**
+   * Reads an intensity model defined on an image domain
+   *
+   * @param file the file to which the model is written
+   * @return A try, where the success case holds the model, and the failure case the corresponding exception
+   */
+  def readImageIntensityModel3D(
+    file: File
+  ): Try[DiscreteLowRankGaussianProcess[_3D, DiscreteImageDomain, Float]] = {
+    StatismoIO.readStatismoImageModel[_3D, Float](file, "/")
+  }
+
+  /** Writes a model of 3D deformation fields defined on a 3D image domain
+   *
+   * @param gp the deformation model
+   * @param file the file to which the model is written
+   * @return Success if model could be read, Failure otherwise
+   */
+  def writeImageIntensityModel3D[Domain[D] <: DiscreteImageDomain[D]](
+    gp: DiscreteLowRankGaussianProcess[_3D, DiscreteImageDomain, Float],
+    file: File
+  ): Try[Unit] = {
+    StatismoIO.writeStatismoImageModel[_3D, Float](gp, file, "/")
+  }
+
 }

--- a/src/test/scala/scalismo/io/MeshIOTests.scala
+++ b/src/test/scala/scalismo/io/MeshIOTests.scala
@@ -20,7 +20,7 @@ import java.net.URLDecoder
 import scalismo.ScalismoTestSuite
 import scalismo.common.DiscreteField.{ScalarMeshField, ScalarVolumeMeshField}
 import scalismo.common.{DiscreteField, PointId, Scalar, ScalarArray, ScalarMeshField, UnstructuredPoints}
-import scalismo.geometry.{Point, _3D}
+import scalismo.geometry.{_3D, Point}
 import scalismo.io.MeshIOTests.{createRandomScalarVolumeMeshField, createRandomTetrahedralMesh}
 import scalismo.mesh._
 import scalismo.utils.Random
@@ -272,8 +272,8 @@ object MeshIOTests {
     val N = 200
     val points = IndexedSeq.fill(N)(
       Point(rng.scalaRandom.nextGaussian() * 2,
-        rng.scalaRandom.nextGaussian() * 100,
-        rng.scalaRandom.nextGaussian() * 1000)
+            rng.scalaRandom.nextGaussian() * 100,
+            rng.scalaRandom.nextGaussian() * 1000)
     )
     val domain = UnstructuredPoints(points)
 
@@ -282,9 +282,9 @@ object MeshIOTests {
     val T = 200
     val cells = IndexedSeq.fill(T)(
       TetrahedralCell(rng.scalaRandom.nextInt(N),
-        rng.scalaRandom.nextInt(N),
-        rng.scalaRandom.nextInt(N),
-        rng.scalaRandom.nextInt(N))
+                      rng.scalaRandom.nextInt(N),
+                      rng.scalaRandom.nextInt(N),
+                      rng.scalaRandom.nextInt(N))
     )
     val list = TetrahedralList(cells)
 
@@ -300,6 +300,5 @@ object MeshIOTests {
     }.toIndexedSeq
     DiscreteField(tetraMesh, scalars)
   }
-
 
 }

--- a/src/test/scala/scalismo/io/MeshIOTests.scala
+++ b/src/test/scala/scalismo/io/MeshIOTests.scala
@@ -17,11 +17,11 @@ package scalismo.io
 
 import java.io.File
 import java.net.URLDecoder
-
 import scalismo.ScalismoTestSuite
 import scalismo.common.DiscreteField.{ScalarMeshField, ScalarVolumeMeshField}
 import scalismo.common.{DiscreteField, PointId, Scalar, ScalarArray, ScalarMeshField, UnstructuredPoints}
-import scalismo.geometry.{_3D, Point}
+import scalismo.geometry.{Point, _3D}
+import scalismo.io.MeshIOTests.{createRandomScalarVolumeMeshField, createRandomTetrahedralMesh}
 import scalismo.mesh._
 import scalismo.utils.Random
 
@@ -262,6 +262,9 @@ class MeshIOTests extends ScalismoTestSuite {
 
   }
 
+}
+
+object MeshIOTests {
   def createRandomTetrahedralMesh(): TetrahedralMesh3D = {
     // points around unit cube
 
@@ -269,8 +272,8 @@ class MeshIOTests extends ScalismoTestSuite {
     val N = 200
     val points = IndexedSeq.fill(N)(
       Point(rng.scalaRandom.nextGaussian() * 2,
-            rng.scalaRandom.nextGaussian() * 1000,
-            rng.scalaRandom.nextGaussian() * 1000000)
+        rng.scalaRandom.nextGaussian() * 100,
+        rng.scalaRandom.nextGaussian() * 1000)
     )
     val domain = UnstructuredPoints(points)
 
@@ -279,9 +282,9 @@ class MeshIOTests extends ScalismoTestSuite {
     val T = 200
     val cells = IndexedSeq.fill(T)(
       TetrahedralCell(rng.scalaRandom.nextInt(N),
-                      rng.scalaRandom.nextInt(N),
-                      rng.scalaRandom.nextInt(N),
-                      rng.scalaRandom.nextInt(N))
+        rng.scalaRandom.nextInt(N),
+        rng.scalaRandom.nextInt(N),
+        rng.scalaRandom.nextInt(N))
     )
     val list = TetrahedralList(cells)
 
@@ -297,5 +300,6 @@ class MeshIOTests extends ScalismoTestSuite {
     }.toIndexedSeq
     DiscreteField(tetraMesh, scalars)
   }
+
 
 }

--- a/src/test/scala/scalismo/io/StatisticalModelIOTest.scala
+++ b/src/test/scala/scalismo/io/StatisticalModelIOTest.scala
@@ -167,10 +167,13 @@ class StatisticalModelIOTest extends ScalismoTestSuite {
       val discreteGPReread = StatisticalModelIO.readVolumeMeshIntensityModel3D(tmpFile).get
 
       discreteGPReread.domain.pointSet.numberOfPoints should equal(discreteGP.domain.pointSet.numberOfPoints)
-      discreteGPReread.domain.pointSet.points.zip(discreteGP.domain.pointSet.points)
-        .foreach {case (p1, p2) =>
-          if ((p1 - p2).norm > 0.1) println(p1 + " : " + p2)
-        (p1 - p2).norm should be < 0.1}
+      discreteGPReread.domain.pointSet.points
+        .zip(discreteGP.domain.pointSet.points)
+        .foreach {
+          case (p1, p2) =>
+            if ((p1 - p2).norm > 0.1) println(p1 + " : " + p2)
+            (p1 - p2).norm should be < 0.1
+        }
       discreteGPReread.domain.cells.toSeq should equal(discreteGP.domain.cells.toSeq)
 
       // also here, due to conversion in float, smaller errors are expected

--- a/src/test/scala/scalismo/io/StatisticalModelIOTest.scala
+++ b/src/test/scala/scalismo/io/StatisticalModelIOTest.scala
@@ -17,12 +17,11 @@ package scalismo.io
 
 import java.io.File
 import java.net.URLDecoder
-
 import scalismo.ScalismoTestSuite
 import scalismo.common.interpolation.NearestNeighborInterpolator
 import scalismo.geometry._
 import scalismo.image.{DiscreteImageDomain, DiscreteImageDomain2D, DiscreteImageDomain3D}
-import scalismo.kernels.{DiagonalKernel, GaussianKernel}
+import scalismo.kernels.{DiagonalKernel, GaussianKernel, GaussianKernel3D}
 import scalismo.statisticalmodel.{GaussianProcess, LowRankGaussianProcess, StatisticalMeshModel}
 
 class StatisticalModelIOTest extends ScalismoTestSuite {
@@ -143,6 +142,36 @@ class StatisticalModelIOTest extends ScalismoTestSuite {
       (discreteGP.domain.origin - discreteGPReread.domain.origin).norm should be < 1e-5
       (discreteGP.domain.spacing - discreteGPReread.domain.spacing).norm should be < 1e-5
       discreteGP.domain.size should equal(discreteGPReread.domain.size)
+
+      // also here, due to conversion in float, smaller errors are expected
+      breeze.linalg.norm(discreteGP.meanVector - discreteGPReread.meanVector) should be < 1e-2
+      breeze.linalg.sum(discreteGP.basisMatrix - discreteGPReread.basisMatrix) should be < 1e-2
+      breeze.linalg.norm(discreteGP.variance - discreteGPReread.variance) should be < 1e-2
+
+    }
+
+  }
+
+  describe("a volume intensity model") {
+    it("can be created, saved and reread in 3D") {
+      val gp = GaussianProcess[_3D, Float](DiagonalKernel(GaussianKernel3D(10.0), 1))
+      val domain = MeshIOTests.createRandomTetrahedralMesh()
+
+      val lowrankGp = LowRankGaussianProcess.approximateGPCholesky(domain, gp, 0.1, NearestNeighborInterpolator())
+
+      val tmpFile = java.io.File.createTempFile("volumeIntensityModel", ".h5")
+      tmpFile.deleteOnExit()
+      val discreteGP = lowrankGp.discretize(domain)
+      StatisticalModelIO.writeVolumeMeshIntensityModel3D(discreteGP, tmpFile).get
+
+      val discreteGPReread = StatisticalModelIO.readVolumeMeshIntensityModel3D(tmpFile).get
+
+      discreteGPReread.domain.pointSet.numberOfPoints should equal(discreteGP.domain.pointSet.numberOfPoints)
+      discreteGPReread.domain.pointSet.points.zip(discreteGP.domain.pointSet.points)
+        .foreach {case (p1, p2) =>
+          if ((p1 - p2).norm > 0.1) println(p1 + " : " + p2)
+        (p1 - p2).norm should be < 0.1}
+      discreteGPReread.domain.cells.toSeq should equal(discreteGP.domain.cells.toSeq)
 
       // also here, due to conversion in float, smaller errors are expected
       breeze.linalg.norm(discreteGP.meanVector - discreteGPReread.meanVector) should be < 1e-2


### PR DESCRIPTION
Added io methods for intensity models (defined on arbitrary methods)

As part of the this PR, I also moved the helper methods in MeshIOTests into the companion object, such that they can be reused in other tests. In that process, the range of the created points of the ```createRandomTetrahedralMesh```  method was reduced, as such a large range leads to numerical problems in the test.