### PR TITLE
numerical stability in low rank marginal likelihood

### DIFF
--- a/src/main/scala/scalismo/statisticalmodel/DiscreteLowRankGaussianProcess.scala
+++ b/src/main/scala/scalismo/statisticalmodel/DiscreteLowRankGaussianProcess.scala
@@ -218,9 +218,11 @@ case class DiscreteLowRankGaussianProcess[D: NDSpace, DDomain[DD] <: DiscreteDom
   override def marginalLikelihood(td: IndexedSeq[(PointId, Value, MultivariateNormalDistribution)]): Double = {
     require(td.nonEmpty, "provide observations to calculate the marginal likelihood")
     val matIds = td.flatMap(t => t._1.id * outputDim until t._1.id * outputDim + outputDim)
-    val U = DenseMatrix.tabulate[Double](matIds.length, rank)((x, y) => basisMatrix(matIds(x), y))
+    val r = variance.data.count(_ > 1e-7)
+    val S = if (r == rank) variance else DenseVector(variance.data.take(r))
+    val U = DenseMatrix.tabulate[Double](matIds.length, r)((x, y) => basisMatrix(matIds(x), y))
     val y = DenseVector(td.flatMap(t => (vectorizer.vectorize(t._2) - vectorizer.vectorize(mean(t._1))).toArray): _*)
-    LowRankGaussianProcess.marginalLikelihoodComputation(U, variance, y, td.map(_._3))
+    LowRankGaussianProcess.marginalLikelihoodComputation(U, S, y, td.map(_._3))
   }
 
   /**

--- a/src/main/scala/scalismo/statisticalmodel/LowRankGaussianProcess.scala
+++ b/src/main/scala/scalismo/statisticalmodel/LowRankGaussianProcess.scala
@@ -200,7 +200,7 @@ class LowRankGaussianProcess[D: NDSpace, Value](mean: Field[D, Value], val klBas
       val data = vectorsSeq.flatMap(value => vectorizer.vectorize(value).toArray).toArray
       val vector = new DenseMatrix(td.length * this.outputDim, 1, data)
       (lambda, vector)
-    }).unzip
+    }).filter(t => t._1 > 1e-7).unzip
 
     val U = DenseMatrix.horzcat(discretePhis: _*)
     val S = DenseVector(eigenvalues: _*)


### PR DESCRIPTION
Previously the calculation was unstable when used in models with very small eigenvalues (<1e-7).

The proposed solution filters out these eigenvalues. Otherwise the same algorithm is used. That means a model with the following eigenvalues/vectors:
`
evec = [v1,v2,v3,v4] 
eval = [1,1,1,1e-10]
`
is treated as the following model
`
evec = [v1,v2,v3]
eval = [1,1,1]
`
