### PR TITLE
add samplePoints method to sampler

### DIFF
--- a/src/main/scala/scalismo/numerics/Sampler.scala
+++ b/src/main/scala/scalismo/numerics/Sampler.scala
@@ -38,6 +38,11 @@ trait Sampler[D] {
    */
   def sample(): IndexedSeq[(Point[D], Double)]
 
+  /**
+   * sample n points.
+   */
+  def samplePoints(): IndexedSeq[Point[D]] = sample().map(_._1)
+
   def volumeOfSampleRegion: Double
 }
 


### PR DESCRIPTION
This PR proposes to add a convenience function,  `samplePoints` to a sampler. 
So far only the `sample` method was available, which returns a tuple of points and their probability. This is useful for internal algorithms, but often not what the user wants to see. As we cannot remove the public `sample` method, a new method `samplePoints` is added, which simply throws away the probabilities. 