### PR TITLE
Fix: Adjacent triangles for free points return empty list

### DIFF
--- a/src/main/scala/scalismo/mesh/TriangleList.scala
+++ b/src/main/scala/scalismo/mesh/TriangleList.scala
@@ -42,7 +42,7 @@ case class TriangleList(triangles: IndexedSeq[TriangleCell]) {
     val dataSeq = IndexedSeq.tabulate(pointIds.size) { i =>
       data(pointIds(i)).toIndexedSeq
     }
-    id => dataSeq(id.id)
+    id => if (id.id < dataSeq.size) dataSeq(id.id) else IndexedSeq()
   }
 
   /** points adjacent to a point */

--- a/src/test/scala/scalismo/mesh/MeshAdjacencyTests.scala
+++ b/src/test/scala/scalismo/mesh/MeshAdjacencyTests.scala
@@ -1,0 +1,77 @@
+package scalismo.mesh
+
+import scalismo.ScalismoTestSuite
+import scalismo.common.PointId
+import scalismo.geometry.Point3D
+
+class MeshAdjacencyTests extends ScalismoTestSuite {
+
+  describe("a mesh adjacency operation") {
+
+    object Fixture {
+      val points = IndexedSeq(
+        Point3D(0,0,0),
+        Point3D(1,0,0),
+        Point3D(0,1,0),
+        Point3D(0,0,1)
+      )
+      val cells = TriangleList(IndexedSeq(
+        TriangleCell(PointId(0),PointId(1),PointId(2)),
+        TriangleCell(PointId(0),PointId(2),PointId(3)),
+      ))
+      val mesh = TriangleMesh3D(
+        points,
+        cells
+      )
+      val meshWithFreePoint = TriangleMesh3D(
+        points,
+        TriangleList(cells.triangles.drop(1))
+      )
+      val meshWithFreePointAtEnd = TriangleMesh3D(
+        points,
+        TriangleList(cells.triangles.dropRight(1))
+      )
+    }
+
+    it("should return the correct triangles for all points") {
+      val mesh = Fixture.mesh
+
+      val tests = Seq(
+        (PointId(0), IndexedSeq(TriangleId(0), TriangleId(1))),
+        (PointId(1), IndexedSeq(TriangleId(0))),
+        (PointId(2), IndexedSeq(TriangleId(0), TriangleId(1))),
+        (PointId(3), IndexedSeq(TriangleId(1)))
+      )
+      for( (pid, adjList) <- tests ) {
+        val adj = mesh.triangulation.adjacentTrianglesForPoint(pid)
+        adj.sortBy(_.id) shouldBe adjList
+      }
+    }
+
+    it("should return the correct triangles for points also not contained in a triangle") {
+      {
+        val mesh = Fixture.meshWithFreePoint
+
+        val tests = Seq((PointId(0), IndexedSeq(TriangleId(0))), (PointId(1), IndexedSeq()), (PointId(2), IndexedSeq(TriangleId(0))), (PointId(3), IndexedSeq(TriangleId(0))))
+        for ((pid, adjList) <- tests) {
+          val adj = mesh.triangulation.adjacentTrianglesForPoint(pid)
+          adj.sortBy(_.id) shouldBe adjList
+        }
+      }
+      {
+        val mesh = Fixture.meshWithFreePointAtEnd
+        val tests = Seq(
+          (PointId(0),  IndexedSeq(TriangleId(0))),
+          (PointId(1),  IndexedSeq(TriangleId(0))),
+          (PointId(2),  IndexedSeq(TriangleId(0))),
+          (PointId(3),  IndexedSeq()),
+        )
+        for ((pid, adjList) <- tests) {
+          val adj = mesh.triangulation.adjacentTrianglesForPoint(pid)
+          adj.sortBy(_.id) shouldBe adjList
+        }
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
This PR fixes #245, which caused an `IndexOutOfBoundsException` when calling `adjacentTrianglesForPoint` on point IDs at the end of the vertex list that are not part of any triangle.

🛠️ Fix: The method now returns an empty list for:

- Point IDs that are not part of any triangle, and
- Point IDs that are not part of the triangle mesh at all

This ensures consistent and safe behavior for all inputs.