### PR TITLE
Add 3D constructor to ScalarMeshField

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ lazy val root = (project in file("."))
   .settings(
     name := "scalismo",
     organization := "ch.unibas.cs.gravis",
-    scalaVersion := "3.2.2",
+    scalaVersion := "3.3.0",
     homepage := Some(url("https://scalismo.org")),
     licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0")),
     scmInfo := Some(
@@ -26,8 +26,8 @@ lazy val root = (project in file("."))
     ),
     resolvers ++= Seq(
       Resolver.jcenterRepo,
-      Resolver.sonatypeRepo("releases"),
-      Resolver.sonatypeRepo("snapshots")
+      Resolver.sonatypeRepo("snapshots"),
+      Resolver.sonatypeRepo("releases")
     ),
     scalacOptions ++= {
       Seq(
@@ -42,16 +42,16 @@ lazy val root = (project in file("."))
     },
     javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
     libraryDependencies ++= Seq(
-      "org.scalactic" %% "scalactic" % "3.2.15",
-      "org.scalatest" %% "scalatest" % "3.2.15" % "test",
+      "org.scalactic" %% "scalactic" % "3.2.16",
+      "org.scalatest" %% "scalatest" % "3.2.16" % "test",
       "org.scalanlp" %% "breeze" % "2.1.0",
       "org.scalanlp" %% "breeze-natives" % "2.1.0",
       "ch.unibas.cs.gravis" % "scalismo-niftijiojar" % "0.1.0",
       "ch.unibas.cs.gravis" %% "scalismo-hdf5-json" % "0.1-RC1",
       "ch.unibas.cs.gravis" % "vtkjavanativesall" % "0.2-RC1",
-      "io.jhdf" % "jhdf" % "0.6.9",
-      "org.scala-lang.modules" %% "scala-parallel-collections" % "1.0.3",
-      "org.slf4j" % "slf4j-nop" % "1.6.0" // this silences slf4j complaints in registration classes
+      "io.jhdf" % "jhdf" % "0.6.10",
+      "org.scala-lang.modules" %% "scala-parallel-collections" % "1.0.4",
+      "org.slf4j" % "slf4j-nop" % "2.0.7" // this silences slf4j complaints in registration classes
     )
   )
   .enablePlugins(GitBranchPrompt)

--- a/src/main/scala/scalismo/common/DiscreteField.scala
+++ b/src/main/scala/scalismo/common/DiscreteField.scala
@@ -239,8 +239,15 @@ trait DiscreteFieldWarp[D, DDomain[D] <: DiscreteDomain[D], Value] {
   ): DiscreteField[D, DDomain, Value]
 }
 
+@deprecated("Use ScalarMeshField3D or DiscreteField3D instead", "0.92")
 object ScalarMeshField {
-  def apply[S: Scalar: ClassTag](mesh: TriangleMesh[_3D], data: Traversable[S]): ScalarMeshField[S] = {
+  def apply[S: Scalar: ClassTag](mesh: TriangleMesh[_3D], data: Iterable[S]): ScalarMeshField[S] = {
+    DiscreteField(mesh, ScalarArray(data.toArray))
+  }
+}
+
+object ScalarMeshField3D {
+  def apply[S: Scalar: ClassTag](mesh: TriangleMesh[_3D], data: Iterable[S]): ScalarMeshField[S] = {
     DiscreteField(mesh, ScalarArray(data.toArray))
   }
 }

--- a/src/main/scala/scalismo/geometry/EuclideanVector.scala
+++ b/src/main/scala/scalismo/geometry/EuclideanVector.scala
@@ -283,7 +283,7 @@ object EuclideanVector {
   /** spire VectorSpace implementation for Vector */
   implicit def spireVectorSpace[D: NDSpace]: VectorSpace[EuclideanVector[D], Double] =
     new spire.algebra.VectorSpace[EuclideanVector[D], Double] {
-      implicit override def scalar: Field[Double] = Field[Double]
+      override def scalar: Field[Double] = Field[Double]
       override def timesl(r: Double, v: EuclideanVector[D]): EuclideanVector[D] = v.map(f => f * r)
       override def negate(x: EuclideanVector[D]): EuclideanVector[D] = x.map(f => -f)
       override def zero: EuclideanVector[D] = zeros[D]

--- a/src/main/scala/scalismo/geometry/IntVector.scala
+++ b/src/main/scala/scalismo/geometry/IntVector.scala
@@ -118,7 +118,7 @@ object IntVector {
   /** spire Module implementation for Index (no scalar division) */
   implicit def spireModule[D: NDSpace]: LeftModule[IntVector[D], Int] =
     new spire.algebra.LeftModule[IntVector[D], Int] {
-      implicit override def scalar: Ring[Int] = Ring[Int]
+      override def scalar: Ring[Int] = Ring[Int]
       override def timesl(r: Int, v: IntVector[D]): IntVector[D] = v.map(i => i * r)
       override def negate(x: IntVector[D]): IntVector[D] = x.map(i => -i)
       override def zero: IntVector[D] = zeros[D]


### PR DESCRIPTION
An explicit constructor for the 3D case was missing, which should be available for all geometric objects. 
This PR adds the constructor and deprecates the generic `ScalarMeshField` constructor. 

Please merge only after #405 is merged. 