### PR TITLE
use jhdf instead of the hdf5 native library for reading hdf5 files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ lib/libvtk*
 /project/project
 /.idea/
 /*.iml
+null/
+.bloop

--- a/build.sbt
+++ b/build.sbt
@@ -67,6 +67,7 @@ lazy val root = (project in file("."))
       "ch.unibas.cs.gravis" % "scalismo-niftijiojar" % "0.1.0",
       "ch.unibas.cs.gravis" % "hdf5javanatives" % "0.1.0",
       "ch.unibas.cs.gravis" % "vtkjavanativesall" % "0.1.1",
+      "io.jhdf" % "jhdf" % "0.6.6",
       "org.slf4j" % "slf4j-nop" % "1.6.0" // this silences slf4j complaints in registration classes
     ),
     libraryDependencies ++= (scalaBinaryVersion.value match {

--- a/src/main/scala/scalismo/io/ActiveShapeModelIO.scala
+++ b/src/main/scala/scalismo/io/ActiveShapeModelIO.scala
@@ -126,7 +126,9 @@ object ActiveShapeModelIO {
 
   }
 
-  private[this] def readProfiles(h5file: HDF5Reader, group: io.jhdf.api.Group, referenceMesh: TriangleMesh[_3D]): Try[Profiles] = {
+  private[this] def readProfiles(h5file: HDF5Reader,
+                                 group: io.jhdf.api.Group,
+                                 referenceMesh: TriangleMesh[_3D]): Try[Profiles] = {
     val groupName = group.getPath
     for {
       profileLength <- h5file.readIntAttribute(groupName, Names.Attribute.ProfileLength)

--- a/src/main/scala/scalismo/io/ActiveShapeModelIO.scala
+++ b/src/main/scala/scalismo/io/ActiveShapeModelIO.scala
@@ -74,7 +74,7 @@ object ActiveShapeModelIO {
     } yield ()
   }
 
-  private def writeProfiles(h5file: HDF5File, group: Group, profiles: Profiles): Try[Unit] =
+  private def writeProfiles(h5file: HDF5Writer, group: Group, profiles: Profiles): Try[Unit] =
     Try {
       val numberOfPoints = profiles.data.length
       val profileLength = if (numberOfPoints > 0) profiles.data.head.distribution.mean.size else 0
@@ -105,8 +105,8 @@ object ActiveShapeModelIO {
       pdm <- StatismoIO.readStatismoPDM[_3D, TriangleMesh](fn)
       h5file <- HDF5Utils.openFileForReading(fn)
       asmGroup <- h5file.getGroup(Names.Group.ActiveShapeModel)
-      asmVersionMajor <- h5file.readIntAttribute(asmGroup.getFullName, Names.Attribute.MajorVersion)
-      asmVersionMinor <- h5file.readIntAttribute(asmGroup.getFullName, Names.Attribute.MinorVersion)
+      asmVersionMajor <- h5file.readIntAttribute(asmGroup.getPath, Names.Attribute.MajorVersion)
+      asmVersionMinor <- h5file.readIntAttribute(asmGroup.getPath, Names.Attribute.MinorVersion)
       _ <- {
         (asmVersionMajor, asmVersionMinor) match {
           case (1, 0) => Success(())
@@ -126,8 +126,8 @@ object ActiveShapeModelIO {
 
   }
 
-  private[this] def readProfiles(h5file: HDF5File, group: Group, referenceMesh: TriangleMesh[_3D]): Try[Profiles] = {
-    val groupName = group.getFullName
+  private[this] def readProfiles(h5file: HDF5Reader, group: io.jhdf.api.Group, referenceMesh: TriangleMesh[_3D]): Try[Profiles] = {
+    val groupName = group.getPath
     for {
       profileLength <- h5file.readIntAttribute(groupName, Names.Attribute.ProfileLength)
       pointIds <- h5file.readArray[Int](s"$groupName/${Names.Item.PointIds}")

--- a/src/main/scala/scalismo/io/HDF5Utils.scala
+++ b/src/main/scala/scalismo/io/HDF5Utils.scala
@@ -22,65 +22,126 @@ import ncsa.hdf.`object`.h5._
 
 import scala.jdk.CollectionConverters._
 import scala.util.{Failure, Success, Try}
+import io.jhdf.HdfFile
 
 case class NDArray[T](dims: IndexedSeq[Long], data: Array[T]) {
   require(dims.product == data.length, s"${dims.product} != ${data.length}")
 }
 
-class HDF5File(h5file: FileFormat) extends Closeable {
+class HDF5Reader(h5file: HdfFile) extends Closeable {
 
   override def close(): Unit = { h5file.close() }
 
-  def exists(path: String): Boolean = h5file.get(path) != null
+  def exists(path: String): Boolean = Try { h5file.getByPath(path) }.isSuccess
 
   def readString(path: String): Try[String] = {
 
-    // a string seems to be represented as an array in hdf5
-    // we return just the first element
-    val stringArrayOrFailure = readNDArray[String](path)
-    stringArrayOrFailure.map { stringArray =>
-      assert(stringArray.dims.length == 1 && stringArray.dims(0) == 1 && stringArray.data.length == 1)
-      stringArray.data.head
+    Try {
+      h5file.getDatasetByPath(sanitizePath(path)).getData.asInstanceOf[String]
     }
   }
 
-  def readStringAttribute(path: String, attrName: String): Try[String] = {
-    h5file.get(path) match {
-      case s @ (_: H5Group | _: H5ScalarDS) => {
-        val metadata = s.getMetadata.asScala
-        val maybeAttr = metadata.find(d => d.asInstanceOf[Attribute].getName.equals(attrName))
-        maybeAttr match {
-          case Some(a) => {
-            Success(a.asInstanceOf[Attribute].getValue.asInstanceOf[Array[String]](0))
-          }
-          case None => Failure(new Exception(s"Attribute $attrName not found"))
-        }
-      }
+  private def sanitizePath(path: String): String = {
+    val pathWithoutTrailingSlash = if (path.endsWith("/")) {
+      path.dropRight(1)
+    } else {
+      path
+    }
+    pathWithoutTrailingSlash.replaceAll("//", "/")
+  }
 
-      case _ => {
-        Failure(new Exception("Expected H5ScalarDS when reading attribute"))
-      }
+  def readStringAttribute(path: String, attrName: String): Try[String] = {
+    Try {
+      h5file
+        .getByPath(sanitizePath(path))
+        .getAttribute(attrName)
+        .getData()
+        .asInstanceOf[Array[String]]
+        .head
     }
   }
 
   def readIntAttribute(path: String, attrName: String): Try[Int] = {
-    h5file.get(path) match {
-      case s @ (_: H5Group | _: H5ScalarDS) => {
-        val metadata = s.getMetadata.asScala
-        val maybeAttr = metadata.find(d => d.asInstanceOf[Attribute].getName.equals(attrName))
-        maybeAttr match {
-          case Some(a) => {
-            Success(a.asInstanceOf[Attribute].getValue.asInstanceOf[Array[Int]](0))
-          }
-          case None => Failure(new Exception(s"Attribute $attrName not found"))
-        }
-      }
 
-      case _ => {
-        Failure(new Exception("Expected H5ScalarDS when reading attribute"))
-      }
+    Try {
+      h5file
+        .getByPath(sanitizePath(path))
+        .getAttribute(attrName)
+        .getData()
+        .asInstanceOf[Array[Int]]
+        .head
+    }
+
+  }
+
+  def getPathOfChildren(path: String): Try[Seq[String]] = {
+    Try {
+      h5file
+        .getByPath(sanitizePath(path))
+        .asInstanceOf[io.jhdf.api.Group]
+        .getChildren
+        .asScala
+        .keys.toSeq
     }
   }
+
+  /**
+   * Reads an ndArray from the path. The dataCast is a caster (usually done with asInstance[T])
+   * which casts a type Object into an Array[T]. The reason this has to be provided is that
+   * it is not possible to cast to a generic type, due to type erasure.
+   */
+  def readNDArray[T](path: String)(implicit dataCast: ObjectToArrayCast[T]): Try[NDArray[T]] = {
+    Try {
+      val node = h5file.getDatasetByPath(sanitizePath(path))
+      val dims = node.getDimensions
+
+      val array = dataCast.cast(node.getData());
+      NDArray(dims.map(_.toLong).toIndexedSeq, array)
+    }
+  }
+
+  /*
+   * Reads an Array from the path.
+   * The dataCast is a caster (usually done with asInstance[T])
+   * which casts a type Object into an Array[T]. The reason this has to be provided is that
+   * it is not possible to cast to a generic type, due to type erasure.
+   */
+  def readArray[T](path: String)(implicit dataCast: ObjectToArrayCast[T]): Try[Array[T]] = {
+    Try {
+      val node = h5file.getDatasetByPath(sanitizePath(path))
+      val dims = node.getDimensions
+      dataCast.cast(node.getData());
+    }
+  }
+
+  def readInt(path: String): Try[Int] = {
+    Try {
+      val node = h5file.getDatasetByPath(sanitizePath(path))
+      node.getData().asInstanceOf[Int]
+    }
+  }
+
+  def readFloat(path: String): Try[Float] = {
+    Try {
+      val node = h5file.getDatasetByPath(sanitizePath(path))
+      node.getData().asInstanceOf[Float]
+    }
+  }
+
+  def getGroup(path : String) : Try[io.jhdf.api.Group] = Try {
+    h5file.getByPath(sanitizePath(path)).asInstanceOf[io.jhdf.api.Group]
+  }
+
+  def getGroup(group : io.jhdf.api.Group, groupName : String) : Try[io.jhdf.api.Group] = Try {
+    h5file.getByPath(sanitizePath(group.getPath + "/" + groupName)).asInstanceOf[io.jhdf.api.Group]
+  }
+}
+
+class HDF5Writer(h5file: FileFormat) extends Closeable {
+
+  override def close(): Unit = { h5file.close() }
+
+  def exists(path: String): Boolean = h5file.get(path) != null
 
   def writeIntAttribute(path: String, attrName: String, attrValue: Int): Try[Unit] = {
     Try {
@@ -100,51 +161,9 @@ class HDF5File(h5file: FileFormat) extends Closeable {
       val fileFormat: FileFormat = FileFormat.getFileFormat(FileFormat.FILE_TYPE_HDF5)
       val dtype: Datatype =
         fileFormat.createDatatype(Datatype.CLASS_STRING, attrValue.length + 1, Datatype.NATIVE, Datatype.NATIVE)
-
       val attr = new Attribute(attrName, dtype, Array(1))
       attr.setValue(Array(attrValue))
       s.writeMetadata(attr)
-    }
-  }
-
-  /**
-   * Reads an ndArray from the path. The dataCast is a caster (usually done with asInstance[T])
-   * which casts a type Object into an Array[T]. The reason this has to be provided is that
-   * it is not possible to cast to a generic type, due to type erasure.
-   */
-  def readNDArray[T](path: String)(implicit dataCast: ObjectToArrayCast[T]): Try[NDArray[T]] = {
-
-    h5file.get(path) match {
-      case null => Failure(new Exception(s"Path $path does not exist"))
-      case s: H5ScalarDS => {
-        // we need to explicitly set the selectedDims to dims, in order to avoid that
-        // in the three D case only the first slice is read (bug in hdf5?)
-        s.read()
-
-        val dims = s.getDims
-        val selectedDims = s.getSelectedDims
-        for (i <- 0 until dims.length) { selectedDims(i) = dims(i) }
-        val data = s.getData
-        Try(NDArray(dims.toIndexedSeq, dataCast.cast(data)))
-
-      }
-      case _ => {
-        Failure(new Exception("Expected H5ScalarDS when reading ND array for key " + path))
-      }
-    }
-  }
-
-  /*
-   * Reads an Array from the path.
-   * The dataCast is a caster (usually done with asInstance[T])
-   * which casts a type Object into an Array[T]. The reason this has to be provided is that
-   * it is not possible to cast to a generic type, due to type erasure.
-   */
-  def readArray[T](path: String)(implicit dataCast: ObjectToArrayCast[T]): Try[Array[T]] = {
-
-    readNDArray[T](path).map { ndArray =>
-      assume(ndArray.dims.length == 1)
-      ndArray.data
     }
   }
 
@@ -212,15 +231,6 @@ class HDF5File(h5file: FileFormat) extends Closeable {
     }
   }
 
-  def readInt(path: String): Try[Int] = Try {
-    h5file.get(path) match {
-      case s: H5ScalarDS =>
-        s.read().asInstanceOf[Array[Int]](0)
-      case _ =>
-        throw new Exception("Expected H5ScalarDS when reading Int " + path)
-    }
-  }
-
   def writeInt(path: String, value: Int): Try[Unit] = {
     val (groupname, datasetname) = splitpath(path)
     val groupOrFailure = createGroup(groupname)
@@ -230,16 +240,6 @@ class HDF5File(h5file: FileFormat) extends Closeable {
       val dtype: Datatype = fileFormat.createDatatype(Datatype.CLASS_INTEGER, 4, Datatype.NATIVE, Datatype.NATIVE)
       h5file.createScalarDS(datasetname, group, dtype, Array[Long](), null, null, 0, value, Array(value))
       ()
-    }
-  }
-
-  def readFloat(path: String): Try[Float] = Try {
-
-    h5file.get(path) match {
-      case s: H5ScalarDS =>
-        s.read().asInstanceOf[Array[Float]](0)
-      case _ =>
-        throw new Exception("Expected H5ScalarDS when reading Float " + path)
     }
   }
 
@@ -326,16 +326,15 @@ object HDF5Utils {
   // to typed values
   object FileAccessMode extends Enumeration {
     type FileAccessMode = Value
-    val READ, WRITE, CREATE = Value
+    val WRITE, CREATE = Value
   }
   import FileAccessMode._
 
   def hdf5Version = "to be defined"
 
-  def openFile(file: File, mode: FileAccessMode): Try[HDF5File] = Try {
+  private def openFileWriterOrCreateFile(file: File, mode: FileAccessMode): Try[HDF5Writer] = Try {
     val filename = file.getAbsolutePath
     val h5fileAccessMode = mode match {
-      case READ   => FileFormat.READ
       case WRITE  => FileFormat.WRITE
       case CREATE => FileFormat.CREATE
     }
@@ -346,26 +345,30 @@ object HDF5Utils {
     if (h5file.open() == -1) {
       throw new IOException("could not open file " + file.getAbsolutePath)
     }
-    new HDF5File(h5file)
+    new HDF5Writer(h5file)
   }
 
-  def openFileForReading(file: File): Try[HDF5File] = openFile(file, READ)
-  def openFileForWriting(file: File): Try[HDF5File] = openFile(file, WRITE)
-  def createFile(file: File): Try[HDF5File] = openFile(file, CREATE)
+  def openFileForReading(file: File): Try[HDF5Reader] = {
+    Try {
+      val hdfFile = new HdfFile(file)
+      new HDF5Reader(hdfFile)
+    }
+  }
+
+  def openFileForWriting(file: File): Try[HDF5Writer] = openFileWriterOrCreateFile(file, WRITE)
+  def createFile(file: File): Try[HDF5Writer] = openFileWriterOrCreateFile(file, CREATE)
 
 }
 
 /**
  * Typeclasses for reading, writing to hdf5 file
  */
-trait HDF5ReadWrite[A] extends HDF5Read[A] with HDF5Write[A]
-
 trait HDF5Read[A] {
-  def read(h5file: HDF5File, group: Group): Try[A]
+  def read(h5file: HDF5Reader, group: Group): Try[A]
 }
 
 trait HDF5Write[A] {
-  def write(value: A, h5file: HDF5File, group: Group): Try[Unit]
+  def write(value: A, h5file: HDF5Writer, group: Group): Try[Unit]
 }
 
 trait ObjectToArrayCast[A] {
@@ -374,20 +377,61 @@ trait ObjectToArrayCast[A] {
 
 object ObjectToArrayCast {
   implicit object ObjectToStringArrayCast extends ObjectToArrayCast[String] {
-    override def cast(arr: Object): Array[String] = arr.asInstanceOf[Array[String]]
+    override def cast(arr: Object): Array[String] = {
+      if (arr.isInstanceOf[Array[Array[String]]]) {
+        arr.asInstanceOf[Array[Array[String]]].flatten
+      } else if (arr.isInstanceOf[Array[Array[Array[String]]]]) {
+        arr.asInstanceOf[Array[Array[Array[String]]]].flatten.flatten
+      } else {
+        arr.asInstanceOf[Array[String]]
+      }
+    }
   }
-  implicit object ObjectToFloatArrayCast extends ObjectToArrayCast[Float] {
-    override def cast(arr: Object): Array[Float] = arr.asInstanceOf[Array[Float]]
+}
+implicit object ObjectToFloatArrayCast extends ObjectToArrayCast[Float] {
+  override def cast(arr: Object): Array[Float] = {
+    if (arr.isInstanceOf[Array[Array[Float]]]) {
+      arr.asInstanceOf[Array[Array[Float]]].flatten
+    } else if (arr.isInstanceOf[Array[Array[Array[Float]]]]) {
+      arr.asInstanceOf[Array[Array[Array[Float]]]].flatten.flatten
+    } else {
+      arr.asInstanceOf[Array[Float]]
+    }
   }
+}
 
-  implicit object ObjectToByteArrayCast extends ObjectToArrayCast[Byte] {
-    override def cast(arr: Object): Array[Byte] = arr.asInstanceOf[Array[Byte]]
+implicit object ObjectToByteArrayCast extends ObjectToArrayCast[Byte] {
+  override def cast(arr: Object): Array[Byte] = {
+    if (arr.isInstanceOf[Array[Array[Byte]]]) {
+      arr.asInstanceOf[Array[Array[Byte]]].flatten
+    } else if (arr.isInstanceOf[Array[Array[Array[Byte]]]]) {
+      arr.asInstanceOf[Array[Array[Array[Byte]]]].flatten.flatten
+    } else {
+      arr.asInstanceOf[Array[Byte]]
+    }
   }
+}
 
-  implicit object ObjectToIntArrayCast extends ObjectToArrayCast[Int] {
-    override def cast(arr: Object): Array[Int] = arr.asInstanceOf[Array[Int]]
+implicit object ObjectToIntArrayCast extends ObjectToArrayCast[Int] {
+  override def cast(arr: Object): Array[Int] = {
+    if (arr.isInstanceOf[Array[Array[Int]]]) {
+      arr.asInstanceOf[Array[Array[Int]]].flatten
+    } else if (arr.isInstanceOf[Array[Array[Array[Int]]]]) {
+      arr.asInstanceOf[Array[Array[Array[Int]]]].flatten.flatten
+    } else {
+      arr.asInstanceOf[Array[Int]]
+    }
   }
-  implicit object ObjectToDoubleArrayCast extends ObjectToArrayCast[Double] {
-    override def cast(arr: Object): Array[Double] = arr.asInstanceOf[Array[Double]]
+}
+
+implicit object ObjectToDoubleArrayCast extends ObjectToArrayCast[Double] {
+  override def cast(arr: Object): Array[Double] = {
+    if (arr.isInstanceOf[Array[Array[Double]]]) {
+      arr.asInstanceOf[Array[Array[Double]]].flatten
+    } else if (arr.isInstanceOf[Array[Array[Array[Double]]]]) {
+      arr.asInstanceOf[Array[Array[Array[Double]]]].flatten.flatten
+    } else {
+      arr.asInstanceOf[Array[Double]]
+    }
   }
 }

--- a/src/main/scala/scalismo/io/HDF5Utils.scala
+++ b/src/main/scala/scalismo/io/HDF5Utils.scala
@@ -81,7 +81,8 @@ class HDF5Reader(h5file: HdfFile) extends Closeable {
         .asInstanceOf[io.jhdf.api.Group]
         .getChildren
         .asScala
-        .keys.toSeq
+        .keys
+        .toSeq
     }
   }
 
@@ -128,11 +129,11 @@ class HDF5Reader(h5file: HdfFile) extends Closeable {
     }
   }
 
-  def getGroup(path : String) : Try[io.jhdf.api.Group] = Try {
+  def getGroup(path: String): Try[io.jhdf.api.Group] = Try {
     h5file.getByPath(sanitizePath(path)).asInstanceOf[io.jhdf.api.Group]
   }
 
-  def getGroup(group : io.jhdf.api.Group, groupName : String) : Try[io.jhdf.api.Group] = Try {
+  def getGroup(group: io.jhdf.api.Group, groupName: String): Try[io.jhdf.api.Group] = Try {
     h5file.getByPath(sanitizePath(group.getPath + "/" + groupName)).asInstanceOf[io.jhdf.api.Group]
   }
 }
@@ -387,51 +388,52 @@ object ObjectToArrayCast {
       }
     }
   }
-}
-implicit object ObjectToFloatArrayCast extends ObjectToArrayCast[Float] {
-  override def cast(arr: Object): Array[Float] = {
-    if (arr.isInstanceOf[Array[Array[Float]]]) {
-      arr.asInstanceOf[Array[Array[Float]]].flatten
-    } else if (arr.isInstanceOf[Array[Array[Array[Float]]]]) {
-      arr.asInstanceOf[Array[Array[Array[Float]]]].flatten.flatten
-    } else {
-      arr.asInstanceOf[Array[Float]]
+
+  implicit object ObjectToFloatArrayCast extends ObjectToArrayCast[Float] {
+    override def cast(arr: Object): Array[Float] = {
+      if (arr.isInstanceOf[Array[Array[Float]]]) {
+        arr.asInstanceOf[Array[Array[Float]]].flatten
+      } else if (arr.isInstanceOf[Array[Array[Array[Float]]]]) {
+        arr.asInstanceOf[Array[Array[Array[Float]]]].flatten.flatten
+      } else {
+        arr.asInstanceOf[Array[Float]]
+      }
     }
   }
-}
 
-implicit object ObjectToByteArrayCast extends ObjectToArrayCast[Byte] {
-  override def cast(arr: Object): Array[Byte] = {
-    if (arr.isInstanceOf[Array[Array[Byte]]]) {
-      arr.asInstanceOf[Array[Array[Byte]]].flatten
-    } else if (arr.isInstanceOf[Array[Array[Array[Byte]]]]) {
-      arr.asInstanceOf[Array[Array[Array[Byte]]]].flatten.flatten
-    } else {
-      arr.asInstanceOf[Array[Byte]]
+  implicit object ObjectToByteArrayCast extends ObjectToArrayCast[Byte] {
+    override def cast(arr: Object): Array[Byte] = {
+      if (arr.isInstanceOf[Array[Array[Byte]]]) {
+        arr.asInstanceOf[Array[Array[Byte]]].flatten
+      } else if (arr.isInstanceOf[Array[Array[Array[Byte]]]]) {
+        arr.asInstanceOf[Array[Array[Array[Byte]]]].flatten.flatten
+      } else {
+        arr.asInstanceOf[Array[Byte]]
+      }
     }
   }
-}
 
-implicit object ObjectToIntArrayCast extends ObjectToArrayCast[Int] {
-  override def cast(arr: Object): Array[Int] = {
-    if (arr.isInstanceOf[Array[Array[Int]]]) {
-      arr.asInstanceOf[Array[Array[Int]]].flatten
-    } else if (arr.isInstanceOf[Array[Array[Array[Int]]]]) {
-      arr.asInstanceOf[Array[Array[Array[Int]]]].flatten.flatten
-    } else {
-      arr.asInstanceOf[Array[Int]]
+  implicit object ObjectToIntArrayCast extends ObjectToArrayCast[Int] {
+    override def cast(arr: Object): Array[Int] = {
+      if (arr.isInstanceOf[Array[Array[Int]]]) {
+        arr.asInstanceOf[Array[Array[Int]]].flatten
+      } else if (arr.isInstanceOf[Array[Array[Array[Int]]]]) {
+        arr.asInstanceOf[Array[Array[Array[Int]]]].flatten.flatten
+      } else {
+        arr.asInstanceOf[Array[Int]]
+      }
     }
   }
-}
 
-implicit object ObjectToDoubleArrayCast extends ObjectToArrayCast[Double] {
-  override def cast(arr: Object): Array[Double] = {
-    if (arr.isInstanceOf[Array[Array[Double]]]) {
-      arr.asInstanceOf[Array[Array[Double]]].flatten
-    } else if (arr.isInstanceOf[Array[Array[Array[Double]]]]) {
-      arr.asInstanceOf[Array[Array[Array[Double]]]].flatten.flatten
-    } else {
-      arr.asInstanceOf[Array[Double]]
+  implicit object ObjectToDoubleArrayCast extends ObjectToArrayCast[Double] {
+    override def cast(arr: Object): Array[Double] = {
+      if (arr.isInstanceOf[Array[Array[Double]]]) {
+        arr.asInstanceOf[Array[Array[Double]]].flatten
+      } else if (arr.isInstanceOf[Array[Array[Array[Double]]]]) {
+        arr.asInstanceOf[Array[Array[Array[Double]]]].flatten.flatten
+      } else {
+        arr.asInstanceOf[Array[Double]]
+      }
     }
   }
 }

--- a/src/main/scala/scalismo/io/StatismoIO.scala
+++ b/src/main/scala/scalismo/io/StatismoIO.scala
@@ -44,21 +44,21 @@ object StatismoIO {
    * List all models that are stored in the given hdf5 file.
    */
   def readModelCatalog(file: File): Try[ModelCatalog] = {
-   
-    Try {
-       val h5file = HDF5Utils.openFileForReading(file).get
-        val modelEntries = for (childPath <- h5file.getPathOfChildren("/catalog").get) yield {       
-            readCatalogEntry(h5file, childPath).get
-        }
-        modelEntries      
-    
-  }
-}
 
-  private def readCatalogEntry(h5file: HDF5Reader, path : String): Try[CatalogEntry] = {
+    Try {
+      val h5file = HDF5Utils.openFileForReading(file).get
+      val modelEntries = for (childPath <- h5file.getPathOfChildren("/catalog").get) yield {
+        readCatalogEntry(h5file, childPath).get
+      }
+      modelEntries
+
+    }
+  }
+
+  private def readCatalogEntry(h5file: HDF5Reader, path: String): Try[CatalogEntry] = {
     for {
-      location <- h5file.readString("/catalog/" +path + "/modelPath")
-      modelType <- h5file.readString("/catalog/" +path + "/modelType")
+      location <- h5file.readString("/catalog/" + path + "/modelPath")
+      modelType <- h5file.readString("/catalog/" + path + "/modelType")
     } yield {
       CatalogEntry(path, StatismoModelType.fromString(modelType), location)
     }

--- a/src/main/scala/scalismo/io/StatismoIO.scala
+++ b/src/main/scala/scalismo/io/StatismoIO.scala
@@ -44,31 +44,23 @@ object StatismoIO {
    * List all models that are stored in the given hdf5 file.
    */
   def readModelCatalog(file: File): Try[ModelCatalog] = {
-    import scala.collection.JavaConverters._
-
-    def flatten[A](xs: Seq[Try[A]]): Try[Seq[A]] = Try(xs.map(_.get))
-
-    for {
-      h5file <- HDF5Utils.openFileForReading(file)
-      catalogGroup <- if (h5file.exists("/catalog")) h5file.getGroup("/catalog") else Failure(NoCatalogPresentException)
-      modelEntries = for (entryGroupObj <- catalogGroup.getMemberList.asScala.toSeq
-                          if entryGroupObj.isInstanceOf[Group]) yield {
-        val entryGroup = entryGroupObj.asInstanceOf[Group]
-        readCatalogEntry(h5file, entryGroup)
-      }
-      modelCatalog <- flatten(modelEntries)
-    } yield {
-      modelCatalog
-    }
+   
+    Try {
+       val h5file = HDF5Utils.openFileForReading(file).get
+        val modelEntries = for (childPath <- h5file.getPathOfChildren("/catalog").get) yield {       
+            readCatalogEntry(h5file, childPath).get
+        }
+        modelEntries      
+    
   }
+}
 
-  private def readCatalogEntry(h5file: HDF5File, entryGroup: Group): Try[CatalogEntry] = {
-    val name = entryGroup.getName
+  private def readCatalogEntry(h5file: HDF5Reader, path : String): Try[CatalogEntry] = {
     for {
-      location <- h5file.readString(entryGroup.getFullName + "/modelPath")
-      modelType <- h5file.readString(entryGroup.getFullName + "/modelType")
+      location <- h5file.readString("/catalog/" +path + "/modelPath")
+      modelType <- h5file.readString("/catalog/" +path + "/modelType")
     } yield {
-      CatalogEntry(name, StatismoModelType.fromString(modelType), location)
+      CatalogEntry(path, StatismoModelType.fromString(modelType), location)
     }
   }
 
@@ -88,7 +80,7 @@ object StatismoIO {
     val modelOrFailure = for {
       h5file <- HDF5Utils.openFileForReading(file)
 
-      representerName <- h5file.readStringAttribute(s"$modelPath/representer/", "name")
+      representerName <- h5file.readStringAttribute(s"$modelPath/representer", "name")
       mesh <- representerName match {
         case ("vtkPolyDataRepresenter") =>
           for {
@@ -164,14 +156,14 @@ object StatismoIO {
     maybeError
   }
 
-  private def writeCells(h5file: HDF5File, modelPath: String, cells: NDArray[Int]): Try[Unit] = {
+  private def writeCells(h5file: HDF5Writer, modelPath: String, cells: NDArray[Int]): Try[Unit] = {
     if (cells.data.length > 0) {
       h5file.writeNDArray[Int](s"$modelPath/representer/cells", cells)
     } else Success(())
   }
 
   private def writeRepresenterStatismov090[D: NDSpace, DDomain[D] <: DiscreteDomain[D]](
-    h5file: HDF5File,
+    h5file: HDF5Writer,
     group: Group,
     domain: DDomain[D],
     modelPath: String
@@ -206,7 +198,7 @@ object StatismoIO {
     DenseMatrix.create(array.dims(1).toInt, array.dims(0).toInt, array.data.map(_.toDouble)).t
   }
 
-  private def readStandardPCAbasis(h5file: HDF5File,
+  private def readStandardPCAbasis(h5file: HDF5Reader,
                                    modelPath: String): Try[(DenseVector[Double], DenseMatrix[Double])] = {
     for {
       representerName <- h5file.readStringAttribute(s"$modelPath/representer/", "name")
@@ -234,7 +226,7 @@ object StatismoIO {
     } yield (pcaVarianceVector, pcaBasis)
   }
 
-  private def readStandardPointsFromRepresenterGroup(h5file: HDF5File,
+  private def readStandardPointsFromRepresenterGroup(h5file: HDF5Reader,
                                                      modelPath: String,
                                                      dim: Int): Try[DenseMatrix[Double]] = {
     for {
@@ -252,7 +244,7 @@ object StatismoIO {
   }
 
   private def readPointSetRepresentation[D: NDSpace, DDomain[D] <: DiscreteDomain[D]](
-    h5file: HDF5File,
+    h5file: HDF5Reader,
     modelPath: String
   )(implicit typeHelper: StatismoDomainIO[D, DDomain], vectorizer: Vectorizer[EuclideanVector[D]]): Try[DDomain[D]] = {
     val dim: Int = vectorizer.dim
@@ -267,7 +259,7 @@ object StatismoIO {
   }
 
   private def readStandardMeshRepresentation[D: NDSpace, DDomain[D] <: DiscreteDomain[D]](
-    h5file: HDF5File,
+    h5file: HDF5Reader,
     modelPath: String
   )(implicit typeHelper: StatismoDomainIO[D, DDomain], vectorizer: Vectorizer[EuclideanVector[D]]): Try[DDomain[D]] = {
     val dim: Int = NDSpace[D].dimensionality
@@ -281,13 +273,13 @@ object StatismoIO {
     } yield domain
   }
 
-  private def readStandardMeanVector(h5file: HDF5File, modelPath: String): Try[DenseVector[Double]] = {
+  private def readStandardMeanVector(h5file: HDF5Reader, modelPath: String): Try[DenseVector[Double]] = {
     for {
       meanArray <- h5file.readNDArray[Float](s"$modelPath/model/mean")
     } yield DenseVector(meanArray.data.map(_.toDouble))
   }
 
-  private def readStandardConnectiveityRepresenterGroup(h5file: HDF5File, modelPath: String): Try[NDArray[Int]] = {
+  private def readStandardConnectiveityRepresenterGroup(h5file: HDF5Reader, modelPath: String): Try[NDArray[Int]] = {
     val cells =
       if (h5file.exists(s"$modelPath/representer/cells")) h5file.readNDArray[Int](s"$modelPath/representer/cells")
       else Failure(new Throwable("No cells found in representer"))
@@ -298,7 +290,7 @@ object StatismoIO {
    * reads the reference (a vtk file, which is stored as a byte array in the hdf5 file)
    */
   //(implicit typeHelper: StatismoDomainIO[D, DDomain])
-  private def readVTKMeshFromRepresenterGroup(h5file: HDF5File, modelPath: String): Try[TriangleMesh[_3D]] = {
+  private def readVTKMeshFromRepresenterGroup(h5file: HDF5Reader, modelPath: String): Try[TriangleMesh[_3D]] = {
     for {
       rawdata <- h5file.readNDArray[Byte](s"$modelPath/representer/reference")
       vtkFile <- writeTmpFile(rawdata.data)
@@ -395,7 +387,7 @@ object StatismoIO {
   }
 
   private def writeImageRepresenter[D: NDSpace, A: Vectorizer](
-    h5file: HDF5File,
+    h5file: HDF5Writer,
     group: Group,
     gp: DiscreteLowRankGaussianProcess[D, DiscreteImageDomain, A],
     modelPath: String
@@ -508,7 +500,7 @@ object StatismoIO {
   }
 
   private def readImageRepresenter[D: NDSpace: CreateStructuredPoints](
-    h5file: HDF5File,
+    h5file: HDF5Reader,
     modelPath: String
   ): Try[DiscreteImageDomain[D]] = {
 

--- a/src/main/scala/scalismo/statisticalmodel/asm/FeatureExtractor.scala
+++ b/src/main/scala/scalismo/statisticalmodel/asm/FeatureExtractor.scala
@@ -19,12 +19,13 @@ import breeze.linalg.DenseVector
 import ncsa.hdf.`object`.Group
 import scalismo.common.PointId
 import scalismo.geometry.{_3D, EuclideanVector, Point}
-import scalismo.io.HDF5File
 import scalismo.mesh.TriangleMesh
 import scalismo.statisticalmodel.asm.PreprocessedImage.{Gradient, Intensity}
 
 import scala.collection.immutable
 import scala.util.{Failure, Try}
+import scalismo.io.HDF5Reader
+import scalismo.io.HDF5Writer
 
 trait FeatureExtractor
     extends Function4[PreprocessedImage, Point[_3D], TriangleMesh[_3D], PointId, Option[DenseVector[Double]]]
@@ -133,15 +134,15 @@ object NormalDirectionFeatureExtractorIOHandler extends FeatureExtractorIOHandle
   private val NumberOfPoints = "numberOfPoints"
   private val Spacing = "spacing"
 
-  override def load(meta: IOMetadata, h5File: HDF5File, h5Group: Group): Try[FeatureExtractor] = {
-    val groupName = h5Group.getFullName
+  override def load(meta: IOMetadata, h5File: HDF5Reader, h5Group: io.jhdf.api.Group): Try[FeatureExtractor] = {
+    val groupName = h5Group.getPath 
     for {
       numberOfPoints <- h5File.readInt(s"$groupName/$NumberOfPoints")
       spacing <- h5File.readFloat(s"$groupName/$Spacing")
     } yield NormalDirectionFeatureExtractor(numberOfPoints, spacing.toDouble, meta)
   }
 
-  override def save(t: FeatureExtractor, h5File: HDF5File, h5Group: Group): Try[Unit] = {
+  override def save(t: FeatureExtractor, h5File: HDF5Writer, h5Group: Group): Try[Unit] = {
     t match {
       case fe: NormalDirectionFeatureExtractor =>
         val groupName = h5Group.getFullName

--- a/src/main/scala/scalismo/statisticalmodel/asm/FeatureExtractor.scala
+++ b/src/main/scala/scalismo/statisticalmodel/asm/FeatureExtractor.scala
@@ -135,7 +135,7 @@ object NormalDirectionFeatureExtractorIOHandler extends FeatureExtractorIOHandle
   private val Spacing = "spacing"
 
   override def load(meta: IOMetadata, h5File: HDF5Reader, h5Group: io.jhdf.api.Group): Try[FeatureExtractor] = {
-    val groupName = h5Group.getPath 
+    val groupName = h5Group.getPath
     for {
       numberOfPoints <- h5File.readInt(s"$groupName/$NumberOfPoints")
       spacing <- h5File.readFloat(s"$groupName/$Spacing")

--- a/src/main/scala/scalismo/statisticalmodel/asm/IOHandler.scala
+++ b/src/main/scala/scalismo/statisticalmodel/asm/IOHandler.scala
@@ -116,7 +116,7 @@ object Hdf5IOHandler {
    */
   def saveMetadata(meta: IOMetadata, h5File: HDF5Writer, h5Group: Group): Try[Unit] = {
     val groupName = h5Group.getFullName
-    println("saving metadata for group " +groupName)
+    println("saving metadata for group " + groupName)
     for {
       _ <- h5File.writeStringAttribute(groupName, IdentifierAttributeName, meta.identifier)
       _ <- h5File.writeIntAttribute(groupName, MajorVersionAttributeName, meta.majorVersion)

--- a/src/main/scala/scalismo/statisticalmodel/asm/ImagePreprocessor.scala
+++ b/src/main/scala/scalismo/statisticalmodel/asm/ImagePreprocessor.scala
@@ -100,7 +100,9 @@ case class IdentityImagePreprocessor(override val ioMetadata: IOMetadata = Ident
 object IdentityImagePreprocessorIOHandler extends ImagePreprocessorIOHandler {
   override def identifier: String = IdentityImagePreprocessor.IOIdentifier
 
-  override def load(meta: IOMetadata, h5File: HDF5Reader, h5Group: io.jhdf.api.Group): Try[IdentityImagePreprocessor] = {
+  override def load(meta: IOMetadata,
+                    h5File: HDF5Reader,
+                    h5Group: io.jhdf.api.Group): Try[IdentityImagePreprocessor] = {
     meta match {
       case IdentityImagePreprocessor.IOMetadata_1_0 => Success(IdentityImagePreprocessor(meta))
       case _                                        => Failure(new IllegalArgumentException(s"Unable to handle $meta"))
@@ -157,7 +159,9 @@ object GaussianGradientImagePreprocessorIOHandler extends ImagePreprocessorIOHan
 
   private val Stddev = "stddev"
 
-  override def load(meta: IOMetadata, h5File: HDF5Reader, h5Group: io.jhdf.api.Group): Try[GaussianGradientImagePreprocessor] = {
+  override def load(meta: IOMetadata,
+                    h5File: HDF5Reader,
+                    h5Group: io.jhdf.api.Group): Try[GaussianGradientImagePreprocessor] = {
     val groupName = h5Group.getPath
     meta match {
       case GaussianGradientImagePreprocessor.IOMetadata_1_0 =>

--- a/src/main/scala/scalismo/statisticalmodel/asm/ImagePreprocessor.scala
+++ b/src/main/scala/scalismo/statisticalmodel/asm/ImagePreprocessor.scala
@@ -23,10 +23,11 @@ import scalismo.common.{Domain, Field}
 import scalismo.geometry.{_3D, EuclideanVector, Point}
 import scalismo.image.DiscreteImage
 import scalismo.image.filter.DiscreteImageFilter
-import scalismo.io.HDF5File
 import scalismo.statisticalmodel.asm.PreprocessedImage.Type
 
 import scala.util.{Failure, Success, Try}
+import scalismo.io.HDF5Reader
+import scalismo.io.HDF5Writer
 
 /**
  * A preprocessed image, which can be fed to a [[FeatureExtractor]].
@@ -99,7 +100,7 @@ case class IdentityImagePreprocessor(override val ioMetadata: IOMetadata = Ident
 object IdentityImagePreprocessorIOHandler extends ImagePreprocessorIOHandler {
   override def identifier: String = IdentityImagePreprocessor.IOIdentifier
 
-  override def load(meta: IOMetadata, h5File: HDF5File, h5Group: Group): Try[IdentityImagePreprocessor] = {
+  override def load(meta: IOMetadata, h5File: HDF5Reader, h5Group: io.jhdf.api.Group): Try[IdentityImagePreprocessor] = {
     meta match {
       case IdentityImagePreprocessor.IOMetadata_1_0 => Success(IdentityImagePreprocessor(meta))
       case _                                        => Failure(new IllegalArgumentException(s"Unable to handle $meta"))
@@ -156,8 +157,8 @@ object GaussianGradientImagePreprocessorIOHandler extends ImagePreprocessorIOHan
 
   private val Stddev = "stddev"
 
-  override def load(meta: IOMetadata, h5File: HDF5File, h5Group: Group): Try[GaussianGradientImagePreprocessor] = {
-    val groupName = h5Group.getFullName
+  override def load(meta: IOMetadata, h5File: HDF5Reader, h5Group: io.jhdf.api.Group): Try[GaussianGradientImagePreprocessor] = {
+    val groupName = h5Group.getPath
     meta match {
       case GaussianGradientImagePreprocessor.IOMetadata_1_0 =>
         for {
@@ -167,7 +168,7 @@ object GaussianGradientImagePreprocessorIOHandler extends ImagePreprocessorIOHan
     }
   }
 
-  override def save(t: ImagePreprocessor, h5File: HDF5File, h5Group: Group): Try[Unit] = {
+  override def save(t: ImagePreprocessor, h5File: HDF5Writer, h5Group: Group): Try[Unit] = {
     val groupName = h5Group.getFullName
     t match {
       case g: GaussianGradientImagePreprocessor => h5File.writeFloat(s"$groupName/$Stddev", g.stddev.toFloat)

--- a/src/test/scala/scalismo/io/HDF5UtilsTests.scala
+++ b/src/test/scala/scalismo/io/HDF5UtilsTests.scala
@@ -42,7 +42,7 @@ class HDF5UtilsTests extends ScalismoTestSuite {
 
     it("can write and read an NDArray[Int]") {
       val h5file = createTmpH5File()
-      val h5: HDF5File = HDF5Utils.createFile(h5file).get
+      val h5: HDF5Writer = HDF5Utils.createFile(h5file).get
       val arr = NDArray(IndexedSeq(2, 3), Array(1, 2, 3, 4, 5, 6))
       h5.writeNDArray("/aGroup/array", arr).get
       val h5new = HDF5Utils.openFileForReading(h5file).get
@@ -52,7 +52,7 @@ class HDF5UtilsTests extends ScalismoTestSuite {
 
     it("can write and read an NDArray[Float]") {
       val h5file = createTmpH5File()
-      val h5: HDF5File = HDF5Utils.createFile(h5file).get
+      val h5: HDF5Writer = HDF5Utils.createFile(h5file).get
       val arr = NDArray(IndexedSeq(2, 3), Array(1f, 2f, 3f, 4f, 5f, 6f))
       h5.writeNDArray("/aGroup/array", arr).get
       val h5new = HDF5Utils.openFileForReading(h5file).get
@@ -63,7 +63,7 @@ class HDF5UtilsTests extends ScalismoTestSuite {
     it("fails to write an unknown type") {
       // find problems with Try[Unit] where map/flatMap issues arise
       val h5file = createTmpH5File()
-      val h5: HDF5File = HDF5Utils.createFile(h5file).get
+      val h5: HDF5Writer = HDF5Utils.createFile(h5file).get
       // new type, certainly unknown
       case class NT(v: Double)
       val arr: NDArray[NT] = NDArray(IndexedSeq(2, 3), Array(NT(1.0), NT(1.0), NT(1.0), NT(1.0), NT(1.0), NT(1.0)))


### PR DESCRIPTION
There exist a number of scurity vulnerabilities in the older hdf5 implementation
that scalismo is using (see https://github.com/unibas-gravis/scalismo-native/issues/6). 

This PR changes all reading routines for hdf5 to use jhdf, which is a pure java
implementation. Writing is still done using hdf5. The implementation is
done such that much of the original structure is preserved. Once we get
completely rid of the native hdf5 libraries, a refactoring should be
done.