### PR TITLE
Fix/426 inconsitent reading and writing in statismoio

### DIFF
--- a/src/main/scala/scalismo/io/statisticalmodel/StatismoDomainIO.scala
+++ b/src/main/scala/scalismo/io/statisticalmodel/StatismoDomainIO.scala
@@ -75,8 +75,8 @@ object StatismoDomainIO {
     override def createDomainWithCells(points: IndexedSeq[Point[_2D]],
                                        cellArray: Option[NDArray[Int]]
     ): Try[TriangleMesh[_2D]] = {
-      cellArray match {
-        case None => Failure(new Throwable("Triangle cells missing"))
+      val triangleList = cellArray match {
+        case None => Success(TriangleList(IndexedSeq()))
         case Some(c) =>
           val cellMatrix = ndIntArrayToIntMatrix(c)
           if (cellMatrix.cols != 3) Failure(new Exception("Representer cells are not triangles"))
@@ -84,10 +84,10 @@ object StatismoDomainIO {
             val cells = for (i <- 0 until cellMatrix.rows) yield {
               TriangleCell(PointId(cellMatrix(i, 0)), PointId(cellMatrix(i, 1)), PointId(cellMatrix(i, 2)))
             }
-            Success(TriangleMesh2D(UnstructuredPoints(points), TriangleList(cells)))
+            Success(TriangleList(cells))
           }
       }
-
+      triangleList.map(triangles => TriangleMesh2D(UnstructuredPoints(points), triangles))
     }
 
     override def cellsToArray(mesh: TriangleMesh[_2D]): NDArray[Int] = {
@@ -103,20 +103,19 @@ object StatismoDomainIO {
     override def createDomainWithCells(points: IndexedSeq[Point[_3D]],
                                        cellArray: Option[NDArray[Int]]
     ): Try[TriangleMesh[_3D]] = {
-      cellArray match {
-        case None => Failure(new Throwable("Triangle cells missing"))
+      val triangleList = cellArray match {
+        case None => Success(TriangleList(IndexedSeq()))
         case Some(c) =>
           val cellMatrix = ndIntArrayToIntMatrix(c)
           if (cellMatrix.cols != 3) Failure(new Exception("Representer cells are not triangles"))
           else {
-            val cells =
-              for (i <- 0 until cellMatrix.rows)
-                yield {
-                  TriangleCell(PointId(cellMatrix(i, 0)), PointId(cellMatrix(i, 1)), PointId(cellMatrix(i, 2)))
-                }
-            Success(TriangleMesh3D(UnstructuredPoints(points), TriangleList(cells)))
+            val cells = for (i <- 0 until cellMatrix.rows) yield {
+              TriangleCell(PointId(cellMatrix(i, 0)), PointId(cellMatrix(i, 1)), PointId(cellMatrix(i, 2)))
+            }
+            Success(TriangleList(cells))
           }
       }
+      triangleList.map(triangles => TriangleMesh3D(UnstructuredPoints(points), triangles))
     }
 
     override def cellsToArray(mesh: TriangleMesh[_3D]): NDArray[Int] = {
@@ -132,8 +131,8 @@ object StatismoDomainIO {
     override def createDomainWithCells(points: IndexedSeq[Point[_3D]],
                                        cellArray: Option[NDArray[Int]]
     ): Try[TetrahedralMesh[_3D]] = {
-      cellArray match {
-        case None => Failure(new Throwable("Tetrahedral cells missing"))
+      val tetrahedralList = cellArray match {
+        case None => Success(TetrahedralList(IndexedSeq()))
         case Some(c) =>
           val cellMatrix = ndIntArrayToIntMatrix(c)
           if (cellMatrix.cols != 4) Failure(new Exception("Representer cells are not tetrahedrons"))
@@ -147,9 +146,10 @@ object StatismoDomainIO {
                                   PointId(cellMatrix(i, 3))
                   )
                 }
-            Success(TetrahedralMesh3D(UnstructuredPoints(points), TetrahedralList(cells)))
+            Success(TetrahedralList(cells))
           }
       }
+      tetrahedralList.map(tetrahedrons => TetrahedralMesh3D(UnstructuredPoints(points), tetrahedrons))
     }
 
     override def cellsToArray(mesh: TetrahedralMesh[_3D]): NDArray[Int] = {
@@ -168,8 +168,8 @@ object StatismoDomainIO {
     override def createDomainWithCells(points: IndexedSeq[Point[_2D]],
                                        cellArray: Option[NDArray[Int]]
     ): Try[LineMesh[_2D]] = {
-      cellArray match {
-        case None => Failure(new Throwable("Line cells missing"))
+      val lineList = cellArray match {
+        case None => Success(LineList(IndexedSeq()))
         case Some(c) =>
           val cellMatrix = ndIntArrayToIntMatrix(c)
           if (cellMatrix.cols != 2) Failure(new Exception("Representer cells are not lines"))
@@ -179,9 +179,10 @@ object StatismoDomainIO {
                 yield {
                   LineCell(PointId(cellMatrix(i, 0)), PointId(cellMatrix(i, 1)))
                 }
-            Try(LineMesh2D(UnstructuredPoints(points), LineList(cells)))
+            Try(LineList(cells))
           }
       }
+      lineList.map(lines => LineMesh2D(UnstructuredPoints(points), lines))
     }
 
     override def cellsToArray(mesh: LineMesh[_2D]): NDArray[Int] = {
@@ -197,8 +198,8 @@ object StatismoDomainIO {
     override def createDomainWithCells(points: IndexedSeq[Point[_3D]],
                                        cellArray: Option[NDArray[Int]]
     ): Try[LineMesh[_3D]] = {
-      cellArray match {
-        case None => Failure(new Throwable("Line cells missing"))
+      val lineList = cellArray match {
+        case None => Success(LineList(IndexedSeq()))
         case Some(c) =>
           val cellMatrix = ndIntArrayToIntMatrix(c)
           if (cellMatrix.cols != 2) Failure(new Exception("Representer cells are not lines"))
@@ -208,9 +209,10 @@ object StatismoDomainIO {
                 yield {
                   LineCell(PointId(cellMatrix(i, 0)), PointId(cellMatrix(i, 1)))
                 }
-            Success(LineMesh3D(UnstructuredPoints(points), LineList(cells)))
+            Success(LineList(cells))
           }
       }
+      lineList.map(lines => LineMesh3D(UnstructuredPoints(points), lines))
     }
 
     override def cellsToArray(mesh: LineMesh[_3D]): NDArray[Int] = {

--- a/src/main/scala/scalismo/io/statisticalmodel/StatismoIO.scala
+++ b/src/main/scala/scalismo/io/statisticalmodel/StatismoIO.scala
@@ -290,8 +290,8 @@ object StatismoIO {
       points <- Try(
         for (i <- 0 until pointsMatrix.cols) yield vectorizer.unvectorize(pointsMatrix(::, i).copy).toPoint
       )
-      cells <- readStandardConnectiveityRepresenterGroup(h5file, modelPath)
-      domain <- typeHelper.createDomainWithCells(points, Option(cells))
+      cells = readStandardConnectiveityRepresenterGroup(h5file, modelPath).toOption
+      domain <- typeHelper.createDomainWithCells(points, cells)
     } yield domain
   }
 
@@ -307,7 +307,7 @@ object StatismoIO {
     val cells =
       if (h5file.exists(HDFPath(modelPath, "/representer/cells")))
         h5file.readNDArrayInt(HDFPath(modelPath, "/representer/cells"))
-      else Failure(new Throwable("No cells found in representer"))
+      else Failure[NDArray[Int]](new Throwable("No cells found in representer"))
     cells
   }
 

--- a/src/test/scala/scalismo/io/statisticalmodel/StatismoDomainIOTests.scala
+++ b/src/test/scala/scalismo/io/statisticalmodel/StatismoDomainIOTests.scala
@@ -44,6 +44,21 @@ class StatismoDomainIOTests extends ScalismoTestSuite {
       t.get
     }
 
+    it("can convert a 2D TriangleMesh without triangles") {
+      val unstructuredPoints =
+        CreateUnstructuredPoints2D.create(IndexedSeq(Point2D(0, 0), Point2D(1, 0), Point2D(1, 1)))
+      val topology = TriangleList(IndexedSeq())
+      val input = TriangleMesh2D(unstructuredPoints, topology)
+      val t = for {
+        output <- StatismoDomainIO.domainIOTriangleMesh2D.createDomainWithCells(unstructuredPoints.points.toIndexedSeq,
+                                                                                None
+        )
+      } yield {
+        assert(input == output)
+      }
+      t.get
+    }
+
     it("can convert a 3D TriangleMesh") {
       val unstructuredPoints =
         CreateUnstructuredPoints3D.create(IndexedSeq(Point3D(0, 0, 0), Point3D(1, 0, 0), Point3D(1, 1, 0)))
@@ -53,6 +68,21 @@ class StatismoDomainIOTests extends ScalismoTestSuite {
       val t = for {
         output <- StatismoDomainIO.domainIOTriangleMesh3D.createDomainWithCells(unstructuredPoints.points.toIndexedSeq,
                                                                                 Option(cellsAsArray)
+        )
+      } yield {
+        assert(input == output)
+      }
+      t.get
+    }
+
+    it("can convert a 3D TriangleMesh without triangles") {
+      val unstructuredPoints =
+        CreateUnstructuredPoints3D.create(IndexedSeq(Point3D(0, 0, 0), Point3D(1, 0, 0), Point3D(1, 1, 0)))
+      val topology = TriangleList(IndexedSeq())
+      val input = TriangleMesh3D(unstructuredPoints, topology)
+      val t = for {
+        output <- StatismoDomainIO.domainIOTriangleMesh3D.createDomainWithCells(unstructuredPoints.points.toIndexedSeq,
+                                                                                None
         )
       } yield {
         assert(input == output)
@@ -76,6 +106,21 @@ class StatismoDomainIOTests extends ScalismoTestSuite {
       t.get
     }
 
+    it("can convert a 3D TetrahedralMesh without tetrahedrons") {
+      val unstructuredPoints = CreateUnstructuredPoints3D.create(
+        IndexedSeq(Point3D(0, 0, 0), Point3D(1, 0, 0), Point3D(1, 1, 0), Point3D(1, 1, 1))
+      )
+      val topology = TetrahedralList(IndexedSeq())
+      val input = TetrahedralMesh3D(unstructuredPoints, topology)
+      val t = for {
+        output <- StatismoDomainIO.domainIOTetrahedralMesh3D
+          .createDomainWithCells(unstructuredPoints.points.toIndexedSeq, None)
+      } yield {
+        assert(input == output)
+      }
+      t.get
+    }
+
     it("can convert a 2D LineMesh") {
       val unstructuredPoints = CreateUnstructuredPoints2D.create(IndexedSeq(Point2D(0, 0), Point2D(1, 0)))
       val topology = LineList(IndexedSeq(LineCell(PointId(0), PointId(1))))
@@ -84,6 +129,20 @@ class StatismoDomainIOTests extends ScalismoTestSuite {
       val t = for {
         output <- StatismoDomainIO.domainIOLineMesh2D.createDomainWithCells(unstructuredPoints.points.toIndexedSeq,
                                                                             Option(cellsAsArray)
+        )
+      } yield {
+        assert(input == output)
+      }
+      t.get
+    }
+
+    it("can convert a 2D LineMesh without lines") {
+      val unstructuredPoints = CreateUnstructuredPoints2D.create(IndexedSeq(Point2D(0, 0), Point2D(1, 0)))
+      val topology = LineList(IndexedSeq())
+      val input = LineMesh2D(unstructuredPoints, topology)
+      val t = for {
+        output <- StatismoDomainIO.domainIOLineMesh2D.createDomainWithCells(unstructuredPoints.points.toIndexedSeq,
+                                                                            None
         )
       } yield {
         assert(input == output)
@@ -100,6 +159,21 @@ class StatismoDomainIOTests extends ScalismoTestSuite {
       val t = for {
         output <- StatismoDomainIO.domainIOLineMesh3D.createDomainWithCells(unstructuredPoints.points.toIndexedSeq,
                                                                             Option(cellsAsArray)
+        )
+      } yield {
+        assert(input == output)
+      }
+      t.get
+    }
+
+    it("can convert a 3D LineMesh without lines") {
+      val unstructuredPoints =
+        CreateUnstructuredPoints3D.create(IndexedSeq(Point3D(0, 0, 0), Point3D(1, 0, 0), Point3D(1, 1, 0)))
+      val topology = LineList(IndexedSeq())
+      val input = LineMesh3D(unstructuredPoints, topology)
+      val t = for {
+        output <- StatismoDomainIO.domainIOLineMesh3D.createDomainWithCells(unstructuredPoints.points.toIndexedSeq,
+                                                                            None
         )
       } yield {
         assert(input == output)

--- a/src/test/scala/scalismo/io/statisticalmodel/StatismoIOTests.scala
+++ b/src/test/scala/scalismo/io/statisticalmodel/StatismoIOTests.scala
@@ -1,7 +1,7 @@
 package scalismo.io.statisticalmodel
 
 import org.scalatest.PrivateMethodTester.*
-import scalismo.geometry.{Point3D, _3D}
+import scalismo.geometry.{_3D, Point3D}
 import scalismo.io.statisticalmodel.StatismoIO
 import scalismo.io.StatisticalModelIO
 import scalismo.ScalismoTestSuite
@@ -17,8 +17,8 @@ import scala.util.Try
 
 class StatismoIOTests extends ScalismoTestSuite {
   def assertModelAlmostEqual[D](m1: UnstructuredPointsDomain[D], m2: UnstructuredPointsDomain[D]): Unit = {
-    m1.pointSet.pointSequence.zip(m2.pointSet.pointSequence).foreach{ case (a,b) =>
-      assert((a-b).norm < 1e-5)
+    m1.pointSet.pointSequence.zip(m2.pointSet.pointSequence).foreach { case (a, b) =>
+      assert((a - b).norm < 1e-5)
     }
   }
 
@@ -32,7 +32,7 @@ class StatismoIOTests extends ScalismoTestSuite {
 
       val dataToWrite = UnstructuredPointsDomain(
         IndexedSeq(
-          Point3D(0, 1, 2),
+          Point3D(0, 1, 2)
         )
       )
 

--- a/src/test/scala/scalismo/io/statisticalmodel/StatismoIOTests.scala
+++ b/src/test/scala/scalismo/io/statisticalmodel/StatismoIOTests.scala
@@ -1,0 +1,60 @@
+package scalismo.io.statisticalmodel
+
+import org.scalatest.PrivateMethodTester.*
+import scalismo.geometry.{Point3D, _3D}
+import scalismo.io.statisticalmodel.StatismoIO
+import scalismo.io.StatisticalModelIO
+import scalismo.ScalismoTestSuite
+import scalismo.common.{UnstructuredPoints, UnstructuredPointsDomain}
+import scalismo.hdf5json.HDFPath
+import scalismo.mesh.{TriangleList, TriangleMesh, TriangleMesh3D}
+import scalismo.statisticalmodel.StatisticalMeshModel
+
+import java.io.File
+import java.net.URLDecoder
+import java.nio.file.Files
+import scala.util.Try
+
+class StatismoIOTests extends ScalismoTestSuite {
+  def assertModelAlmostEqual[D](m1: UnstructuredPointsDomain[D], m2: UnstructuredPointsDomain[D]): Unit = {
+    m1.pointSet.pointSequence.zip(m2.pointSet.pointSequence).foreach{ case (a,b) =>
+      assert((a-b).norm < 1e-5)
+    }
+  }
+
+  describe("the StatismoIO methods") {}
+
+  it("can write and read again a domain without cells") {
+
+    val upd = UnstructuredPointsDomain(
+      IndexedSeq(
+        Point3D(0,1,2),
+      )
+    )
+
+    val tmpDir = Files.createTempDirectory("test-StatismoIO")
+    tmpDir.toFile.deleteOnExit()
+    val dummyFile = new File(tmpDir.toFile, "empty-representer.h5.json")
+
+    val modelPath = HDFPath("/")
+    val representerPath = HDFPath(modelPath,"representer")
+
+    val privateMethodWriter = PrivateMethod[Try[Unit]](Symbol("writeRepresenterStatismov090"))
+    val privateMethodReader = PrivateMethod[Try[UnstructuredPointsDomain[_3D]]](Symbol("readStandardMeshRepresentation"))
+
+    val t = for {
+      h5out <- StatisticalModelIOUtils.openFileForWriting(dummyFile)
+      t <- StatismoIO invokePrivate privateMethodWriter(h5out, representerPath, upd, modelPath, scalismo.geometry.Dim.ThreeDSpace, scalismo.io.StatismoDomainIO.domainIOUnstructuredPoints3D)
+      _ <- h5out.write()
+      _ <- Try {
+        h5out.close()
+      }
+      h5file <- StatisticalModelIOUtils.openFileForReading(dummyFile)
+      loadedRefMesh <- StatismoIO invokePrivate privateMethodReader(h5file, modelPath, scalismo.geometry.Dim.ThreeDSpace, scalismo.io.StatismoDomainIO.domainIOUnstructuredPoints3D, scalismo.geometry.EuclideanVector.Vector_3DVectorizer)
+    } yield {
+      assertModelAlmostEqual(upd, loadedRefMesh)
+    }
+    t.get
+
+  }
+}

--- a/src/test/scala/scalismo/io/statisticalmodel/StatismoIOTests.scala
+++ b/src/test/scala/scalismo/io/statisticalmodel/StatismoIOTests.scala
@@ -24,7 +24,7 @@ class StatismoIOTests extends ScalismoTestSuite {
 
   describe("the StatismoIO methods") {}
 
-  it("can write and read again a domain without cells") {
+  it("can write and read UnstructuredPointsDomain") {
 
     val upd = UnstructuredPointsDomain(
       IndexedSeq(


### PR DESCRIPTION
This PR fixes #426 which is nescessary to write and read UnstructuredPointsDomains.

A test is introduced for writing and reading an UnstrucutedPointsDomain. The test fails without adapting the StatismoIO class. The test looks a bit more complicated, as only the private method is tested.

UPDATE:
This PR does also fixes #332.

Tests added which checks that passing None creates empty line or triangle lists.