### PR TITLE
Feature: Adds implementation to find n closest points in structured points

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: Scala CI
 
 on:
   push:
-    branches: [ master, release* ]
+    branches: [ main, release* ]
   pull_request:
-    branches: [ master, develop, release* ]
+    branches: [ main, release* ]
 
 jobs:
   test:
@@ -16,6 +16,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 11
+      - uses: sbt/setup-sbt@v1
       - name: Run tests
         run:  |
           sudo apt-get update
@@ -26,5 +27,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: sbt/setup-sbt@v1
       - name: Formatting
         run: sbt scalafmtSbtCheck scalafmtCheck test:scalafmtCheck

--- a/src/main/scala/scalismo/image/StructuredPoints.scala
+++ b/src/main/scala/scalismo/image/StructuredPoints.scala
@@ -16,8 +16,8 @@
 package scalismo.image
 
 import breeze.linalg.{diag, DenseMatrix, DenseVector}
-import scalismo.common._
-import scalismo.geometry._
+import scalismo.common.*
+import scalismo.geometry.*
 import scalismo.transformations.{
   Rotation,
   Rotation2D,
@@ -30,6 +30,7 @@ import scalismo.transformations.{
   TranslationAfterRotation3D
 }
 
+import scala.collection.mutable
 import scala.language.implicitConversions
 
 /**
@@ -106,9 +107,60 @@ abstract class StructuredPoints[D: NDSpace] extends PointSet[D] with Equals {
   }
 
   /**
-   * returns the n closest points to the given set of points
+   * returns the n closest points to the given point
+   *
+   * Note: If two points are equidistant, there is no guarantee which one is taken first into the set.
    */
-  override def findNClosestPoints(pt: Point[D], n: Int): Seq[PointWithId[D]] = throw new UnsupportedOperationException
+  override def findNClosestPoints(pt: Point[D], n: Int): Seq[PointWithId[D]] = {
+    val expansionDirections: Seq[DenseVector[Int]] = (0 until pt.dimensionality) flatMap { d =>
+      Seq(-1, 1) map { offset =>
+        val arr = Array.fill(pt.dimensionality)(0)
+        arr(d) = offset
+        DenseVector(arr)
+      }
+    }
+    val cIdx = pointToContinuousIndex(pt)
+    val idxClosestPoint = continuousIndextoIndex(cIdx)
+    val tuple = ((pt - indexToPoint(idxClosestPoint)).norm, idxClosestPoint)
+    val expansionPoints =
+      mutable.PriorityQueue[(Double, IntVector[D])](tuple)(Ordering.by(-_._1))
+    val closestPoints = mutable.PriorityQueue[(Double, IntVector[D])](tuple)(Ordering.by(_._1))
+
+    val visitedPoints = mutable.Set[Int](pointId(idxClosestPoint).id)
+    while (
+      expansionPoints.nonEmpty && ( // we still have points to process
+        closestPoints.size < n // not enough points
+          || expansionPoints.head._1 < closestPoints.head._1 // maybe closer point
+      )
+    ) {
+      val (dist, expansionIndex) = expansionPoints.dequeue()
+      val pid = pointId(expansionIndex).id
+
+      if (!visitedPoints.contains(pid)) {
+        visitedPoints += pid
+        closestPoints.enqueue((dist, expansionIndex))
+        if (closestPoints.size > n) {
+          closestPoints.dequeue()
+        }
+      }
+
+      expansionDirections.foreach { delta =>
+        val newCandidate = IntVector((expansionIndex.toBreezeVector + delta).toArray)
+        val pid = pointId(newCandidate).id
+        if (!visitedPoints.contains(pid)) {
+          val tuple = ((pt - indexToPoint(newCandidate)).norm, newCandidate)
+          if (closestPoints.size < n || tuple._1 < closestPoints.head._1) {
+            expansionPoints.enqueue(tuple)
+          } else {
+            if (closestPoints.size >= n) {
+              visitedPoints += pid
+            }
+          }
+        }
+      }
+    }
+    closestPoints.take(n).dequeueAll.sortBy(_._1).map(cp => PointWithId(indexToPoint(cp._2), pointId(cp._2)))
+  }
 
   def continuousIndextoIndex(cidx: EuclideanVector[D]): IntVector[D] = {
     var d = 0

--- a/src/test/scala/scalismo/image/DiscreteImageDomainTests.scala
+++ b/src/test/scala/scalismo/image/DiscreteImageDomainTests.scala
@@ -1,7 +1,7 @@
 package scalismo.image
 
 import scalismo.ScalismoTestSuite
-import scalismo.common.BoxDomain
+import scalismo.common.{BoxDomain, PointWithId}
 import scalismo.geometry.*
 
 class DiscreteImageDomainTests extends ScalismoTestSuite {
@@ -30,6 +30,35 @@ class DiscreteImageDomainTests extends ScalismoTestSuite {
         domain.boundingBox.origin,
         domain.boundingBox.oppositeCorner + EuclideanVector(1.0, 1.0)
       ).volume
+    }
+
+    it("finds the correct nearest neighbour") {
+      val domain =
+        DiscreteImageDomain3D(Point3D(1.0, 3.5, 42.0), EuclideanVector3D(1.0, 2.1, 0.42), IntVector3D(42, 49, 32))
+
+      val query = Point3D(4.0, 20.0, 44.0)
+      val cp = domain.structuredPoints.findClosestPoint(query)
+      val brutForce = domain.structuredPoints.pointsWithId.map(pId => ((pId._1 - query).norm, pId)).minBy(_._1)
+
+      val bf = PointWithId(brutForce._2._1, brutForce._2._2)
+
+      cp shouldBe bf
+    }
+
+    it("finds the correct n nearest neighbours") {
+      val domain =
+        DiscreteImageDomain3D(Point3D(1.0, 3.5, 42.0), EuclideanVector3D(1.0, 2.1, 0.42), IntVector3D(42, 49, 32))
+
+      val query = Point3D(4.0, 20.0, 44.0)
+      val N = 28
+      val cp = domain.structuredPoints.findNClosestPoints(query, N)
+
+      val brutForce =
+        domain.structuredPoints.pointsWithId.map(pId => ((pId._1 - query).norm, pId)).toSeq.sortBy(_._1).take(N)
+      val bf = brutForce.map(bf => PointWithId(bf._2._1, bf._2._2))
+
+      cp.size shouldBe bf.size
+      bf.foreach(bf => cp.contains(bf) shouldBe true)
     }
   }
 


### PR DESCRIPTION
This PR fixes #57 and fixes #397.

The implementation does a wave search starting from the closest point along the grid axis. This should be rather efficient for smaller N's while for very large N's one might to consider another implementation.