### PR TITLE
fixed the log normalization for the logpdf.

### DIFF
--- a/src/main/scala/scalismo/statisticalmodel/MultivariateNormalDistribution.scala
+++ b/src/main/scala/scalismo/statisticalmodel/MultivariateNormalDistribution.scala
@@ -50,7 +50,7 @@ case class MultivariateNormalDistribution(mean: DenseVector[Double], cov: DenseM
   override val dim = mean.size
 
   private lazy val covInv = breeze.linalg.pinv(cov.map(_.toDouble))
-  private lazy val logCovDet = 2 * (0 until root.rows).map(i => math.log(root(i,i))).sum
+  private lazy val logCovDet = 2 * (0 until root.rows).map(i => math.log(root(i, i))).sum
   private lazy val covDet = math.exp(logCovDet)
 
   // The root of the covariance matrix is precomputed for efficient sampling.

--- a/src/main/scala/scalismo/statisticalmodel/MultivariateNormalDistribution.scala
+++ b/src/main/scala/scalismo/statisticalmodel/MultivariateNormalDistribution.scala
@@ -50,7 +50,8 @@ case class MultivariateNormalDistribution(mean: DenseVector[Double], cov: DenseM
   override val dim = mean.size
 
   private lazy val covInv = breeze.linalg.pinv(cov.map(_.toDouble))
-  private lazy val covDet = det(cov.map(_.toDouble))
+  private lazy val logCovDet = 2 * (0 until root.rows).map(i => math.log(root(i,i))).sum
+  private lazy val covDet = math.exp(logCovDet)
 
   // The root of the covariance matrix is precomputed for efficient sampling.
   // The cholesky sometimes fails for ill conditioned matrices. We increase
@@ -87,11 +88,11 @@ case class MultivariateNormalDistribution(mean: DenseVector[Double], cov: DenseM
 
   override def logpdf(x: DenseVector[Double]) = {
     if (x.size != dim) throw new Exception(s"invalid vector dimensionality (provided ${x.size} should be $dim)")
-    val normFactor = math.pow(2.0 * math.Pi, -dim / 2.0) * 1.0 / math.sqrt(covDet + 1e-10)
+    val logNormFactor = -0.5 * (dim * math.log(2.0 * math.Pi) + logCovDet)
 
     val x0 = (x - mean).map(_.toDouble)
     val exponent = -0.5f * x0.dot(covInv * x0)
-    math.log(normFactor) + exponent
+    logNormFactor + exponent
 
   }
 

--- a/src/test/scala/scalismo/statisticalmodel/MultivariateNormalDistributionTests.scala
+++ b/src/test/scala/scalismo/statisticalmodel/MultivariateNormalDistributionTests.scala
@@ -34,6 +34,39 @@ class MultivariateNormalDistributionTests extends ScalismoTestSuite {
 
   }
 
+  describe("A nD diagonal Multivariate normal") {
+    it("should give the same logpdf values as breeze Gaussian with the same parameters to test numerical stability") {
+      val n = 100
+      val variance = 0.01
+      val mean = DenseVector.zeros[Double](n)
+      val cov = variance * DenseMatrix.eye[Double](n)
+      val mvn = new MultivariateNormalDistribution(mean, cov)
+      val breezeMvn = breeze.stats.distributions.MultivariateGaussian.apply(mean, cov)
+      for (v <- (1 to 4).map(_ =>
+                DenseVector.tabulate(n)(i => random.scalaRandom.nextGaussian()*math.sqrt(cov(i,i)) + mean(i)))) {
+        breezeMvn.logPdf(v) should be(mvn.logpdf(v) +- 1e-5)
+      }
+    }
+  }
+
+  describe("A nD Multivariate normal") {
+    it("should give the same logpdf values as breeze Gaussian with the same parameters to test numerical stability") {
+      val n = 100
+      val variance = 0.01
+      val mean = DenseVector.zeros[Double](n)
+      val cov = variance * DenseMatrix.eye[Double](n)
+      for (x <- 1 until cov.rows) {
+        cov(x,x-1) = 0.002
+        cov(x-1,x) = 0.002
+      }
+      cov(-1,0) = 0.002
+      cov(0,-1) = 0.002
+      val mvn = new MultivariateNormalDistribution(mean, cov)
+      val breezeMvn = breeze.stats.distributions.MultivariateGaussian.apply(mean, cov)
+      breezeMvn.logPdf(DenseVector.zeros[Double](n)) should be(mvn.logpdf(DenseVector.zeros[Double](n)) +- 1e-5)
+    }
+  }
+
   describe("A 3D Multivariate normal") {
     val mu = DenseVector(2.0, 1.0, 3.0)
     val X = DenseMatrix.rand[Double](3, 3, random.breezeRandBasis.uniform)

--- a/src/test/scala/scalismo/statisticalmodel/MultivariateNormalDistributionTests.scala
+++ b/src/test/scala/scalismo/statisticalmodel/MultivariateNormalDistributionTests.scala
@@ -43,7 +43,8 @@ class MultivariateNormalDistributionTests extends ScalismoTestSuite {
       val mvn = new MultivariateNormalDistribution(mean, cov)
       val breezeMvn = breeze.stats.distributions.MultivariateGaussian.apply(mean, cov)
       for (v <- (1 to 4).map(_ =>
-                DenseVector.tabulate(n)(i => random.scalaRandom.nextGaussian()*math.sqrt(cov(i,i)) + mean(i)))) {
+             DenseVector.tabulate(n)(i => random.scalaRandom.nextGaussian() * math.sqrt(cov(i, i)) + mean(i))
+           )) {
         breezeMvn.logPdf(v) should be(mvn.logpdf(v) +- 1e-5)
       }
     }
@@ -56,11 +57,11 @@ class MultivariateNormalDistributionTests extends ScalismoTestSuite {
       val mean = DenseVector.zeros[Double](n)
       val cov = variance * DenseMatrix.eye[Double](n)
       for (x <- 1 until cov.rows) {
-        cov(x,x-1) = 0.002
-        cov(x-1,x) = 0.002
+        cov(x, x - 1) = 0.002
+        cov(x - 1, x) = 0.002
       }
-      cov(-1,0) = 0.002
-      cov(0,-1) = 0.002
+      cov(-1, 0) = 0.002
+      cov(0, -1) = 0.002
       val mvn = new MultivariateNormalDistribution(mean, cov)
       val breezeMvn = breeze.stats.distributions.MultivariateGaussian.apply(mean, cov)
       breezeMvn.logPdf(DenseVector.zeros[Double](n)) should be(mvn.logpdf(DenseVector.zeros[Double](n)) +- 1e-5)


### PR DESCRIPTION
Fixes #371 the log normalization for covariance values that are small and lead to numerical issues (->0.0) in higher dimensions (>50). also added two tests to check the numerical stability for diagonal and non-diagonal covs.