### PR TITLE
drop crossScalaVersion 2.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -27,7 +27,6 @@ lazy val root = (project in file("."))
       else
         Opts.resolver.sonatypeStaging
     ),
-    crossScalaVersions := Seq("2.13.6", "3.1.0"),
     resolvers ++= Seq(
       Resolver.jcenterRepo,
       Resolver.sonatypeRepo("releases"),
@@ -38,23 +37,11 @@ lazy val root = (project in file("."))
         "-encoding",
         "UTF-8",
         "-feature",
-        "-language:implicitConversions"
+        "-language:implicitConversions",
+        "-unchecked"
         // disabled during the migration
         // "-Xfatal-warnings"
-      ) ++
-        (CrossVersion.partialVersion(scalaVersion.value) match {
-          case Some((3, _)) =>
-            Seq(
-              "-unchecked",
-              "-source:3.0-migration"
-            )
-          case _ =>
-            Seq(
-              "-deprecation",
-              "-Wunused:imports,privates,locals",
-              "-Wvalue-discard"
-            )
-        })
+      )
     },
     javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
     libraryDependencies ++= Seq(
@@ -67,19 +54,9 @@ lazy val root = (project in file("."))
       "ch.unibas.cs.gravis" % "hdf5javanatives" % "0.1.0",
       "ch.unibas.cs.gravis" % "vtkjavanativesall" % "0.1.1",
       "io.jhdf" % "jhdf" % "0.6.9",
+      "org.scala-lang.modules" %% "scala-parallel-collections" % "1.0.3",
       "org.slf4j" % "slf4j-nop" % "1.6.0" // this silences slf4j complaints in registration classes
-    ),
-    libraryDependencies ++= (scalaBinaryVersion.value match {
-      case "3" =>
-        Seq(
-          "org.scala-lang.modules" %% "scala-parallel-collections" % "1.0.3"
-        )
-      case "2.13" =>
-        Seq(
-          "org.scala-lang.modules" %% "scala-parallel-collections" % "0.2.0"
-        )
-      case _ => { println(scalaBinaryVersion.value); Seq() }
-    })
+    )
   )
   .enablePlugins(GitVersioning)
   .settings(

--- a/src/main/scala/scalismo/io/StatisticalModelIO.scala
+++ b/src/main/scala/scalismo/io/StatisticalModelIO.scala
@@ -15,7 +15,9 @@
  */
 package scalismo.io
 
-import java.io._
+import scalismo.common.interpolation.NearestNeighborInterpolator3D
+
+import java.io.*
 import scalismo.common.{Scalar, UnstructuredPointsDomain, Vectorizer}
 import scalismo.geometry.{_1D, _2D, _3D, EuclideanVector}
 import scalismo.image.DiscreteImageDomain
@@ -240,7 +242,7 @@ object StatisticalModelIO {
    * @return statisticalMeshModel
    */
   private def modelConverterToMeshModel(model: PointDistributionModel[_3D, TriangleMesh]): StatisticalMeshModel = {
-    StatisticalMeshModel(model.reference, model.gp)
+    StatisticalMeshModel(model.reference, model.gp.interpolate(NearestNeighborInterpolator3D()))
   }
 
   /**

--- a/src/main/scala/scalismo/registration/MutualInformationMetric.scala
+++ b/src/main/scala/scalismo/registration/MutualInformationMetric.scala
@@ -208,7 +208,7 @@ case class MutualInformationMetric[D: NDSpace, A: Scalar](fixedImage: Field[D, A
       val derivsAtValidPoints = derivsForPoints.collect { case Some(v) => v }
       val deriv = derivsAtValidPoints.foldLeft(zeroVec)((acc, v) => acc + v)
 
-      val scaledDeriv = (1.0 / (derivsAtValidPoints.size * binSizeMovingImage)) * deriv
+      val scaledDeriv = deriv * (1.0 / (derivsAtValidPoints.size * binSizeMovingImage))
       ((l, k), scaledDeriv)
     }
 
@@ -283,7 +283,7 @@ case class MutualInformationMetric[D: NDSpace, A: Scalar](fixedImage: Field[D, A
 
       if (marginalHistogramFixedImage(k) != 0 && marginalHistMoving(l) != 0) {
         (jointHistDeriv(l, k) * log(jointHist(l, k) / (marginalHistMoving(l) * marginalHistogramFixedImage(k)) + 1)
-          - (jointHist(l, k) / marginalHistMoving(l)) * marginalHistDerivMoving(l))
+          - marginalHistDerivMoving(l) * (jointHist(l, k) / marginalHistMoving(l)))
       } else {
         DenseVector.zeros[Double](numberOfParameters)
       }
@@ -326,7 +326,7 @@ case class MutualInformationMetric[D: NDSpace, A: Scalar](fixedImage: Field[D, A
 
       if (marginalHistogramRef(k) != 0 && marginalHistMoving(l) != 0) {
         (joingHistDeriv(l, k) * log(jointHist(l, k) / (marginalHistMoving(l) * marginalHistogramRef(k)) + 1)
-          - (jointHist(l, k) / marginalHistMoving(l)) * marginalHistDerivMoving(l))
+          - marginalHistDerivMoving(l) * (jointHist(l, k) / marginalHistMoving(l)))
       } else {
         DenseVector.zeros[Double](numberOfParameters)
       }

--- a/src/main/scala/scalismo/statisticalmodel/LowRankGaussianProcess.scala
+++ b/src/main/scala/scalismo/statisticalmodel/LowRankGaussianProcess.scala
@@ -424,7 +424,7 @@ object LowRankGaussianProcess {
     val Ut = U.t
 
     //calling functions remove small values for this inversion
-    val Si = 1.0 / S
+    val Si = S.map(s => 1.0 / s)
     val Ai = {
       val bi = new CSCMatrix.Builder[Double](y.length, y.length)
       for ((mvn, i) <- td.zipWithIndex) {

--- a/src/test/scala/scalismo/statisticalmodel/MultivariateNormalDistributionTests.scala
+++ b/src/test/scala/scalismo/statisticalmodel/MultivariateNormalDistributionTests.scala
@@ -41,7 +41,7 @@ class MultivariateNormalDistributionTests extends ScalismoTestSuite {
       val n = 100
       val variance = 0.01
       val mean = DenseVector.zeros[Double](n)
-      val cov = variance * DenseMatrix.eye[Double](n)
+      val cov = DenseMatrix.eye[Double](n) * variance
       val mvn = new MultivariateNormalDistribution(mean, cov)
       val breezeMvn = breeze.stats.distributions.MultivariateGaussian.apply(mean, cov)
       for (v <- (1 to 4).map(_ =>
@@ -57,7 +57,7 @@ class MultivariateNormalDistributionTests extends ScalismoTestSuite {
       val n = 100
       val variance = 0.01
       val mean = DenseVector.zeros[Double](n)
-      val cov = variance * DenseMatrix.eye[Double](n)
+      val cov = DenseMatrix.eye[Double](n) * variance
       for (x <- 1 until cov.rows) {
         cov(x, x - 1) = 0.002
         cov(x - 1, x) = 0.002


### PR DESCRIPTION
So far we compiled scalismo for both scala 3 and scala 2.13. This restricts the syntax to a subset of the language and forces the downstream libraries to be available as 2.13. As Scala 2.13 is able to consume libraries written in Scala 3.x, I would argue that we can safely drop scala 2.13 and focus instead on writing clean scala 3.x code, making use of the many language improvements. 