### PR TITLE
Fix/slow boundary calculation for large meshes

### DIFF
--- a/src/main/scala/scalismo/mesh/MeshBoundaryPredicates.scala
+++ b/src/main/scala/scalismo/mesh/MeshBoundaryPredicates.scala
@@ -170,21 +170,29 @@ object MeshBoundaryPredicates {
       }
     }
     val edgeOnBorderTmp = edgeOnBorderBuilder.result()
-
     // edges from only a single triangle lie on the border,
     // edges contained in two triangles are not on a border
+    var edgeOnBorderSet: Set[(Int, Int)] = Set.empty
     triangles.foreach { triangle =>
       edgesOfATriangle.foreach { edge =>
         val v1 = triangle.pointIds(edge._1).id
         val v2 = triangle.pointIds(edge._2).id
-        edgeOnBorderTmp(v1, v2) = !edgeOnBorderTmp(v1, v2)
-        edgeOnBorderTmp(v2, v1) = !edgeOnBorderTmp(v2, v1)
+
+        if (edgeOnBorderSet.contains((v1, v2)) || edgeOnBorderSet.contains((v2, v1))) {
+          edgeOnBorderSet -= ((v1, v2))
+          edgeOnBorderSet -= ((v2, v1))
+        } else {
+          edgeOnBorderSet += ((v1, v2))
+        }
       }
+    }
+    edgeOnBorderSet.foreach{case(v1, v2) =>
+      edgeOnBorderTmp(v1, v2) = true
+      edgeOnBorderTmp(v2, v1) = true
     }
 
     // optimization : we do not need values corresponding to false in the sparse representation
     val edgeOnBorder = reduceCSCMatrixBooleansToTrueEntries(edgeOnBorderTmp)
-
     // points at one end of a border edge are also on the border,
     // triangles with one side on the border are also on the border
     triangles.zipWithIndex.foreach { t =>
@@ -205,12 +213,12 @@ object MeshBoundaryPredicates {
   }
 
   /**
-   * Build boundary index for triangle mesh.
+   * Build boundary index for tetrahedral mesh.
    *
    * @param mesh
-   *   Incoming triangle mesh.
+   *   Incoming tetrahedral mesh.
    * @return
-   *   Boundary that can be queried for by index for points, edges, and triangles.
+   *   Boundary that can be queried for by index for points, edges, and tetrahedral.
    */
   def apply[D](mesh: TetrahedralMesh[D]): TetrahedralMeshBoundaryPredicates = {
 

--- a/src/test/scala/scalismo/mesh/MeshBoundaryTests.scala
+++ b/src/test/scala/scalismo/mesh/MeshBoundaryTests.scala
@@ -55,11 +55,19 @@ class MeshBoundaryTests extends ScalismoTestSuite {
 
     it("should calculate the correct number of mesh boundary points and triangles") {
       val mesh = Fixture.faceMesh
+      val meshNoTriangles = TriangleMesh3D(
+        mesh.pointSet.points.toIndexedSeq,
+        TriangleList(IndexedSeq())
+      )
       val boundaryPointIds = mesh.pointSet.pointIds.toSeq.filter(id => mesh.operations.pointIsOnBoundary(id))
       val boundaryTriangleIds = mesh.triangulation.triangleIds.filter(id => mesh.operations.triangleIsOnBoundary(id))
-
       boundaryPointIds.length shouldBe 918
       boundaryTriangleIds.length shouldBe 782
+
+      val allBoundaryPointIds = meshNoTriangles.pointSet.pointIds.toSeq.filter(id => meshNoTriangles.operations.pointIsOnBoundary(id))
+      val allBoundaryTriangleIds = meshNoTriangles.triangulation.triangleIds.filter(id => meshNoTriangles.operations.triangleIsOnBoundary(id))
+      allBoundaryPointIds.length shouldBe 0
+      allBoundaryTriangleIds.length shouldBe 0
     }
 
     it("should have all elements on the boundary for a single-triangle mesh") {

--- a/src/test/scala/scalismo/mesh/MeshBoundaryTests.scala
+++ b/src/test/scala/scalismo/mesh/MeshBoundaryTests.scala
@@ -40,6 +40,9 @@ class MeshBoundaryTests extends ScalismoTestSuite {
                                            TriangleList(IndexedSeq(TriangleCell(0, 1, 2), TriangleCell(0, 2, 3)))
       )
 
+      val path = getClass.getResource("/facemesh.stl").getPath
+      val faceMesh = MeshIO.readMesh(new File(URLDecoder.decode(path, "UTF-8"))).get
+
       val traingesMeshWithOneCompletelySouroundedTriangle = {
         val points = for (y <- 0 until 4; x <- 0 until 4) yield Point(x, y, 0)
         val trianglesV =
@@ -48,6 +51,15 @@ class MeshBoundaryTests extends ScalismoTestSuite {
           for (y <- 0 until 3; x <- 0 until 3) yield TriangleCell(x + 1 + y * 4, x + (y + 1) * 4, (x + 1) + (y + 1) * 4)
         TriangleMesh3D(points, TriangleList(trianglesV ++ trianglesA))
       }
+    }
+
+    it("should calculate the correct number of mesh boundary points and triangles") {
+      val mesh = Fixture.faceMesh
+      val boundaryPointIds = mesh.pointSet.pointIds.toSeq.filter(id => mesh.operations.pointIsOnBoundary(id))
+      val boundaryTriangleIds = mesh.triangulation.triangleIds.filter(id => mesh.operations.triangleIsOnBoundary(id))
+
+      boundaryPointIds.length shouldBe 918
+      boundaryTriangleIds.length shouldBe 782
     }
 
     it("should have all elements on the boundary for a single-triangle mesh") {


### PR DESCRIPTION
Fixes a speed issue with calculation boundary points on large triangle meshes.
 - add intermediate edge set
 - add boundary test on face mesh
This addresses issue https://github.com/unibas-gravis/scalismo/issues/413