### PR TITLE
Bug fix: avoid using caching in SurfaceSpatialIndex as this results i…

### DIFF
--- a/src/main/scala/scalismo/mesh/boundingSpheres/SurfaceSpatialIndex.scala
+++ b/src/main/scala/scalismo/mesh/boundingSpheres/SurfaceSpatialIndex.scala
@@ -188,7 +188,7 @@ private[mesh] class TriangleMesh3DSpatialIndex(private val bs: BoundingSphere,
     val p = point.toVector
 
     // last triangle might be a good candidate
-    val result = BSDistance.toTriangle(point.toVector, triangles(lastIdx.get().idx))
+    val result = BSDistance.toTriangle(point.toVector, triangles(0))
     updateCP(res.get(), result)
 
     // search for true candidate

--- a/src/main/scala/scalismo/mesh/boundingSpheres/SurfaceSpatialIndex.scala
+++ b/src/main/scala/scalismo/mesh/boundingSpheres/SurfaceSpatialIndex.scala
@@ -187,7 +187,6 @@ private[mesh] class TriangleMesh3DSpatialIndex(private val bs: BoundingSphere,
   private def _getClosestPoint(point: Point[_3D]): Unit = {
     val p = point.toVector
 
-    // last triangle might be a good candidate
     val result = BSDistance.toTriangle(point.toVector, triangles(0))
     updateCP(res.get(), result)
 


### PR DESCRIPTION
…n different values for the same point when ran in parallel. Fixes issue #367 