### PR TITLE
Bugfixes when reading Nifti image with transformations

### DIFF
--- a/src/main/scala/scalismo/io/FastReadOnlyNiftiVolume.scala
+++ b/src/main/scala/scalismo/io/FastReadOnlyNiftiVolume.scala
@@ -403,11 +403,20 @@ object FastReadOnlyNiftiVolume {
     new FastReadOnlyNiftiVolume(filename)
   }
 
-  def getScalarType(file: File): Try[Short] = Try {
+  def getScalarType(file: File): Try[ScalarDataType.Value] = Try {
     val raf = new RandomAccessFile(file, "r")
     val buf = ByteBuffer.allocate(348)
     raf.readFully(buf.array())
     raf.close()
-    new FastReadOnlyNiftiVolume.NiftiHeader(buf).datatype
+    val header = new FastReadOnlyNiftiVolume.NiftiHeader(buf)
+    val dtype = header.datatype
+    val hasTransform = !(header.scl_slope == 0 || (header.scl_slope == 1.0f && header.scl_inter == 0.0f))
+
+    // Whenever an image has a transform, we let the scalar type be
+    // float, in order to make sure that no data is lost by the transform
+    // as it would be the case for the unsigned type.
+    if (hasTransform) ScalarDataType.Float
+    else ScalarDataType.fromNiftiId(dtype)
+
   }
 }

--- a/src/main/scala/scalismo/io/FastReadOnlyNiftiVolume.scala
+++ b/src/main/scala/scalismo/io/FastReadOnlyNiftiVolume.scala
@@ -213,7 +213,7 @@ class FastReadOnlyNiftiVolume private (private val filename: String) {
         }
       case NIFTI_TYPE_INT16 =>
         if (hasTransform) {
-          loadArrayWithTransform[Byte](1, _.get, _.toFloat)
+          loadArrayWithTransform[Char](2, loadChar, _.toFloat)
         } else {
           loadArray[Short, Short](2, loadShort, ShortIsScalar.createArray)
         }

--- a/src/main/scala/scalismo/io/ImageIO.scala
+++ b/src/main/scala/scalismo/io/ImageIO.scala
@@ -254,6 +254,7 @@ object ImageIO {
   ): Try[DiscreteImage[_3D, S]] = {
 
     val expectedScalarType = ScalarDataType.fromType[S]
+
     // If a volume has a transform, we always treat it as a float image and convert accordingly.
     // Otherwise we take the type that is found in the nifty header
     val foundScalarType =

--- a/src/main/scala/scalismo/io/ScalarDataType.scala
+++ b/src/main/scala/scalismo/io/ScalarDataType.scala
@@ -102,7 +102,7 @@ private[scalismo] object ScalarDataType extends Enumeration {
   def ofFile(file: File): Try[ScalarDataType.Value] = {
     val fn = file.getName
     if (fn.endsWith(".nii") || fn.endsWith(".nia")) {
-      FastReadOnlyNiftiVolume.getScalarType(file).map(ScalarDataType.fromNiftiId)
+      FastReadOnlyNiftiVolume.getScalarType(file)
     } else if (fn.endsWith(".vtk")) Try {
       val reader = new vtkStructuredPointsReader
       reader.SetFileName(file.getAbsolutePath)


### PR DESCRIPTION
This PR fixes different problems with the Nifti reader, which manifested whenever nifti images, that have an intensity transformation were read. 

One problem that is fixed is that when a transformation was applied to a short image, the values were truncated, as they were read as Byte rather than Char (copy paste mistake).

The second problem is with the actual conversion of the datatype. Whenever we read an image that has an associated intensity transformation, we convert it to float. This caused problems when we use the readImageAs[Type] method, as the type encoded in the file would differ from what we would return. The solution is to fix the method getScalarType, which determines the type coded in the image header,  to be aware that a transformation is present, and to return the type float, rather than the encoded type.