### PR TITLE
Fix: Make thread local variables consistent in their state in the surface spatial index

### DIFF
--- a/src/main/scala/scalismo/mesh/boundingSpheres/SurfaceSpatialIndex.scala
+++ b/src/main/scala/scalismo/mesh/boundingSpheres/SurfaceSpatialIndex.scala
@@ -200,7 +200,8 @@ private[mesh] class TriangleMesh3DSpatialIndex(private val bs: BoundingSphere,
   private def _getClosestPoint(point: Point[_3D]): Unit = {
     val p = point.toVector
 
-    val result = BSDistance.toTriangle(point.toVector, triangles(0))
+    lastIdx.set(new Index(0))
+    val result = BSDistance.toTriangle(point.toVector, triangles(lastIdx.get().idx))
     updateCP(res.get(), result)
 
     // search for true candidate


### PR DESCRIPTION
We observed that sometimes when using the `TriangleMeshInterpolator3D[EuclideanVector[_3D]]()`  in `approximateGPCholesky`  we had some artifacts, most of the time somewhere at the border.

This is due to a bug of non-consistent state in the two thread local variables `res` and `lastIdx` in the surface spatial index. This PR fixes this while still trying to preserve the deterministic behavior, which we wanted to establish with the changes that introduced the bug.