### PR TITLE
Feat/gp map

### DIFF
--- a/src/main/scala/scalismo/statisticalmodel/DiscreteLowRankGaussianProcess.scala
+++ b/src/main/scala/scalismo/statisticalmodel/DiscreteLowRankGaussianProcess.scala
@@ -197,27 +197,25 @@ class DiscreteLowRankGaussianProcess[D: NDSpace, DDomain[DD] <: DiscreteDomain[D
 
   /**
    * Discrete version of
-   * [[DiscreteLowRankGaussianProcess.MAP(IndexedSeq[(Point[D], Vector[DO])], sigma2: Double]]. In contrast to
+   * [[DiscreteLowRankGaussianProcess.posteriorMean(IndexedSeq[(Point[D], Vector[DO])], sigma2: Double]]. In contrast to
    * this method, the points for the training data are defined by the pointId. The returned posterior process is defined
    * at the same points.
    */
-  def MAP(trainingData: IndexedSeq[(PointId, Value)],
-                sigma2: Double
-               ): DiscreteField[D, DDomain, Value] = {
+  def posteriorMean(trainingData: IndexedSeq[(PointId, Value)], sigma2: Double): DiscreteField[D, DDomain, Value] = {
     val cov =
       MultivariateNormalDistribution(DenseVector.zeros[Double](outputDim), DenseMatrix.eye[Double](outputDim) * sigma2)
     val newtd = trainingData.map { case (ptId, df) => (ptId, df, cov) }
-    MAP(newtd)
+    posteriorMean(newtd)
   }
 
   /**
-   * Discrete version of [[DiscreteLowRankGaussianProcess.MAP(IndexedSeq[(Point[D], Vector[DO], Double)])]]. In
-   * contrast to this method, the points for the training data are defined by the pointId. The returned posterior
+   * Discrete version of [[DiscreteLowRankGaussianProcess.posteriorMean(IndexedSeq[(Point[D], Vector[DO], Double)])]].
+   * In contrast to this method, the points for the training data are defined by the pointId. The returned posterior
    * process is defined at the same points.
    */
-  def MAP(
-                 trainingData: IndexedSeq[(PointId, Value, MultivariateNormalDistribution)]
-               ): DiscreteField[D, DDomain, Value] = {
+  def posteriorMean(
+    trainingData: IndexedSeq[(PointId, Value, MultivariateNormalDistribution)]
+  ): DiscreteField[D, DDomain, Value] = {
     DiscreteLowRankGaussianProcess.regressionMean(this, trainingData)
   }
 
@@ -527,10 +525,10 @@ object DiscreteLowRankGaussianProcess {
    * Discrete implementation of [[LowRankGaussianProcess.regressionMean]]
    */
   def regressionMean[D: NDSpace, DDomain[D] <: DiscreteDomain[D], Value](
-                                                                      gp: DiscreteLowRankGaussianProcess[D, DDomain, Value],
-                                                                      trainingData: IndexedSeq[(PointId, Value, MultivariateNormalDistribution)],
-                                                                      naNStrategy: NaNStrategy = NanIsNumericValue
-                                                                    )(implicit vectorizer: Vectorizer[Value]): DiscreteField[D, DDomain, Value] = {
+    gp: DiscreteLowRankGaussianProcess[D, DDomain, Value],
+    trainingData: IndexedSeq[(PointId, Value, MultivariateNormalDistribution)],
+    naNStrategy: NaNStrategy = NanIsNumericValue
+  )(implicit vectorizer: Vectorizer[Value]): DiscreteField[D, DDomain, Value] = {
 
     val LowRankRegressionComputation(_Minv, yVec, mVec, _QtL) =
       LowRankRegressionComputation.fromDiscreteLowRankGP(gp, trainingData, naNStrategy)

--- a/src/main/scala/scalismo/statisticalmodel/DiscreteLowRankGaussianProcess.scala
+++ b/src/main/scala/scalismo/statisticalmodel/DiscreteLowRankGaussianProcess.scala
@@ -195,6 +195,32 @@ class DiscreteLowRankGaussianProcess[D: NDSpace, DDomain[DD] <: DiscreteDomain[D
     DiscreteLowRankGaussianProcess.regression(this, trainingData)
   }
 
+  /**
+   * Discrete version of
+   * [[DiscreteLowRankGaussianProcess.MAP(IndexedSeq[(Point[D], Vector[DO])], sigma2: Double]]. In contrast to
+   * this method, the points for the training data are defined by the pointId. The returned posterior process is defined
+   * at the same points.
+   */
+  def MAP(trainingData: IndexedSeq[(PointId, Value)],
+                sigma2: Double
+               ): DiscreteField[D, DDomain, Value] = {
+    val cov =
+      MultivariateNormalDistribution(DenseVector.zeros[Double](outputDim), DenseMatrix.eye[Double](outputDim) * sigma2)
+    val newtd = trainingData.map { case (ptId, df) => (ptId, df, cov) }
+    MAP(newtd)
+  }
+
+  /**
+   * Discrete version of [[DiscreteLowRankGaussianProcess.MAP(IndexedSeq[(Point[D], Vector[DO], Double)])]]. In
+   * contrast to this method, the points for the training data are defined by the pointId. The returned posterior
+   * process is defined at the same points.
+   */
+  def MAP(
+                 trainingData: IndexedSeq[(PointId, Value, MultivariateNormalDistribution)]
+               ): DiscreteField[D, DDomain, Value] = {
+    DiscreteLowRankGaussianProcess.regressionMean(this, trainingData)
+  }
+
   override def marginal(pointIds: Seq[PointId])(implicit
     domainCreator: UnstructuredPoints.Create[D]
   ): DiscreteLowRankGaussianProcess[D, UnstructuredPointsDomain, Value] = {
@@ -495,6 +521,21 @@ object DiscreteLowRankGaussianProcess {
     }
 
     new DiscreteLowRankGaussianProcess(gp.domain, mean_pVector, lambdas_p, eigenMatrix_p)
+  }
+
+  /**
+   * Discrete implementation of [[LowRankGaussianProcess.regressionMean]]
+   */
+  def regressionMean[D: NDSpace, DDomain[D] <: DiscreteDomain[D], Value](
+                                                                      gp: DiscreteLowRankGaussianProcess[D, DDomain, Value],
+                                                                      trainingData: IndexedSeq[(PointId, Value, MultivariateNormalDistribution)],
+                                                                      naNStrategy: NaNStrategy = NanIsNumericValue
+                                                                    )(implicit vectorizer: Vectorizer[Value]): DiscreteField[D, DDomain, Value] = {
+
+    val LowRankRegressionComputation(_Minv, yVec, mVec, _QtL) =
+      LowRankRegressionComputation.fromDiscreteLowRankGP(gp, trainingData, naNStrategy)
+    val mean_coeffs = (_Minv * _QtL) * (yVec - mVec)
+    gp.instance(mean_coeffs)
   }
 
   def createUsingPCA[D: NDSpace, DDomain[D] <: DiscreteDomain[D], Value](

--- a/src/main/scala/scalismo/statisticalmodel/GaussianProcess.scala
+++ b/src/main/scala/scalismo/statisticalmodel/GaussianProcess.scala
@@ -27,14 +27,14 @@ import scalismo.utils.Random
  * The output space is a Euclidean vector space of dimensionality DO.
  *
  * @param mean
- * The mean function
+ *   The mean function
  * @param cov
- * The covariance function. Needs to be positive definite
+ *   The covariance function. Needs to be positive definite
  * @tparam D
- * The dimensionality of the input space
+ *   The dimensionality of the input space
  */
 class GaussianProcess[D: NDSpace, Value](val mean: Field[D, Value], val cov: MatrixValuedPDKernel[D])(implicit
-                                                                                                      val vectorizer: Vectorizer[Value]
+  val vectorizer: Vectorizer[Value]
 ) {
 
   def outputDim = vectorizer.dim
@@ -45,8 +45,8 @@ class GaussianProcess[D: NDSpace, Value](val mean: Field[D, Value], val cov: Mat
    * Sample values of the Gaussian process evaluated at the given points.
    */
   def sampleAtPoints[DDomain[DD] <: DiscreteDomain[DD]](
-                                                         domain: DDomain[D]
-                                                       )(implicit rand: Random): DiscreteField[D, DDomain, Value] = {
+    domain: DDomain[D]
+  )(implicit rand: Random): DiscreteField[D, DDomain, Value] = {
     this.discretize(domain).sample()
   }
 
@@ -55,7 +55,7 @@ class GaussianProcess[D: NDSpace, Value](val mean: Field[D, Value], val cov: Mat
    * unstructured points domain
    */
   def marginal(points: IndexedSeq[Point[D]])(implicit
-                                             domainCreator: UnstructuredPointsDomain.Create[D]
+    domainCreator: UnstructuredPointsDomain.Create[D]
   ): DiscreteGaussianProcess[D, UnstructuredPointsDomain, Value] = {
     val domain = domainCreator.create(points)
     discretize(domain)
@@ -73,8 +73,8 @@ class GaussianProcess[D: NDSpace, Value](val mean: Field[D, Value], val cov: Mat
    * observed data would be selected.
    *
    * @param trainingData
-   * Point/value pairs where that the sample should approximate, together with an error model (the uncertainty) at
-   * each point.
+   *   Point/value pairs where that the sample should approximate, together with an error model (the uncertainty) at
+   *   each point.
    */
   def marginalLikelihood(trainingData: IndexedSeq[(Point[D], Value, MultivariateNormalDistribution)]): Double = {
     require(trainingData.nonEmpty, "provide observations to calculate the marginal likelihood")
@@ -132,8 +132,8 @@ class GaussianProcess[D: NDSpace, Value](val mean: Field[D, Value], val cov: Mat
    * Gaussian process regression.
    */
   def posterior(
-                 trainingData: IndexedSeq[(Point[D], Value, MultivariateNormalDistribution)]
-               ): GaussianProcess[D, Value] = {
+    trainingData: IndexedSeq[(Point[D], Value, MultivariateNormalDistribution)]
+  ): GaussianProcess[D, Value] = {
     GaussianProcess.regression(this, trainingData)
   }
 
@@ -142,8 +142,8 @@ class GaussianProcess[D: NDSpace, Value](val mean: Field[D, Value], val cov: Mat
    * regression.
    */
   def MAP(
-           trainingData: IndexedSeq[(Point[D], Value, MultivariateNormalDistribution)]
-         ): Field[D, Value] = {
+    trainingData: IndexedSeq[(Point[D], Value, MultivariateNormalDistribution)]
+  ): Field[D, Value] = {
     GaussianProcess.regressionMean(this, trainingData)
   }
 }
@@ -157,7 +157,7 @@ object GaussianProcess {
    * Creates a new Gaussian process with given mean and covariance, which is defined on the given domain.
    */
   def apply[D: NDSpace, Value](mean: Field[D, Value], cov: MatrixValuedPDKernel[D])(implicit
-                                                                                    vectorizer: Vectorizer[Value]
+    vectorizer: Vectorizer[Value]
   ): GaussianProcess[D, Value] = {
     new GaussianProcess[D, Value](mean, cov)
   }
@@ -166,8 +166,8 @@ object GaussianProcess {
    * Creates a new zero-mean Gaussian process with the given covariance function.
    */
   def apply[D: NDSpace, Value](
-                                cov: MatrixValuedPDKernel[D]
-                              )(implicit vectorizer: Vectorizer[Value]): GaussianProcess[D, Value] = {
+    cov: MatrixValuedPDKernel[D]
+  )(implicit vectorizer: Vectorizer[Value]): GaussianProcess[D, Value] = {
     val zeroVec = vectorizer.unvectorize(DenseVector.zeros(vectorizer.dim))
     val zeroField = Field[D, Value](EuclideanSpace[D], (p: Point[D]) => zeroVec)
     GaussianProcess[D, Value](zeroField, cov)
@@ -178,17 +178,18 @@ object GaussianProcess {
    * noise with given variance.
    *
    * @param gp
-   * The gaussian process
+   *   The gaussian process
    * @param trainingData
-   * Point/value pairs where that the sample should approximate, together with an error model (the uncertainty) at
-   * each point.
+   *   Point/value pairs where that the sample should approximate, together with an error model (the uncertainty) at
+   *   each point.
    */
   def regression[D: NDSpace, Value](
-                                     gp: GaussianProcess[D, Value],
-                                     trainingData: IndexedSeq[(Point[D], Value, MultivariateNormalDistribution)]
-                                   )(implicit vectorizer: Vectorizer[Value]): GaussianProcess[D, Value] = {
+    gp: GaussianProcess[D, Value],
+    trainingData: IndexedSeq[(Point[D], Value, MultivariateNormalDistribution)]
+  )(implicit vectorizer: Vectorizer[Value]): GaussianProcess[D, Value] = {
 
     val (decomK, xstar, posteriorMean) = regressionDataUnpack(gp, trainingData)
+
     val posteriorKernel = new MatrixValuedPDKernel[D] {
       override def domain = gp.domain
 
@@ -207,15 +208,15 @@ object GaussianProcess {
    * noise with given variance.
    *
    * @param gp
-   * The gaussian process
+   *   The gaussian process
    * @param trainingData
-   * Point/value pairs where that the sample should approximate, together with an error model (the uncertainty) at
-   * each point.
+   *   Point/value pairs where that the sample should approximate, together with an error model (the uncertainty) at
+   *   each point.
    */
   def regressionMean[D: NDSpace, Value](
-                                         gp: GaussianProcess[D, Value],
-                                         trainingData: IndexedSeq[(Point[D], Value, MultivariateNormalDistribution)]
-                                       )(implicit vectorizer: Vectorizer[Value]): Field[D, Value] = {
+    gp: GaussianProcess[D, Value],
+    trainingData: IndexedSeq[(Point[D], Value, MultivariateNormalDistribution)]
+  )(implicit vectorizer: Vectorizer[Value]): Field[D, Value] = {
 
     val (_, _, posteriorMean) = regressionDataUnpack(gp, trainingData)
 
@@ -223,15 +224,15 @@ object GaussianProcess {
   }
 
   private def regressionDataUnpack[D: NDSpace, Value](
-                                                       gp: GaussianProcess[D, Value],
-                                                       trainingData: IndexedSeq[(Point[D], Value, MultivariateNormalDistribution)]
-                                                     )(implicit
-                                                       vectorizer: Vectorizer[Value]
-                                                     ): (
+    gp: GaussianProcess[D, Value],
+    trainingData: IndexedSeq[(Point[D], Value, MultivariateNormalDistribution)]
+  )(implicit
+    vectorizer: Vectorizer[Value]
+  ): (
     DenseMatrix[Double],
-      Point[D] => DenseMatrix[Double],
-      Point[D] => Value
-    ) = {
+    Point[D] => DenseMatrix[Double],
+    Point[D] => Value
+  ) = {
     val outputDim = vectorizer.dim
     val (xs, ys, errorDists) = trainingData.unzip3
     val mVec = DiscreteField.vectorize[D, Value](xs.map(gp.mean))
@@ -242,13 +243,14 @@ object GaussianProcess {
       K(i * outputDim until (i + 1) * outputDim, i * outputDim until (i + 1) * outputDim) += errorDist.cov
     }
     val L: DenseMatrix[Double] = breeze.linalg.cholesky(K)
+    val alpha = L.t \ (L \ fVec)
 
     def xstar(x: Point[D]): DenseMatrix[Double] = {
       Kernel.computeKernelVectorFor[D](x, xs, gp.cov)
     }
 
     def posteriorMean(x: Point[D]): Value = {
-      vectorizer.unvectorize(xstar(x) * L.t \ (L \ fVec) + vectorizer.vectorize(gp.mean(x)))
+      vectorizer.unvectorize(xstar(x) * alpha + vectorizer.vectorize(gp.mean(x)))
     }
 
     (L, xstar, posteriorMean)
@@ -261,31 +263,31 @@ object GaussianProcess {
    * observed data would be selected.
    *
    * @param gp
-   * The gaussian process
+   *   The gaussian process
    * @param trainingData
-   * Point/value pairs where that the sample should approximate, together with an error model (the uncertainty) at
-   * each point.
+   *   Point/value pairs where that the sample should approximate, together with an error model (the uncertainty) at
+   *   each point.
    */
   def marginalLikelihood[D: NDSpace, Value](
-                                             gp: GaussianProcess[D, Value],
-                                             trainingData: IndexedSeq[(Point[D], Value, MultivariateNormalDistribution)]
-                                           )(implicit vectorizer: Vectorizer[Value]): Double = {
+    gp: GaussianProcess[D, Value],
+    trainingData: IndexedSeq[(Point[D], Value, MultivariateNormalDistribution)]
+  )(implicit vectorizer: Vectorizer[Value]): Double = {
     gp.marginalLikelihood(trainingData)
   }
 
   /**
    * @tparam A
-   * combines the interface for NDSpace for GaussianProcess as well as PointId in DiscreteGaussianProcess
+   *   combines the interface for NDSpace for GaussianProcess as well as PointId in DiscreteGaussianProcess
    * @todo
-   * The current implementation can be optimized as it inverts the data covariance matrix (that can be heavy for more
-   * than a few points). Instead an implementation with a Cholesky decomposition would be more efficient.
+   *   The current implementation can be optimized as it inverts the data covariance matrix (that can be heavy for more
+   *   than a few points). Instead an implementation with a Cholesky decomposition would be more efficient.
    */
   private[scalismo] def marginalLikelihoodCalculation[A, Value](
-                                                                 cov: (A, A) => DenseMatrix[Double],
-                                                                 mean: A => Value,
-                                                                 trainingData: IndexedSeq[(A, Value, MultivariateNormalDistribution)],
-                                                                 outputDim: Int
-                                                               )(implicit vectorizer: Vectorizer[Value]): Double = {
+    cov: (A, A) => DenseMatrix[Double],
+    mean: A => Value,
+    trainingData: IndexedSeq[(A, Value, MultivariateNormalDistribution)],
+    outputDim: Int
+  )(implicit vectorizer: Vectorizer[Value]): Double = {
     // below is the implementation according to Rassmussen Gaussian Processes, Chapter 5, page 113
     val (xs, ys, errorDistributions) = trainingData.unzip3
     val meanValues = xs.map(mean)
@@ -323,7 +325,7 @@ object GaussianProcess {
 object GaussianProcess1D {
 
   def apply[Value](mean: Field[_1D, Value], cov: MatrixValuedPDKernel[_1D])(implicit
-                                                                            vectorizer: Vectorizer[Value]
+    vectorizer: Vectorizer[Value]
   ): GaussianProcess[_1D, Value] = {
     new GaussianProcess[_1D, Value](mean, cov)
   }
@@ -332,8 +334,8 @@ object GaussianProcess1D {
    * Creates a new zero-mean Gaussian process with the given covariance function.
    */
   def apply[Value](
-                    cov: MatrixValuedPDKernel[_1D]
-                  )(implicit vectorizer: Vectorizer[Value]): GaussianProcess[_1D, Value] = {
+    cov: MatrixValuedPDKernel[_1D]
+  )(implicit vectorizer: Vectorizer[Value]): GaussianProcess[_1D, Value] = {
     val zeroVec = vectorizer.unvectorize(DenseVector.zeros(vectorizer.dim))
     val zeroField = Field1D[Value](EuclideanSpace1D, (p: Point[_1D]) => zeroVec)
     GaussianProcess[_1D, Value](zeroField, cov)
@@ -344,7 +346,7 @@ object GaussianProcess1D {
 object GaussianProcess2D {
 
   def apply[Value](mean: Field[_2D, Value], cov: MatrixValuedPDKernel[_2D])(implicit
-                                                                            vectorizer: Vectorizer[Value]
+    vectorizer: Vectorizer[Value]
   ): GaussianProcess[_2D, Value] = {
     new GaussianProcess[_2D, Value](mean, cov)
   }
@@ -353,8 +355,8 @@ object GaussianProcess2D {
    * Creates a new zero-mean Gaussian process with the given covariance function.
    */
   def apply[Value](
-                    cov: MatrixValuedPDKernel[_2D]
-                  )(implicit vectorizer: Vectorizer[Value]): GaussianProcess[_2D, Value] = {
+    cov: MatrixValuedPDKernel[_2D]
+  )(implicit vectorizer: Vectorizer[Value]): GaussianProcess[_2D, Value] = {
     val zeroVec = vectorizer.unvectorize(DenseVector.zeros(vectorizer.dim))
     val zeroField = Field2D[Value](EuclideanSpace2D, (p: Point[_2D]) => zeroVec)
     GaussianProcess[_2D, Value](zeroField, cov)
@@ -365,7 +367,7 @@ object GaussianProcess2D {
 object GaussianProcess3D {
 
   def apply[Value](mean: Field[_3D, Value], cov: MatrixValuedPDKernel[_3D])(implicit
-                                                                            vectorizer: Vectorizer[Value]
+    vectorizer: Vectorizer[Value]
   ): GaussianProcess[_3D, Value] = {
     new GaussianProcess[_3D, Value](mean, cov)
   }
@@ -374,8 +376,8 @@ object GaussianProcess3D {
    * Creates a new zero-mean Gaussian process with the given covariance function.
    */
   def apply[Value](
-                    cov: MatrixValuedPDKernel[_3D]
-                  )(implicit vectorizer: Vectorizer[Value]): GaussianProcess[_3D, Value] = {
+    cov: MatrixValuedPDKernel[_3D]
+  )(implicit vectorizer: Vectorizer[Value]): GaussianProcess[_3D, Value] = {
     val zeroVec = vectorizer.unvectorize(DenseVector.zeros(vectorizer.dim))
     val zeroField = Field3D[Value](EuclideanSpace3D, (p: Point[_3D]) => zeroVec)
     GaussianProcess[_3D, Value](zeroField, cov)

--- a/src/main/scala/scalismo/statisticalmodel/GaussianProcess.scala
+++ b/src/main/scala/scalismo/statisticalmodel/GaussianProcess.scala
@@ -278,9 +278,6 @@ object GaussianProcess {
   /**
    * @tparam A
    *   combines the interface for NDSpace for GaussianProcess as well as PointId in DiscreteGaussianProcess
-   * @todo
-   *   The current implementation can be optimized as it inverts the data covariance matrix (that can be heavy for more
-   *   than a few points). Instead an implementation with a Cholesky decomposition would be more efficient.
    */
   private[scalismo] def marginalLikelihoodCalculation[A, Value](
     cov: (A, A) => DenseMatrix[Double],
@@ -313,10 +310,10 @@ object GaussianProcess {
       }
     }
 
-    val KyInv = inv(Ky)
+    val L = breeze.linalg.cholesky(Ky)
     val const = outputDim * trainingData.length * 0.5 * math.log(math.Pi * 2)
     // det(KyInv) > 0, because Ky is PSD, therefore we can ignore the sign of logdet
-    val margLikehood = ((yVecZeroMean.t * KyInv * yVecZeroMean) * -0.5) - (0.5 * logdet(Ky)._2) - const
+    val margLikehood = ((yVecZeroMean.t * L.t \ (L \ yVecZeroMean)) * -0.5) - (0.5 * logdet(Ky)._2) - const
     margLikehood
   }
 

--- a/src/main/scala/scalismo/statisticalmodel/GaussianProcess.scala
+++ b/src/main/scala/scalismo/statisticalmodel/GaussianProcess.scala
@@ -117,10 +117,10 @@ class GaussianProcess[D: NDSpace, Value](val mean: Field[D, Value], val cov: Mat
   }
 
   /**
-   * The MAP of a gaussian process, with respect to the given trainingData. It is computed using Gaussian process
+   * The posterior mean (MAP) of a gaussian process, with respect to the given trainingData. It is computed using Gaussian process
    * regression. We assume that the trainingData is subject to isotropic Gaussian noise with variance sigma2.
    */
-  def MAP(trainingData: IndexedSeq[(Point[D], Value)], sigma2: Double): Field[D, Value] = {
+  def posteriorMean(trainingData: IndexedSeq[(Point[D], Value)], sigma2: Double): Field[D, Value] = {
     val cov =
       MultivariateNormalDistribution(DenseVector.zeros[Double](outputDim), DenseMatrix.eye[Double](outputDim) * sigma2)
     val fullTrainingData = trainingData.map { case (p, v) => (p, v, cov) }
@@ -138,10 +138,10 @@ class GaussianProcess[D: NDSpace, Value](val mean: Field[D, Value], val cov: Mat
   }
 
   /**
-   * The MAP of a gaussian process, with respect to the given trainingData. It is computed using Gaussian process
+   * The posterior mean (MAP) of a gaussian process, with respect to the given trainingData. It is computed using Gaussian process
    * regression.
    */
-  def MAP(
+  def posteriorMean(
     trainingData: IndexedSeq[(Point[D], Value, MultivariateNormalDistribution)]
   ): Field[D, Value] = {
     GaussianProcess.regressionMean(this, trainingData)

--- a/src/main/scala/scalismo/statisticalmodel/LowRankGaussianProcess.scala
+++ b/src/main/scala/scalismo/statisticalmodel/LowRankGaussianProcess.scala
@@ -191,14 +191,14 @@ class LowRankGaussianProcess[D: NDSpace, Value](mean: Field[D, Value], val klBas
     LowRankGaussianProcess.regression(this, trainingData)
   }
 
-  override def MAP(trainingData: IndexedSeq[(Point[D], Value)], sigma2: Double): Field[D, Value] = {
+  override def posteriorMean(trainingData: IndexedSeq[(Point[D], Value)], sigma2: Double): Field[D, Value] = {
     val cov =
       MultivariateNormalDistribution(DenseVector.zeros[Double](outputDim), DenseMatrix.eye[Double](outputDim) * sigma2)
     val newtd = trainingData.map { case (pt, df) => (pt, df, cov) }
-    MAP(newtd)
+    posteriorMean(newtd)
   }
 
-  override def MAP(
+  override def posteriorMean(
     trainingData: IndexedSeq[(Point[D], Value, MultivariateNormalDistribution)]
   ): Field[D, Value] = {
     LowRankGaussianProcess.regressionMean(this, trainingData)

--- a/src/main/scala/scalismo/statisticalmodel/PointDistributionModel.scala
+++ b/src/main/scala/scalismo/statisticalmodel/PointDistributionModel.scala
@@ -173,6 +173,32 @@ case class PointDistributionModel[D: NDSpace, DDomain[D] <: DiscreteDomain[D]](
   }
 
   /**
+   * Similar to [[DiscreteLowRankGaussianProcess.MAP(Int, Point[_3D])], sigma2: Double)]], but the training data
+   * is defined by specifying the target point instead of the displacement vector
+   */
+  def MAP(trainingData: IndexedSeq[(PointId, Point[D])], sigma2: Double): DDomain[D] = {
+    val trainingDataWithDisplacements = trainingData.map { case (id, targetPoint) =>
+      (id, targetPoint - reference.pointSet.point(id))
+    }
+    val mean = gp.MAP(trainingDataWithDisplacements, sigma2)
+    warper.transformWithField(gp.domain, mean)
+  }
+
+  /**
+   * Similar to [[DiscreteLowRankGaussianProcess.MAP(Int, Point[_3D], Double)]]], but the training data is defined
+   * by specifying the target point instead of the displacement vector
+   */
+  def MAP(
+                 trainingData: IndexedSeq[(PointId, Point[D], MultivariateNormalDistribution)]
+               ): DDomain[D] = {
+    val trainingDataWithDisplacements = trainingData.map { case (id, targetPoint, cov) =>
+      (id, targetPoint - reference.pointSet.point(id), cov)
+    }
+    val mean = gp.MAP(trainingDataWithDisplacements)
+    warper.transformWithField(gp.domain, mean)
+  }
+
+  /**
    * transform the statistical mesh model using the given rigid transform. The spanned shape space is not affected by
    * this operations.
    */

--- a/src/main/scala/scalismo/statisticalmodel/PointDistributionModel.scala
+++ b/src/main/scala/scalismo/statisticalmodel/PointDistributionModel.scala
@@ -173,28 +173,28 @@ case class PointDistributionModel[D: NDSpace, DDomain[D] <: DiscreteDomain[D]](
   }
 
   /**
-   * Similar to [[DiscreteLowRankGaussianProcess.MAP(Int, Point[_3D])], sigma2: Double)]], but the training data
-   * is defined by specifying the target point instead of the displacement vector
+   * Similar to [[DiscreteLowRankGaussianProcess.posteriorMean(Int, Point[_3D])], sigma2: Double)]], but the training
+   * data is defined by specifying the target point instead of the displacement vector
    */
-  def MAP(trainingData: IndexedSeq[(PointId, Point[D])], sigma2: Double): DDomain[D] = {
+  def posteriorMean(trainingData: IndexedSeq[(PointId, Point[D])], sigma2: Double): DDomain[D] = {
     val trainingDataWithDisplacements = trainingData.map { case (id, targetPoint) =>
       (id, targetPoint - reference.pointSet.point(id))
     }
-    val mean = gp.MAP(trainingDataWithDisplacements, sigma2)
+    val mean = gp.posteriorMean(trainingDataWithDisplacements, sigma2)
     warper.transformWithField(gp.domain, mean)
   }
 
   /**
-   * Similar to [[DiscreteLowRankGaussianProcess.MAP(Int, Point[_3D], Double)]]], but the training data is defined
-   * by specifying the target point instead of the displacement vector
+   * Similar to [[DiscreteLowRankGaussianProcess.posteriorMean(Int, Point[_3D], Double)]]], but the training data is
+   * defined by specifying the target point instead of the displacement vector
    */
-  def MAP(
-                 trainingData: IndexedSeq[(PointId, Point[D], MultivariateNormalDistribution)]
-               ): DDomain[D] = {
+  def posteriorMean(
+    trainingData: IndexedSeq[(PointId, Point[D], MultivariateNormalDistribution)]
+  ): DDomain[D] = {
     val trainingDataWithDisplacements = trainingData.map { case (id, targetPoint, cov) =>
       (id, targetPoint - reference.pointSet.point(id), cov)
     }
-    val mean = gp.MAP(trainingDataWithDisplacements)
+    val mean = gp.posteriorMean(trainingDataWithDisplacements)
     warper.transformWithField(gp.domain, mean)
   }
 

--- a/src/main/scala/scalismo/statisticalmodel/StatisticalMeshModel.scala
+++ b/src/main/scala/scalismo/statisticalmodel/StatisticalMeshModel.scala
@@ -146,18 +146,18 @@ case class StatisticalMeshModel private (referenceMesh: TriangleMesh[_3D],
   }
 
   /**
-   * Similar to [[DiscreteLowRankGaussianProcess.MAP(Int, Point[_3D])], sigma2: Double)]], but the training data
-   * is defined by specifying the target point instead of the displacement vector
+   * Similar to [[DiscreteLowRankGaussianProcess.posteriorMean(Int, Point[_3D])], sigma2: Double)]], but the training
+   * data is defined by specifying the target point instead of the displacement vector
    */
-  def MAP(trainingData: IndexedSeq[(PointId, Point[_3D])], sigma2: Double): TriangleMesh3D =
-    pdm.MAP(trainingData, sigma2)
+  def posteriorMean(trainingData: IndexedSeq[(PointId, Point[_3D])], sigma2: Double): TriangleMesh3D =
+    pdm.posteriorMean(trainingData, sigma2)
 
   /**
-   * Similar to [[DiscreteLowRankGaussianProcess.MAP(Int, Point[_3D], Double)]]], but the training data is defined
-   * by specifying the target point instead of the displacement vector
+   * Similar to [[DiscreteLowRankGaussianProcess.posteriorMean(Int, Point[_3D], Double)]]], but the training data is
+   * defined by specifying the target point instead of the displacement vector
    */
-  def MAP(trainingData: IndexedSeq[(PointId, Point[_3D], MultivariateNormalDistribution)]): TriangleMesh3D =
-    pdm.MAP(trainingData)
+  def posteriorMean(trainingData: IndexedSeq[(PointId, Point[_3D], MultivariateNormalDistribution)]): TriangleMesh3D =
+    pdm.posteriorMean(trainingData)
 
   /**
    * transform the statistical mesh model using the given rigid transform. The spanned shape space is not affected by

--- a/src/main/scala/scalismo/statisticalmodel/StatisticalMeshModel.scala
+++ b/src/main/scala/scalismo/statisticalmodel/StatisticalMeshModel.scala
@@ -146,6 +146,20 @@ case class StatisticalMeshModel private (referenceMesh: TriangleMesh[_3D],
   }
 
   /**
+   * Similar to [[DiscreteLowRankGaussianProcess.MAP(Int, Point[_3D])], sigma2: Double)]], but the training data
+   * is defined by specifying the target point instead of the displacement vector
+   */
+  def MAP(trainingData: IndexedSeq[(PointId, Point[_3D])], sigma2: Double): TriangleMesh3D =
+    pdm.MAP(trainingData, sigma2)
+
+  /**
+   * Similar to [[DiscreteLowRankGaussianProcess.MAP(Int, Point[_3D], Double)]]], but the training data is defined
+   * by specifying the target point instead of the displacement vector
+   */
+  def MAP(trainingData: IndexedSeq[(PointId, Point[_3D], MultivariateNormalDistribution)]): TriangleMesh3D =
+    pdm.MAP(trainingData)
+
+  /**
    * transform the statistical mesh model using the given rigid transform. The spanned shape space is not affected by
    * this operations.
    */

--- a/src/test/scala/scalismo/ScalismoTestSuite.scala
+++ b/src/test/scala/scalismo/ScalismoTestSuite.scala
@@ -4,4 +4,12 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 class ScalismoTestSuite extends AnyFunSpec with Matchers {
   scalismo.initialize()
+
+  def measureTime[A](func: => A): (A, Double) = {
+    val startTime = System.currentTimeMillis()
+    val result = func
+    val endTime = System.currentTimeMillis()
+    val elapsedTime = (endTime - startTime)
+    (result, elapsedTime)
+  }
 }

--- a/src/test/scala/scalismo/statisticalmodel/GaussianProcessTests.scala
+++ b/src/test/scala/scalismo/statisticalmodel/GaussianProcessTests.scala
@@ -548,11 +548,11 @@ class GaussianProcessTests extends ScalismoTestSuite {
           .sum / numIterations.toDouble
       val timeMap =
         (0 until numIterations)
-          .map(_ => measureTime(f.gp.MAP(f.trainingDataGP, sigma))._2)
+          .map(_ => measureTime(f.gp.posteriorMean(f.trainingDataGP, sigma))._2)
           .sum / numIterations.toDouble
 
       val gpMean = f.gp.posterior(f.trainingDataGP, sigma).mean
-      val gpMAP = f.gp.MAP(f.trainingDataGP, sigma)
+      val gpMAP = f.gp.posteriorMean(f.trainingDataGP, sigma)
 
       // both posterior processes should give the same values at the specialized points
       for ((pt, id) <- f.discretizationPoints.zipWithIndex) {
@@ -573,11 +573,11 @@ class GaussianProcessTests extends ScalismoTestSuite {
           .sum / numIterations.toDouble
       val timeMap =
         (0 until numIterations)
-          .map(_ => measureTime(f.discreteLowRankGp.MAP(f.trainingDataDiscreteGP))._2)
+          .map(_ => measureTime(f.discreteLowRankGp.posteriorMean(f.trainingDataDiscreteGP))._2)
           .sum / numIterations.toDouble
 
       val gpMean = f.discreteLowRankGp.posterior(f.trainingDataDiscreteGP).mean
-      val gpMAP = f.discreteLowRankGp.MAP(f.trainingDataDiscreteGP)
+      val gpMAP = f.discreteLowRankGp.posteriorMean(f.trainingDataDiscreteGP)
 
       // both posterior processes should give the same values at the specialized points
       for ((_, id) <- gpMean.pointsWithIds.toSeq) {

--- a/src/test/scala/scalismo/statisticalmodel/StatisticalModelTests.scala
+++ b/src/test/scala/scalismo/statisticalmodel/StatisticalModelTests.scala
@@ -87,6 +87,17 @@ class StatisticalModelTests extends ScalismoTestSuite {
       compareModels(model, newModel)
     }
 
+    it("yield equivalent result if using mean of posterior and MAP calculation while MAP is faster to compute") {
+      val path = getClass.getResource("/facemodel.h5").getPath
+      val model = StatisticalModelIO.readStatisticalMeshModel(new File(URLDecoder.decode(path, "UTF-8"))).get
+      val ref = model.referenceMesh
+      val data = ref.pointSet.pointIds.toIndexedSeq.map(id => (id, ref.pointSet.point(id)))
+      val mean = measureTime(model.posterior(data, 1.0).mean)
+      val map = measureTime(model.MAP(data, 1.0))
+      map._2 should be < mean._2
+      assert(mean._1 == map._1)
+    }
+
     it("can change the mean shape and still yield the same shape space") {
 
       val path = getClass.getResource("/facemodel.h5").getPath

--- a/src/test/scala/scalismo/statisticalmodel/StatisticalModelTests.scala
+++ b/src/test/scala/scalismo/statisticalmodel/StatisticalModelTests.scala
@@ -93,7 +93,7 @@ class StatisticalModelTests extends ScalismoTestSuite {
       val ref = model.referenceMesh
       val data = ref.pointSet.pointIds.toIndexedSeq.map(id => (id, ref.pointSet.point(id)))
       val mean = measureTime(model.posterior(data, 1.0).mean)
-      val map = measureTime(model.MAP(data, 1.0))
+      val map = measureTime(model.posteriorMean(data, 1.0))
       map._2 should be < mean._2
       assert(mean._1 == map._1)
     }


### PR DESCRIPTION
MR related to https://github.com/unibas-gravis/scalismo/issues/421

Provides handle to directly calculate the `.posterior.mean` with `.MAP` without calculating the posterior kernel/covariance matrix.